### PR TITLE
quickfix peer dependency issue with @rollup/pluginutils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1252,9 +1252,9 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
@@ -1264,7 +1264,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -1345,9 +1345,9 @@
       }
     },
     "node_modules/@rollup/plugin-node-resolve/node_modules/@rollup/pluginutils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
@@ -1357,7 +1357,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -9588,9 +9588,9 @@
           "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
         },
         "@rollup/pluginutils": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-          "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+          "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
           "requires": {
             "@types/estree": "^1.0.0",
             "estree-walker": "^2.0.2",
@@ -9649,9 +9649,9 @@
       },
       "dependencies": {
         "@rollup/pluginutils": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-          "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+          "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
           "requires": {
             "@types/estree": "^1.0.0",
             "estree-walker": "^2.0.2",


### PR DESCRIPTION
`@rollup/plugin-commonjs` depends on pluginutils `^5.0.1` which does not have rollup v4 in the peerDependencies

```
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: @rollup/pluginutils@5.0.2
npm WARN Found: rollup@4.1.4
npm WARN node_modules/rollup
npm WARN   rollup@"4.1.4" from the root project
npm WARN   5 more (@rollup/plugin-commonjs, ...)
npm WARN
npm WARN Could not resolve dependency:
npm WARN peerOptional rollup@"^1.20.0||^2.0.0||^3.0.0" from @rollup/pluginutils@5.0.2
npm WARN node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils
npm WARN   @rollup/pluginutils@"^5.0.1" from @rollup/plugin-commonjs@25.0.7
npm WARN   node_modules/@rollup/plugin-commonjs
npm WARN
npm WARN Conflicting peer dependency: rollup@3.29.4
npm WARN node_modules/rollup
npm WARN   peerOptional rollup@"^1.20.0||^2.0.0||^3.0.0" from @rollup/pluginutils@5.0.2
npm WARN   node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils
npm WARN     @rollup/pluginutils@"^5.0.1" from @rollup/plugin-commonjs@25.0.7
npm WARN     node_modules/@rollup/plugin-commonjs
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: @rollup/pluginutils@5.0.2
npm WARN Found: rollup@4.1.4
npm WARN node_modules/rollup
npm WARN   rollup@"4.1.4" from the root project
npm WARN   5 more (@rollup/plugin-commonjs, ...)
npm WARN
npm WARN Could not resolve dependency:
npm WARN peerOptional rollup@"^1.20.0||^2.0.0||^3.0.0" from @rollup/pluginutils@5.0.2
npm WARN node_modules/@rollup/plugin-node-resolve/node_modules/@rollup/pluginutils
npm WARN   @rollup/pluginutils@"^5.0.1" from @rollup/plugin-node-resolve@15.2.3
npm WARN   node_modules/@rollup/plugin-node-resolve
npm WARN
npm WARN Conflicting peer dependency: rollup@3.29.4
npm WARN node_modules/rollup
npm WARN   peerOptional rollup@"^1.20.0||^2.0.0||^3.0.0" from @rollup/pluginutils@5.0.2
npm WARN   node_modules/@rollup/plugin-node-resolve/node_modules/@rollup/pluginutils
npm WARN     @rollup/pluginutils@"^5.0.1" from @rollup/plugin-node-resolve@15.2.3
npm WARN     node_modules/@rollup/plugin-node-resolve
```

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
