### PR TITLE
Improve health check behaviour in docker-compose example

### DIFF
--- a/.examples/docker-compose/docker-compose.yml
+++ b/.examples/docker-compose/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_DEFAULT_ISSUER-URI: http://localhost:8090/auth/realms/zeiterfassung-realm
       ZEITERFASSUNG_SECURITY_OIDC_SERVER-URL: http://localhost:8090/auth
       ZEITERFASSUNG_SECURITY_OIDC_LOGIN-FORM-URL: http://localhost:8080/oauth2/authorization/default
+      SPRING_AUTOCONFIGURE_EXCLUDE: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
     depends_on:
       postgres:
         condition: service_healthy

--- a/.examples/docker-compose/docker-compose.yml
+++ b/.examples/docker-compose/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       ZEITERFASSUNG_SECURITY_OIDC_LOGIN-FORM-URL: http://localhost:8080/oauth2/authorization/default
       SPRING_AUTOCONFIGURE_EXCLUDE: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
     depends_on:
+      keycloak:
+        condition: service_healthy
       postgres:
         condition: service_healthy
       mailhog:
@@ -67,5 +69,11 @@ services:
       KC_HTTP_RELATIVE_PATH: /auth
       KC_HOSTNAME_STRICT: 'false'
       KC_HOSTNAME_STRICT_HTTPS: 'false'
+      KC_HEALTH_ENABLED: 'true'
     ports:
       - '8090:8090'
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8090/auth/health" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/.examples/docker-compose/docker-compose.yml
+++ b/.examples/docker-compose/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: ghcr.io/urlaubsverwaltung/zeiterfassung/zeiterfassung:1.0.1
     network_mode: "host"
     environment:
+      SERVER_PORT: 8080
       # Database
       SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/zeiterfassung
       SPRING_DATASOURCE_USERNAME: user

--- a/.examples/docker-compose/docker-compose.yml
+++ b/.examples/docker-compose/docker-compose.yml
@@ -35,11 +35,6 @@ services:
         condition: service_healthy
       mailhog:
         condition: service_started
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-      interval: 30s
-      timeout: 30s
-      retries: 5
 
   postgres:
     image: postgres:9.6


### PR DESCRIPTION
* Paketo.io / CloudNativeBuildPack created Container image doesn't have curl installed
* Exclude amqp configuration
* Keycloak health check