### PR TITLE
Use same representation for timeentry start/end in reports as in timeentries

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/report/DetailDayEntryDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/DetailDayEntryDto.java
@@ -1,11 +1,15 @@
 package de.focusshift.zeiterfassung.report;
 
-import java.time.Duration;
-import java.util.Date;
+import org.springframework.format.annotation.DateTimeFormat;
 
-record DetailDayEntryDto(String username, String comment, Date start, Date end) {
+import java.time.Duration;
+import java.time.LocalTime;
+
+import static org.springframework.format.annotation.DateTimeFormat.ISO.TIME;
+
+record DetailDayEntryDto(String username, String comment, @DateTimeFormat(iso = TIME) LocalTime start, @DateTimeFormat(iso = TIME) LocalTime end) {
 
     public Duration getDuration() {
-        return Duration.ofMillis(end.getTime() - start.getTime());
+        return Duration.between(start, end);
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
@@ -139,6 +139,6 @@ class ReportControllerHelper {
     }
 
     private DetailDayEntryDto toDetailDayEntryDto(ReportDayEntry reportDayEntry) {
-        return new DetailDayEntryDto(reportDayEntry.user().fullName(), reportDayEntry.comment(), Date.from(reportDayEntry.start().toInstant()), Date.from(reportDayEntry.end().toInstant()));
+        return new DetailDayEntryDto(reportDayEntry.user().fullName(), reportDayEntry.comment(), reportDayEntry.start().toLocalTime(), reportDayEntry.end().toLocalTime());
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -178,7 +178,7 @@ report.detail.week.section.title=Kalenderwoche {2}: {0,date,short} bis {1,date,s
 report.detail.no-entries=Für diesen Tag wurden noch keine Zeiten erfasst.
 report.detail.day.head={0}, {1} ({2, choice, 0#{2} Stunden|1#1 Stunde|1.01#{2} Stunden})
 report.detail.day.comment.label=Kommentar:
-report.detail.time={0,time,short} bis {1,time,short}
+report.detail.time={0} bis {1}
 
 usermanagement.heading=Personen
 usermanagement.teaser-text=Information: Es werden hier nur Personen angezeigt, welche sich mindestens einmal in der Zeiterfassung angemeldet haben.


### PR DESCRIPTION
Representation in reports was always in UTC and not in local timezone as in timeentries.

#242 