### PR TITLE
fix alignment of sticky time-week-header

### DIFF
--- a/src/main/css/style.css
+++ b/src/main/css/style.css
@@ -423,7 +423,7 @@
 
   .time-week-header {
     @apply sticky;
-    @apply top-13;
+    @apply top-12;
     @apply z-10;
     @apply pt-3;
     @apply pb-6;


### PR DESCRIPTION
broken:
![broken](https://user-images.githubusercontent.com/1732200/203633041-0d230886-1fe4-4a24-a343-c4a5735dbff2.png)

fixed:
![fixed](https://user-images.githubusercontent.com/1732200/203633051-45a068f9-31cd-4ac4-939b-180e15e361b8.png)
