### PR TITLE
fix rounded time entry box

### DIFF
--- a/src/main/resources/templates/timeentries/index.html
+++ b/src/main/resources/templates/timeentries/index.html
@@ -222,7 +222,7 @@
           <div class="flex-1 flex flex-col md:flex-row">
             <div
               is="z-time-entry-date-picker"
-              class="flex flex-col items-center bg-timeslot-form-datepicker text-timeslot-form-day py-6 px-5 rounded-t-[27px] md:rounded-t-none md:rounded-l-[27px] md:w-56 border-r-timeslot-form"
+              class="flex flex-col items-center bg-timeslot-form-datepicker text-timeslot-form-day py-6 px-5 rounded-t-[27px] md:rounded-tr-none md:rounded-l-[27px] md:w-56 border-r-timeslot-form"
               data-js-class-remove="flex-col"
             >
               <input


### PR DESCRIPTION
tailwind sorts classes alphabetically now -> just disable top-right rounded border on md screen