### PR TITLE
Add oidc login_hint parameter aware OAuth2AuthorizationRequestResolver

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/security/LoginHintAwareResolver.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/LoginHintAwareResolver.java
@@ -1,0 +1,47 @@
+package de.focusshift.zeiterfassung.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
+
+public class LoginHintAwareResolver implements OAuth2AuthorizationRequestResolver {
+
+    private static final String OIDC_PARAMETER_LOGIN_HINT = "login_hint";
+
+    private final DefaultOAuth2AuthorizationRequestResolver defaultResolver;
+
+    public LoginHintAwareResolver(ClientRegistrationRepository clientRegistrationRepository) {
+
+        this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
+                clientRegistrationRepository, DEFAULT_AUTHORIZATION_REQUEST_BASE_URI);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        return addLoginHintIfPresent(request, defaultResolver.resolve(request));
+    }
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        return addLoginHintIfPresent(request, defaultResolver.resolve(request, clientRegistrationId));
+    }
+
+    private OAuth2AuthorizationRequest addLoginHintIfPresent(HttpServletRequest request, OAuth2AuthorizationRequest defaultAuthorizationRequest) {
+        final String loginHint = request.getParameter(OIDC_PARAMETER_LOGIN_HINT);
+        if (loginHint == null || loginHint.isEmpty()) {
+            return defaultAuthorizationRequest;
+        } else {
+            Map<String, Object> additionalParameters = new HashMap<>(defaultAuthorizationRequest.getAdditionalParameters());
+            additionalParameters.put(OIDC_PARAMETER_LOGIN_HINT, loginHint);
+            return OAuth2AuthorizationRequest.from(defaultAuthorizationRequest)
+                    .additionalParameters(additionalParameters)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/security/SecurityWebConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/SecurityWebConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -25,16 +26,18 @@ class SecurityWebConfiguration {
     private final AuthenticationSuccessHandler authenticationSuccessHandler;
     private final OidcClientInitiatedLogoutSuccessHandler oidcClientInitiatedLogoutSuccessHandler;
     private final OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService;
+    private final ClientRegistrationRepository clientRegistrationRepository;
 
     @Autowired
     SecurityWebConfiguration(AuthenticationEntryPoint authenticationEntryPoint,
                              AuthenticationSuccessHandler authenticationSuccessHandler,
                              OidcClientInitiatedLogoutSuccessHandler oidcClientInitiatedLogoutSuccessHandler,
-                             OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService) {
+                             OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService, ClientRegistrationRepository clientRegistrationRepository) {
         this.authenticationEntryPoint = authenticationEntryPoint;
         this.authenticationSuccessHandler = authenticationSuccessHandler;
         this.oidcClientInitiatedLogoutSuccessHandler = oidcClientInitiatedLogoutSuccessHandler;
         this.oidcUserService = oidcUserService;
+        this.clientRegistrationRepository = clientRegistrationRepository;
     }
 
     @Bean
@@ -48,6 +51,9 @@ class SecurityWebConfiguration {
                 .anyRequest().authenticated()
             .and()
             .oauth2Login()
+                .authorizationEndpoint()
+                    .authorizationRequestResolver(new LoginHintAwareResolver(this.clientRegistrationRepository))
+                .and()
                 .successHandler(authenticationSuccessHandler)
                 .userInfoEndpoint()
                 .oidcUserService(oidcUserService);
@@ -69,4 +75,5 @@ class SecurityWebConfiguration {
         //@formatter:on
         return http.build();
     }
+
 }

--- a/src/test/java/de/focusshift/zeiterfassung/security/LoginHintAwareResolverTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/security/LoginHintAwareResolverTest.java
@@ -1,0 +1,87 @@
+package de.focusshift.zeiterfassung.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class LoginHintAwareResolverTest {
+
+    private ClientRegistration clientRegistration;
+    private InMemoryClientRegistrationRepository clientRegistrationRepository;
+
+    @BeforeEach
+    void setUp() {
+        this.clientRegistration = ClientRegistration.withRegistrationId("registration").clientId("client").clientSecret("secret").clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC).authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE).scope("user").authorizationUri("https://provider.com/oauth2/authorize").tokenUri("https://provider.com/oauth2/token").userInfoUri("https://provider.com/oauth2/user").redirectUri("{baseUrl}/{action}/oauth2/code/{registrationId}").userNameAttributeName("id").clientName("client").build();
+
+        this.clientRegistrationRepository = new InMemoryClientRegistrationRepository(this.clientRegistration);
+    }
+
+    @Test
+    void authorizationRequestRedirectWithLoginHint() throws ServletException, IOException {
+
+        String requestUri = OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/" + this.clientRegistration.getRegistrationId();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", requestUri);
+        request.setServletPath(requestUri);
+        String loginHintParamName = "login_hint";
+        request.addParameter(loginHintParamName, "office");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+
+        OAuth2AuthorizationRequestResolver sut = new LoginHintAwareResolver(this.clientRegistrationRepository);
+        OAuth2AuthorizationRequestRedirectFilter filter = new OAuth2AuthorizationRequestRedirectFilter(sut);
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getRedirectedUrl()).matches("https://provider.com/oauth2/authorize\\?response_type=code&client_id=client&scope=user&state=.{15,}&redirect_uri=http://localhost/login/oauth2/code/registration&login_hint=office");
+    }
+
+    @Test
+    void authorizationRequestRedirectWithoutLoginHint() throws ServletException, IOException {
+
+        String requestUri = OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/" + this.clientRegistration.getRegistrationId();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", requestUri);
+        request.setServletPath(requestUri);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+
+        OAuth2AuthorizationRequestResolver sut = new LoginHintAwareResolver(this.clientRegistrationRepository);
+        OAuth2AuthorizationRequestRedirectFilter filter = new OAuth2AuthorizationRequestRedirectFilter(sut);
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getRedirectedUrl()).matches("https://provider.com/oauth2/authorize\\?response_type=code&client_id=client&scope=user&state=.{15,}&redirect_uri=http://localhost/login/oauth2/code/registration");
+    }
+
+    @Test
+    void authorizationRequestRedirectWithUnknownParameter() throws ServletException, IOException {
+
+        String requestUri = OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/" + this.clientRegistration.getRegistrationId();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", requestUri);
+        request.setServletPath(requestUri);
+        String loginHintParamName = "some_parameter";
+        request.addParameter(loginHintParamName, "foobar");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+
+        OAuth2AuthorizationRequestResolver sut = new LoginHintAwareResolver(this.clientRegistrationRepository);
+        OAuth2AuthorizationRequestRedirectFilter filter = new OAuth2AuthorizationRequestRedirectFilter(sut);
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getRedirectedUrl()).matches("https://provider.com/oauth2/authorize\\?response_type=code&client_id=client&scope=user&state=.{15,}&redirect_uri=http://localhost/login/oauth2/code/registration");
+    }
+}


### PR DESCRIPTION
to pass login_hint from application to idp

its needed to pass the login_hint originated by application because nonce and state need to be right in place during redirect to application

## how to test

1. start docker-compose setup
2. start application
3. goto http://localhost:8060/oauth2/authorization/default?login_hint=lala
4. see prefilled username `lala`

see:
* https://github.com/spring-projects/spring-security/issues/5521
* https://docs.spring.io/spring-security/reference/servlet/oauth2/client/authorization-grants.html#_customizing_the_authorization_request 
* https://github.com/spring-projects/spring-security/blob/779597af2a6ed777707f08ae8106818e0b8e299e/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilterTests.java#L337

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
