### PR TITLE
Set tenantId to TenantContextHolder via CurrentTenantInterceptor

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/tenancy/configuration/multi/TenantContextHolderMultiTenant.java
+++ b/src/main/java/de/focusshift/zeiterfassung/tenancy/configuration/multi/TenantContextHolderMultiTenant.java
@@ -2,26 +2,38 @@ package de.focusshift.zeiterfassung.tenancy.configuration.multi;
 
 import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
 import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
 import static de.focusshift.zeiterfassung.tenancy.TenantConfigurationProperties.MULTI;
+import static java.lang.invoke.MethodHandles.lookup;
 
 @Component
 @ConditionalOnProperty(value = "zeiterfassung.tenant.mode", havingValue = MULTI)
 class TenantContextHolderMultiTenant implements TenantContextHolder {
 
+    private static final Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());
+
+    private static final InheritableThreadLocal<TenantId> currentTenantId = new InheritableThreadLocal<>();
+
+    @Override
     public Optional<TenantId> getCurrentTenantId() {
-        if (SecurityContextHolder.getContext().getAuthentication() instanceof final OAuth2AuthenticationToken oauthToken) {
-            final TenantId tenantId = new TenantId(oauthToken.getAuthorizedClientRegistrationId());
-            if (tenantId.valid()) {
-                return Optional.of(tenantId);
-            }
-        }
-        return Optional.empty();
+        return Optional.ofNullable(currentTenantId.get());
+    }
+
+    @Override
+    public void setTenantId(TenantId tenantId) {
+        LOG.debug("Setting tenantId to {}", tenantId);
+        currentTenantId.set(tenantId);
+    }
+
+    @Override
+    public void clear() {
+        LOG.debug("Clearing tenantId");
+        currentTenantId.remove();
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/tenancy/configuration/single/TenantContextHolderSingleTenant.java
+++ b/src/main/java/de/focusshift/zeiterfassung/tenancy/configuration/single/TenantContextHolderSingleTenant.java
@@ -19,7 +19,18 @@ class TenantContextHolderSingleTenant implements TenantContextHolder {
         this.defaultTenantId = singleTenantConfigurationProperties.getDefaultTenantId();
     }
 
+    @Override
     public Optional<TenantId> getCurrentTenantId() {
         return Optional.of(new TenantId(defaultTenantId));
+    }
+
+    @Override
+    public void setTenantId(TenantId tenantId) {
+        // do nothing
+    }
+
+    @Override
+    public void clear() {
+        // do nothing
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/tenancy/tenant/TenantContextHolder.java
+++ b/src/main/java/de/focusshift/zeiterfassung/tenancy/tenant/TenantContextHolder.java
@@ -5,4 +5,8 @@ import java.util.Optional;
 public interface TenantContextHolder {
 
     Optional<TenantId> getCurrentTenantId();
+
+    void setTenantId(TenantId tenantId);
+
+    void clear();
 }

--- a/src/main/java/de/focusshift/zeiterfassung/web/CurrentTenantInterceptor.java
+++ b/src/main/java/de/focusshift/zeiterfassung/web/CurrentTenantInterceptor.java
@@ -1,0 +1,51 @@
+package de.focusshift.zeiterfassung.web;
+
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.security.Principal;
+
+import static java.lang.invoke.MethodHandles.lookup;
+
+@Component
+class CurrentTenantInterceptor implements HandlerInterceptor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());
+
+    private final TenantContextHolder tenantContextHolder;
+
+    CurrentTenantInterceptor(TenantContextHolder tenantContextHolder) {
+        this.tenantContextHolder = tenantContextHolder;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+
+        final Principal userPrincipal = request.getUserPrincipal();
+
+        if (userPrincipal instanceof final OAuth2AuthenticationToken oauthToken) {
+            final TenantId tenantId = new TenantId(oauthToken.getAuthorizedClientRegistrationId());
+            if (tenantId.valid()) {
+                tenantContextHolder.setTenantId(tenantId);
+            } else {
+                LOG.warn("invalid tenantId={}", tenantId);
+                tenantContextHolder.clear();
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) {
+        tenantContextHolder.clear();
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/web/WebConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/web/WebConfiguration.java
@@ -10,15 +10,18 @@ class WebConfiguration implements WebMvcConfigurer {
 
     private final AuthoritiesModelProvider authoritiesModelProvider;
     private final DoubleFormatter doubleFormatter;
+    private final CurrentTenantInterceptor currentTenantInterceptor;
 
-    WebConfiguration(AuthoritiesModelProvider authoritiesModelProvider, DoubleFormatter doubleFormatter) {
+    WebConfiguration(AuthoritiesModelProvider authoritiesModelProvider, CurrentTenantInterceptor currentTenantInterceptor, DoubleFormatter doubleFormatter) {
         this.authoritiesModelProvider = authoritiesModelProvider;
+        this.currentTenantInterceptor = currentTenantInterceptor;
         this.doubleFormatter = doubleFormatter;
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authoritiesModelProvider);
+        registry.addInterceptor(currentTenantInterceptor);
     }
 
     @Override

--- a/src/test/java/de/focusshift/zeiterfassung/tenancy/configuration/multi/TenantContextHolderMultiTenantTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/tenancy/configuration/multi/TenantContextHolderMultiTenantTest.java
@@ -2,56 +2,39 @@ package de.focusshift.zeiterfassung.tenancy.configuration.multi;
 
 
 import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.context.SecurityContextImpl;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-
-import java.util.List;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 class TenantContextHolderMultiTenantTest {
 
     private final TenantContextHolderMultiTenant sut = new TenantContextHolderMultiTenant();
 
+    @BeforeEach
+    void setup() {
+        sut.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        sut.clear();
+    }
+
     @Test
-    void ensureTenantForOAuth2AuthenticationToken() {
+    void hasTenantId() {
+        sut.setTenantId(new TenantId("a154bc4e"));
+        assertThat(sut.getCurrentTenantId()).hasValue(new TenantId("a154bc4e"));
+    }
 
-        final OAuth2User oAuth2User = mock(OAuth2User.class);
-        final Authentication authentication = new OAuth2AuthenticationToken(oAuth2User, List.of(), "a154bc4e");
-
-        final SecurityContext securityContext = new SecurityContextImpl();
-        securityContext.setAuthentication(authentication);
-        SecurityContextHolder.setContext(securityContext);
-
+    @Test
+    void clearsTenantId() {
+        sut.setTenantId(new TenantId("a154bc4e"));
         assertThat(sut.getCurrentTenantId()).hasValue(new TenantId("a154bc4e"));
 
+        sut.clear();
+        assertThat(sut.getCurrentTenantId()).isEmpty();
     }
 
-    private static Stream<Authentication> authenticationSource() {
-        return Stream.of(
-            null,
-            UsernamePasswordAuthenticationToken.authenticated(null, null, List.of())
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("authenticationSource")
-    void ensureExceptionWithoutOAuth2AuthenticationToken(final Authentication authentication) {
-
-        final SecurityContext securityContext = new SecurityContextImpl();
-        securityContext.setAuthentication(authentication);
-        SecurityContextHolder.setContext(securityContext);
-
-        assertThat(sut.getCurrentTenantId()).isNotPresent();
-    }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/timeclock/TimeClockControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeclock/TimeClockControllerTest.java
@@ -1,8 +1,11 @@
 package de.focusshift.zeiterfassung.timeclock;
 
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
 import de.focusshift.zeiterfassung.user.CurrentUserProvider;
 import de.focusshift.zeiterfassung.user.UserId;
 import de.focusshift.zeiterfassung.web.DoubleFormatter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -53,7 +56,15 @@ class TimeClockControllerTest {
     private CurrentUserProvider currentUserProvider;
 
     @MockBean
+    private TenantContextHolder tenantContextHolder;
+
+    @MockBean
     private DoubleFormatter doubleFormatter;
+
+    @BeforeEach
+    void setUp() {
+        when(tenantContextHolder.getCurrentTenantId()).thenReturn(Optional.of(new TenantId("default")));
+    }
 
     @Test
     void ensureStartTimeClock() throws Exception {

--- a/src/test/java/de/focusshift/zeiterfassung/web/CurrentTenantInterceptorTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/web/CurrentTenantInterceptorTest.java
@@ -1,0 +1,83 @@
+package de.focusshift.zeiterfassung.web;
+
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CurrentTenantInterceptorTest {
+
+    @Mock
+    private TenantContextHolder tenantContextHolder;
+
+    @InjectMocks
+    private CurrentTenantInterceptor sut;
+
+    @Test
+    void testPreHandleWithOAuthToken() {
+
+        final OAuth2User oAuth2User = mock(OAuth2User.class);
+        final Authentication authentication = new OAuth2AuthenticationToken(oAuth2User, List.of(), "a154bc4e");
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getUserPrincipal()).thenReturn(authentication);
+
+        sut.preHandle(request, mock(HttpServletResponse.class), null);
+
+        verify(tenantContextHolder).setTenantId(new TenantId("a154bc4e"));
+        verifyNoMoreInteractions(tenantContextHolder);
+    }
+
+    @Test
+    void testPreHandleWithoutAuthorizedClientRegistrationId() {
+
+        final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getUserPrincipal()).thenReturn(authentication);
+
+        sut.preHandle(request, mock(HttpServletResponse.class), null);
+
+        verify(tenantContextHolder, never()).setTenantId(any());
+        verify(tenantContextHolder).clear();
+    }
+
+    @Test
+    void testPreHandleWithoutOAuth2AuthenticationToken() {
+
+        final UsernamePasswordAuthenticationToken authentication = mock(UsernamePasswordAuthenticationToken.class);
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+
+        when(request.getUserPrincipal()).thenReturn(authentication);
+
+        sut.preHandle(request, mock(HttpServletResponse.class), null);
+
+        verify(tenantContextHolder, never()).setTenantId(any());
+    }
+
+    @Test
+    void testpostHandle() {
+
+        sut.postHandle(mock(HttpServletRequest.class), mock(HttpServletResponse.class), null, null);
+
+        verify(tenantContextHolder, never()).setTenantId(any());
+        verify(tenantContextHolder).clear();
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/web/WebConfigurationTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/web/WebConfigurationTest.java
@@ -1,0 +1,53 @@
+package de.focusshift.zeiterfassung.web;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class WebConfigurationTest {
+
+    @InjectMocks
+    private WebConfiguration sut;
+
+    @Mock
+    private AuthoritiesModelProvider authoritiesModelProvider;
+    @Mock
+    private DoubleFormatter doubleFormatter;
+    @Mock
+    private CurrentTenantInterceptor currentTenantInterceptor;
+
+    @Test
+    void ensureThatAuthoritiesModelProviderWasAdded() {
+
+        final InterceptorRegistry registry = mock(InterceptorRegistry.class);
+        sut.addInterceptors(registry);
+
+        verify(registry).addInterceptor(authoritiesModelProvider);
+    }
+
+    @Test
+    void ensureThatCurrentTenantInterceptorWasAdded() {
+
+        final InterceptorRegistry registry = mock(InterceptorRegistry.class);
+        sut.addInterceptors(registry);
+
+        verify(registry).addInterceptor(currentTenantInterceptor);
+    }
+
+    @Test
+    void ensureThatDoubleFormatterWasAdded() {
+
+        final FormatterRegistry registry = mock(FormatterRegistry.class);
+        sut.addFormatters(registry);
+
+        verify(registry).addFormatter(doubleFormatter);
+    }
+}


### PR DESCRIPTION
so TenantContextHolder.setTenantId() can be used e.g. in EventListeners or Schedulers without the http request context

refs #303 


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
