### PR TITLE
allow time-entry update when start-end-duration are given and plausible

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
@@ -167,10 +167,8 @@ class TimeEntryServiceImpl implements TimeEntryService {
         final boolean durationChanged = !existingTimeEntry.duration().value().equals(duration);
         final boolean plausibleUpdate = delta(start, end).equals(duration);
 
-        if (startChanged && endChanged && durationChanged) {
-            if (!plausibleUpdate) {
-                throw new TimeEntryUpdateException("cannot update time-entry when start, end and duration should be changed. pick two of them.");
-            }
+        if (startChanged && endChanged && durationChanged && !plausibleUpdate) {
+            throw new TimeEntryUpdateException("cannot update time-entry when start, end and duration should be changed. pick two of them.");
         }
 
         if (plausibleUpdate || startChanged) {

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
@@ -165,12 +165,15 @@ class TimeEntryServiceImpl implements TimeEntryService {
         final boolean startChanged = notEquals(existingTimeEntry.start(), start);
         final boolean endChanged = notEquals(existingTimeEntry.end(), end);
         final boolean durationChanged = !existingTimeEntry.duration().value().equals(duration);
+        final boolean plausibleUpdate = delta(start, end).equals(duration);
 
         if (startChanged && endChanged && durationChanged) {
-            throw new TimeEntryUpdateException("cannot update time-entry when start, end and duration should be changed. pick two of them.");
+            if (!plausibleUpdate) {
+                throw new TimeEntryUpdateException("cannot update time-entry when start, end and duration should be changed. pick two of them.");
+            }
         }
 
-        if (startChanged) {
+        if (plausibleUpdate || startChanged) {
             entity.setStart(start.toInstant());
             entity.setStartZoneId(start.getZone().getId());
             if (durationChanged) {
@@ -180,7 +183,7 @@ class TimeEntryServiceImpl implements TimeEntryService {
             }
         }
 
-        if (endChanged) {
+        if (plausibleUpdate || endChanged) {
             entity.setEnd(end.toInstant());
             entity.setEndZoneId(end.getZone().getId());
             if (durationChanged) {
@@ -200,6 +203,10 @@ class TimeEntryServiceImpl implements TimeEntryService {
         entity.setBreak(isBreak);
 
         return save(entity);
+    }
+
+    private Duration delta(ZonedDateTime first, ZonedDateTime second) {
+        return Duration.ofMinutes(MINUTES.between(first, second));
     }
 
     private boolean notEquals(ZonedDateTime one, ZonedDateTime two) {

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
@@ -548,7 +548,7 @@ class TimeEntryServiceImplTest {
 
         assertThat(actualUpdatedTimeEntry.id()).isEqualTo(new TimeEntryId(42L));
         assertThat(actualUpdatedTimeEntry.userId()).isEqualTo(new UserId("batman"));
-        assertThat(actualUpdatedTimeEntry.comment()).isEqualTo("");
+        assertThat(actualUpdatedTimeEntry.comment()).isEmpty();
         assertThat(actualUpdatedTimeEntry.start()).isEqualTo(newStart);
         assertThat(actualUpdatedTimeEntry.end()).isEqualTo(newEnd);
         assertThat(actualUpdatedTimeEntry.isBreak()).isFalse();
@@ -561,7 +561,7 @@ class TimeEntryServiceImplTest {
 
         assertThat(actualPersisted.getId()).isEqualTo(42L);
         assertThat(actualPersisted.getOwner()).isEqualTo("batman");
-        assertThat(actualPersisted.getComment()).isEqualTo("");
+        assertThat(actualPersisted.getComment()).isEmpty();
         assertThat(actualPersisted.getStart()).isEqualTo(newStart.toInstant());
         assertThat(actualPersisted.getStartZoneId()).isEqualTo(newStart.getZone().getId());
         assertThat(actualPersisted.getEnd()).isEqualTo(newEnd.toInstant());

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
@@ -517,6 +517,60 @@ class TimeEntryServiceImplTest {
     }
 
     @Test
+    void ensureUpdateTimeEntryWhenStartEndDurationAreGivenAndPlausible() throws Exception {
+
+        final Clock fixedClock = Clock.fixed(Instant.now(), UTC);
+        sut = new TimeEntryServiceImpl(timeEntryRepository, userManagementService, workingTimeService, userDateService, fixedClock);
+
+        final LocalDate date = LocalDate.of(2023, 2, 27);
+        final LocalDateTime previousStart = LocalDateTime.of(date, LocalTime.of(15, 0, 0));
+        final LocalDateTime previousEnd = LocalDateTime.of(date, LocalTime.of(16, 0, 0));
+
+        final TimeEntryEntity entity = new TimeEntryEntity(
+            42L,
+            "batman",
+            "",
+            previousStart.toInstant(UTC),
+            ZONE_ID_UTC,
+            previousEnd.toInstant(UTC),
+            ZONE_ID_UTC,
+            Instant.now(),
+            false);
+
+        when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(entity));
+        when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
+
+        final ZonedDateTime newStart = previousStart.minusHours(1).atZone(ZONE_ID_UTC);
+        final ZonedDateTime newEnd = previousEnd.plusHours(1).atZone(ZONE_ID_UTC);
+        final Duration newDuration = Duration.ofHours(3);
+
+        final TimeEntry actualUpdatedTimeEntry = sut.updateTimeEntry(new TimeEntryId(42L), "", newStart, newEnd, newDuration, false);
+
+        assertThat(actualUpdatedTimeEntry.id()).isEqualTo(new TimeEntryId(42L));
+        assertThat(actualUpdatedTimeEntry.userId()).isEqualTo(new UserId("batman"));
+        assertThat(actualUpdatedTimeEntry.comment()).isEqualTo("");
+        assertThat(actualUpdatedTimeEntry.start()).isEqualTo(newStart);
+        assertThat(actualUpdatedTimeEntry.end()).isEqualTo(newEnd);
+        assertThat(actualUpdatedTimeEntry.isBreak()).isFalse();
+        assertThat(actualUpdatedTimeEntry.workDuration().value()).isEqualTo(newDuration);
+
+        final ArgumentCaptor<TimeEntryEntity> captor = ArgumentCaptor.forClass(TimeEntryEntity.class);
+        verify(timeEntryRepository).save(captor.capture());
+
+        final TimeEntryEntity actualPersisted = captor.getValue();
+
+        assertThat(actualPersisted.getId()).isEqualTo(42L);
+        assertThat(actualPersisted.getOwner()).isEqualTo("batman");
+        assertThat(actualPersisted.getComment()).isEqualTo("");
+        assertThat(actualPersisted.getStart()).isEqualTo(newStart.toInstant());
+        assertThat(actualPersisted.getStartZoneId()).isEqualTo(newStart.getZone().getId());
+        assertThat(actualPersisted.getEnd()).isEqualTo(newEnd.toInstant());
+        assertThat(actualPersisted.getEndZoneId()).isEqualTo(newEnd.getZone().getId());
+        assertThat(actualPersisted.getUpdatedAt()).isEqualTo(Instant.now(fixedClock));
+        assertThat(actualPersisted.isBreak()).isFalse();
+    }
+
+    @Test
     void ensureUpdateTimeEntryIsBreak() throws Exception {
 
         final Clock fixedClock = Clock.fixed(Instant.now(), UTC);


### PR DESCRIPTION
part of #194 

This pr allows to update all three parameters if the combination are correct. E.g. if I add one minute to start and and remove one minute of end and remove two minutes of duration.

