### PR TITLE
consume absence (sicknote and vacations) lifecycle events from urlaubsverwaltung

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>launchpad</artifactId>
             <version>1.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>de.focus-shift.urlaubsverwaltung.extension.api</groupId>
+            <artifactId>model-events</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
 
         <!-- Security -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>de.focus-shift.urlaubsverwaltung.extension.api</groupId>
             <artifactId>model-events</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
+            <version>0.3.0</version>
         </dependency>
 
         <!-- Security -->

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationEventHandlerRabbitmq.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationEventHandlerRabbitmq.java
@@ -2,13 +2,11 @@ package de.focusshift.zeiterfassung.integration.urlaubsverwaltung.application;
 
 import de.focus_shift.urlaubsverwaltung.extension.api.application.ApplicationAllowedEventDTO;
 import de.focus_shift.urlaubsverwaltung.extension.api.application.ApplicationCancelledEventDTO;
-import de.focus_shift.urlaubsverwaltung.extension.api.application.ApplicationDeletedEventDTO;
 import org.slf4j.Logger;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 
 import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.application.ApplicationRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_ALLOWED_QUEUE;
 import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.application.ApplicationRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_CANCELLED_QUEUE;
-import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.application.ApplicationRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_DELETED_QUEUE;
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -23,10 +21,5 @@ public class ApplicationEventHandlerRabbitmq {
     @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_CANCELLED_QUEUE})
     void on(ApplicationCancelledEventDTO event) {
         LOG.info("Received ApplicationCancelledEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
-    }
-
-    @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_DELETED_QUEUE})
-    void on(ApplicationDeletedEventDTO event) {
-        LOG.info("Received ApplicationDeletedEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationEventHandlerRabbitmq.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationEventHandlerRabbitmq.java
@@ -1,0 +1,32 @@
+package de.focusshift.zeiterfassung.integration.urlaubsverwaltung.application;
+
+import de.focus_shift.urlaubsverwaltung.extension.api.application.ApplicationAllowedEventDTO;
+import de.focus_shift.urlaubsverwaltung.extension.api.application.ApplicationCancelledEventDTO;
+import de.focus_shift.urlaubsverwaltung.extension.api.application.ApplicationDeletedEventDTO;
+import org.slf4j.Logger;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+
+import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.application.ApplicationRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_ALLOWED_QUEUE;
+import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.application.ApplicationRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_CANCELLED_QUEUE;
+import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.application.ApplicationRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_DELETED_QUEUE;
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class ApplicationEventHandlerRabbitmq {
+    private static final Logger LOG = getLogger(lookup().lookupClass());
+
+    @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_ALLOWED_QUEUE})
+    void on(ApplicationAllowedEventDTO event) {
+        LOG.info("Received ApplicationAllowedEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
+    }
+
+    @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_CANCELLED_QUEUE})
+    void on(ApplicationCancelledEventDTO event) {
+        LOG.info("Received ApplicationCancelledEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
+    }
+
+    @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_DELETED_QUEUE})
+    void on(ApplicationDeletedEventDTO event) {
+        LOG.info("Received ApplicationDeletedEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationRabbitmqConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationRabbitmqConfiguration.java
@@ -16,8 +16,6 @@ class ApplicationRabbitmqConfiguration {
 
     static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_ALLOWED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.application.allowed";
     static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_CANCELLED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.application.cancelled";
-    static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_DELETED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.application.deleted";
-
     @Bean
     ApplicationEventHandlerRabbitmq applicationEventHandlerRabbitmq() {
         return new ApplicationEventHandlerRabbitmq();
@@ -62,19 +60,6 @@ class ApplicationRabbitmqConfiguration {
             return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungApplicationCancelledQueue())
                 .to(applicationTopic())
                 .with(routingKeyCancelled);
-        }
-
-        @Bean
-        Queue zeiterfassungUrlaubsverwaltungApplicationDeletedQueue() {
-            return new Queue(ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_DELETED_QUEUE, true);
-        }
-
-        @Bean
-        Binding bindZeiterfassungUrlaubsverwaltungApplicationDeletedQueue() {
-            final String routingKeyDeleted = applicationRabbitmqConfigurationProperties.getRoutingKeyDeleted();
-            return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungApplicationDeletedQueue())
-                .to(applicationTopic())
-                .with(routingKeyDeleted);
         }
 
     }

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationRabbitmqConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationRabbitmqConfiguration.java
@@ -1,0 +1,81 @@
+package de.focusshift.zeiterfassung.integration.urlaubsverwaltung.application;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(value = "zeiterfassung.integration.urlaubsverwaltung.application.enabled", havingValue = "true")
+@EnableConfigurationProperties(ApplicationRabbitmqConfigurationProperties.class)
+class ApplicationRabbitmqConfiguration {
+
+    static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_ALLOWED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.application.allowed";
+    static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_CANCELLED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.application.cancelled";
+    static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_DELETED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.application.deleted";
+
+    @Bean
+    ApplicationEventHandlerRabbitmq applicationEventHandlerRabbitmq() {
+        return new ApplicationEventHandlerRabbitmq();
+    }
+
+    @Configuration
+    @ConditionalOnProperty(value = "zeiterfassung.integration.urlaubsverwaltung.application.manage-topology", havingValue = "true")
+    static class ManageTopologyConfiguration {
+
+        private final ApplicationRabbitmqConfigurationProperties applicationRabbitmqConfigurationProperties;
+
+        ManageTopologyConfiguration(ApplicationRabbitmqConfigurationProperties applicationRabbitmqConfigurationProperties) {
+            this.applicationRabbitmqConfigurationProperties = applicationRabbitmqConfigurationProperties;
+        }
+
+        @Bean
+        public TopicExchange applicationTopic() {
+            return new TopicExchange(applicationRabbitmqConfigurationProperties.getTopic());
+        }
+
+        @Bean
+        Queue zeiterfassungUrlaubsverwaltungApplicationAllowedQueue() {
+            return new Queue(ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_ALLOWED_QUEUE, true);
+        }
+
+        @Bean
+        Binding bindZeiterfassungUrlaubsverwaltungApplicationAllowedQueue() {
+            final String routingKeyAllowed = applicationRabbitmqConfigurationProperties.getRoutingKeyAllowed();
+            return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungApplicationAllowedQueue())
+                .to(applicationTopic())
+                .with(routingKeyAllowed);
+        }
+
+        @Bean
+        Queue zeiterfassungUrlaubsverwaltungApplicationCancelledQueue() {
+            return new Queue(ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_CANCELLED_QUEUE, true);
+        }
+
+        @Bean
+        Binding bindZeiterfassungUrlaubsverwaltungApplicationCancelledQueue() {
+            final String routingKeyCancelled = applicationRabbitmqConfigurationProperties.getRoutingKeyCancelled();
+            return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungApplicationCancelledQueue())
+                .to(applicationTopic())
+                .with(routingKeyCancelled);
+        }
+
+        @Bean
+        Queue zeiterfassungUrlaubsverwaltungApplicationDeletedQueue() {
+            return new Queue(ZEITERFASSUNG_URLAUBSVERWALTUNG_APPLICATION_DELETED_QUEUE, true);
+        }
+
+        @Bean
+        Binding bindZeiterfassungUrlaubsverwaltungApplicationDeletedQueue() {
+            final String routingKeyDeleted = applicationRabbitmqConfigurationProperties.getRoutingKeyDeleted();
+            return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungApplicationDeletedQueue())
+                .to(applicationTopic())
+                .with(routingKeyDeleted);
+        }
+
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationRabbitmqConfigurationProperties.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationRabbitmqConfigurationProperties.java
@@ -1,0 +1,74 @@
+package de.focusshift.zeiterfassung.integration.urlaubsverwaltung.application;
+
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties("zeiterfassung.integration.urlaubsverwaltung.application")
+class ApplicationRabbitmqConfigurationProperties {
+
+    private boolean enabled = false;
+
+    private boolean manageTopology = false;
+
+    @NotEmpty
+    private String topic = "application.topic";
+
+    @NotEmpty
+    private String routingKeyAllowed = "allowed";
+
+    @NotEmpty
+    private String routingKeyCancelled = "cancelled";
+
+    @NotEmpty
+    private String routingKeyDeleted = "deleted";
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isManageTopology() {
+        return manageTopology;
+    }
+
+    public void setManageTopology(boolean manageTopology) {
+        this.manageTopology = manageTopology;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getRoutingKeyAllowed() {
+        return routingKeyAllowed;
+    }
+
+    public void setRoutingKeyAllowed(String routingKeyAllowed) {
+        this.routingKeyAllowed = routingKeyAllowed;
+    }
+
+    public String getRoutingKeyCancelled() {
+        return routingKeyCancelled;
+    }
+
+    public void setRoutingKeyCancelled(String routingKeyCancelled) {
+        this.routingKeyCancelled = routingKeyCancelled;
+    }
+
+    public String getRoutingKeyDeleted() {
+        return routingKeyDeleted;
+    }
+
+    public void setRoutingKeyDeleted(String routingKeyDeleted) {
+        this.routingKeyDeleted = routingKeyDeleted;
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmq.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmq.java
@@ -1,12 +1,14 @@
 package de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote;
 
 import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteCancelledEventDTO;
+import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteConvertedToApplicationEventDTO;
 import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteCreatedEventDTO;
 import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteUpdatedEventDTO;
 import org.slf4j.Logger;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 
 import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CANCELLED_QUEUE;
+import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CONVERTED_TO_APPLICATION_QUEUE;
 import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CREATED_QUEUE;
 import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_UPDATED_QUEUE;
 import static java.lang.invoke.MethodHandles.lookup;
@@ -28,5 +30,10 @@ public class SickNoteEventHandlerRabbitmq {
     @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_UPDATED_QUEUE})
     void on(SickNoteUpdatedEventDTO event) {
         LOG.info("Received SickNoteUpdatedEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
+    }
+
+    @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CONVERTED_TO_APPLICATION_QUEUE})
+    void on(SickNoteConvertedToApplicationEventDTO event) {
+        LOG.info("Received SickNoteConvertedToApplicationEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmq.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmq.java
@@ -2,14 +2,12 @@ package de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote;
 
 import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteCancelledEventDTO;
 import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteCreatedEventDTO;
-import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteDeletedEventDTO;
 import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteUpdatedEventDTO;
 import org.slf4j.Logger;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 
 import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CANCELLED_QUEUE;
 import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CREATED_QUEUE;
-import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_DELETED_QUEUE;
 import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_UPDATED_QUEUE;
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -25,11 +23,6 @@ public class SickNoteEventHandlerRabbitmq {
     @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CREATED_QUEUE})
     void on(SickNoteCreatedEventDTO event) {
         LOG.info("Received SickNoteCreatedEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
-    }
-
-    @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_DELETED_QUEUE})
-    void on(SickNoteDeletedEventDTO event) {
-        LOG.info("Received SickNoteDeletedEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
     }
 
     @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_UPDATED_QUEUE})

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmq.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmq.java
@@ -1,0 +1,39 @@
+package de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote;
+
+import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteCancelledEventDTO;
+import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteCreatedEventDTO;
+import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteDeletedEventDTO;
+import de.focus_shift.urlaubsverwaltung.extension.api.sicknote.SickNoteUpdatedEventDTO;
+import org.slf4j.Logger;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+
+import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CANCELLED_QUEUE;
+import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CREATED_QUEUE;
+import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_DELETED_QUEUE;
+import static de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote.SickNoteRabbitmqConfiguration.ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_UPDATED_QUEUE;
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class SickNoteEventHandlerRabbitmq {
+    private static final Logger LOG = getLogger(lookup().lookupClass());
+
+    @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CANCELLED_QUEUE})
+    void on(SickNoteCancelledEventDTO event) {
+        LOG.info("Received SickNoteCancelledEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
+    }
+
+    @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CREATED_QUEUE})
+    void on(SickNoteCreatedEventDTO event) {
+        LOG.info("Received SickNoteCreatedEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
+    }
+
+    @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_DELETED_QUEUE})
+    void on(SickNoteDeletedEventDTO event) {
+        LOG.info("Received SickNoteDeletedEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
+    }
+
+    @RabbitListener(queues = {ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_UPDATED_QUEUE})
+    void on(SickNoteUpdatedEventDTO event) {
+        LOG.info("Received SickNoteUpdatedEvent for person={} and tenantId={}", event.getPerson(), event.getTenantId());
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteRabbitmqConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteRabbitmqConfiguration.java
@@ -16,7 +16,6 @@ class SickNoteRabbitmqConfiguration {
 
     static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CANCELLED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.cancelled";
     static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CREATED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.created";
-    static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_DELETED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.deleted";
     static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_UPDATED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.updated";
 
     @Bean
@@ -63,19 +62,6 @@ class SickNoteRabbitmqConfiguration {
             return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungSickNoteCreatedQueue())
                 .to(sickNoteTopic())
                 .with(routingKeyCreated);
-        }
-
-        @Bean
-        Queue zeiterfassungUrlaubsverwaltungSickNoteDeletedQueue() {
-            return new Queue(ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_DELETED_QUEUE, true);
-        }
-
-        @Bean
-        Binding bindZeiterfassungUrlaubsverwaltungSickNoteDeletedQueue() {
-            final String routingKeyDeleted = sickNoteRabbitmqConfigurationProperties.getRoutingKeyDeleted();
-            return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungSickNoteDeletedQueue())
-                .to(sickNoteTopic())
-                .with(routingKeyDeleted);
         }
 
         @Bean

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteRabbitmqConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteRabbitmqConfiguration.java
@@ -1,0 +1,95 @@
+package de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(value = "zeiterfassung.integration.urlaubsverwaltung.sicknote.enabled", havingValue = "true")
+@EnableConfigurationProperties(SickNoteRabbitmqConfigurationProperties.class)
+class SickNoteRabbitmqConfiguration {
+
+    static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CANCELLED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.cancelled";
+    static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CREATED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.created";
+    static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_DELETED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.deleted";
+    static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_UPDATED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.updated";
+
+    @Bean
+    SickNoteEventHandlerRabbitmq sickNoteEventHandlerRabbitmq() {
+        return new SickNoteEventHandlerRabbitmq();
+    }
+
+    @Configuration
+    @ConditionalOnProperty(value = "zeiterfassung.integration.urlaubsverwaltung.sicknote.manage-topology", havingValue = "true")
+    static class ManageTopologyConfiguration {
+
+        private final SickNoteRabbitmqConfigurationProperties sickNoteRabbitmqConfigurationProperties;
+
+        ManageTopologyConfiguration(SickNoteRabbitmqConfigurationProperties sickNoteRabbitmqConfigurationProperties) {
+            this.sickNoteRabbitmqConfigurationProperties = sickNoteRabbitmqConfigurationProperties;
+        }
+
+        @Bean
+        public TopicExchange sickNoteTopic() {
+            return new TopicExchange(sickNoteRabbitmqConfigurationProperties.getTopic());
+        }
+
+        @Bean
+        Queue zeiterfassungUrlaubsverwaltungSickNoteCancelledQueue() {
+            return new Queue(ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CANCELLED_QUEUE, true);
+        }
+
+        @Bean
+        Binding bindZeiterfassungUrlaubsverwaltungSickNoteCancelledQueue() {
+            final String routingKeyCancelled = sickNoteRabbitmqConfigurationProperties.getRoutingKeyCancelled();
+            return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungSickNoteCancelledQueue())
+                .to(sickNoteTopic())
+                .with(routingKeyCancelled);
+        }
+
+        @Bean
+        Queue zeiterfassungUrlaubsverwaltungSickNoteCreatedQueue() {
+            return new Queue(ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CREATED_QUEUE, true);
+        }
+
+        @Bean
+        Binding bindZeiterfassungUrlaubsverwaltungSickNoteCreatedQueue() {
+            final String routingKeyCreated = sickNoteRabbitmqConfigurationProperties.getRoutingKeyCreated();
+            return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungSickNoteCreatedQueue())
+                .to(sickNoteTopic())
+                .with(routingKeyCreated);
+        }
+
+        @Bean
+        Queue zeiterfassungUrlaubsverwaltungSickNoteDeletedQueue() {
+            return new Queue(ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_DELETED_QUEUE, true);
+        }
+
+        @Bean
+        Binding bindZeiterfassungUrlaubsverwaltungSickNoteDeletedQueue() {
+            final String routingKeyDeleted = sickNoteRabbitmqConfigurationProperties.getRoutingKeyDeleted();
+            return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungSickNoteDeletedQueue())
+                .to(sickNoteTopic())
+                .with(routingKeyDeleted);
+        }
+
+        @Bean
+        Queue zeiterfassungUrlaubsverwaltungSickNoteUpdatedQueue() {
+            return new Queue(ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_UPDATED_QUEUE, true);
+        }
+
+        @Bean
+        Binding bindZeiterfassungUrlaubsverwaltungSickNoteUpdatedQueue() {
+            final String routingKeyUpdated = sickNoteRabbitmqConfigurationProperties.getRoutingKeyUpdated();
+            return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungSickNoteUpdatedQueue())
+                .to(sickNoteTopic())
+                .with(routingKeyUpdated);
+        }
+
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteRabbitmqConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteRabbitmqConfiguration.java
@@ -18,6 +18,9 @@ class SickNoteRabbitmqConfiguration {
     static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CREATED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.created";
     static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_UPDATED_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.updated";
 
+    static final String ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CONVERTED_TO_APPLICATION_QUEUE = "zeiterfassung.queue.urlaubsverwaltung.sicknote.converted_to_application";
+
+
     @Bean
     SickNoteEventHandlerRabbitmq sickNoteEventHandlerRabbitmq() {
         return new SickNoteEventHandlerRabbitmq();
@@ -76,6 +79,20 @@ class SickNoteRabbitmqConfiguration {
                 .to(sickNoteTopic())
                 .with(routingKeyUpdated);
         }
+
+        @Bean
+        Queue zeiterfassungUrlaubsverwaltungSickNoteConvertedToApplicationQueue() {
+            return new Queue(ZEITERFASSUNG_URLAUBSVERWALTUNG_SICKNOTE_CONVERTED_TO_APPLICATION_QUEUE, true);
+        }
+
+        @Bean
+        Binding bindZeiterfassungUrlaubsverwaltungSickNoteConvertedToApplicationQueue() {
+            final String routingKeyUpdated = sickNoteRabbitmqConfigurationProperties.getRoutingKeyConvertedToApplication();
+            return BindingBuilder.bind(zeiterfassungUrlaubsverwaltungSickNoteConvertedToApplicationQueue())
+                    .to(sickNoteTopic())
+                    .with(routingKeyUpdated);
+        }
+
 
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteRabbitmqConfigurationProperties.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteRabbitmqConfigurationProperties.java
@@ -27,6 +27,9 @@ class SickNoteRabbitmqConfigurationProperties {
     @NotEmpty
     private String routingKeyUpdated = "updated";
 
+    @NotEmpty
+    private String routingKeyConvertedToApplication = "converted_to_application";
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -81,5 +84,13 @@ class SickNoteRabbitmqConfigurationProperties {
 
     public void setRoutingKeyUpdated(String routingKeyUpdated) {
         this.routingKeyUpdated = routingKeyUpdated;
+    }
+
+    public String getRoutingKeyConvertedToApplication() {
+        return routingKeyConvertedToApplication;
+    }
+
+    public void setRoutingKeyConvertedToApplication(String routingKeyConvertedToApplication) {
+        this.routingKeyConvertedToApplication = routingKeyConvertedToApplication;
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteRabbitmqConfigurationProperties.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteRabbitmqConfigurationProperties.java
@@ -1,0 +1,85 @@
+package de.focusshift.zeiterfassung.integration.urlaubsverwaltung.sicknote;
+
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties("zeiterfassung.integration.urlaubsverwaltung.sicknote")
+class SickNoteRabbitmqConfigurationProperties {
+
+    private boolean enabled = false;
+
+    private boolean manageTopology = false;
+
+    @NotEmpty
+    private String topic = "sicknote.topic";
+
+    @NotEmpty
+    private String routingKeyCancelled = "cancelled";
+
+    @NotEmpty
+    private String routingKeyCreated = "created";
+
+    @NotEmpty
+    private String routingKeyDeleted = "deleted";
+
+    @NotEmpty
+    private String routingKeyUpdated = "updated";
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isManageTopology() {
+        return manageTopology;
+    }
+
+    public void setManageTopology(boolean manageTopology) {
+        this.manageTopology = manageTopology;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getRoutingKeyCancelled() {
+        return routingKeyCancelled;
+    }
+
+    public void setRoutingKeyCancelled(String routingKeyCancelled) {
+        this.routingKeyCancelled = routingKeyCancelled;
+    }
+
+    public String getRoutingKeyCreated() {
+        return routingKeyCreated;
+    }
+
+    public void setRoutingKeyCreated(String routingKeyCreated) {
+        this.routingKeyCreated = routingKeyCreated;
+    }
+
+    public String getRoutingKeyDeleted() {
+        return routingKeyDeleted;
+    }
+
+    public void setRoutingKeyDeleted(String routingKeyDeleted) {
+        this.routingKeyDeleted = routingKeyDeleted;
+    }
+
+    public String getRoutingKeyUpdated() {
+        return routingKeyUpdated;
+    }
+
+    public void setRoutingKeyUpdated(String routingKeyUpdated) {
+        this.routingKeyUpdated = routingKeyUpdated;
+    }
+}


### PR DESCRIPTION
Here are some things you should have thought about:

ToDo:
- [ ] Save absences in new domain
- [ ] Show absences in "time"
- [ ] Show absences in "report"

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?
- [x] Delete Events nicht mehr konsumieren

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
