### PR TITLE
refactoring: improve UserId / UserLocalId handling

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceService.java
@@ -1,6 +1,7 @@
 package de.focusshift.zeiterfassung.absence;
 
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 
 import java.time.Instant;
@@ -25,9 +26,9 @@ public interface AbsenceService {
      *
      * @param from        from
      * @param toExclusive to (exclusive)
-     * @return absences grouped by {@link UserLocalId}. empty list value when there are no absences on a date within the period.
+     * @return absences grouped by {@link UserIdComposite}. empty list value when there are no absences on a date within the period.
      */
-    Map<UserLocalId, List<Absence>> getAbsencesForAllUsers(LocalDate from, LocalDate toExclusive);
+    Map<UserIdComposite, List<Absence>> getAbsencesForAllUsers(LocalDate from, LocalDate toExclusive);
 
     /**
      * Find all absences in a given date range for the given users
@@ -35,9 +36,9 @@ public interface AbsenceService {
      * @param userLocalIds users
      * @param from         from
      * @param toExclusive  to (exclusive)
-     * @return absences grouped by {@link UserLocalId}. empty list value when there are no absences on a date within the period.
+     * @return absences grouped by {@link UserIdComposite}. empty list value when there are no absences on a date within the period.
      */
-    Map<UserLocalId, List<Absence>> getAbsencesByUserIds(List<UserLocalId> userLocalIds, LocalDate from, LocalDate toExclusive);
+    Map<UserIdComposite, List<Absence>> getAbsencesByUserIds(List<UserLocalId> userLocalIds, LocalDate from, LocalDate toExclusive);
 
     /**
      * Find all absences in a given date range for the given user

--- a/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceServiceImpl.java
@@ -75,11 +75,11 @@ class AbsenceServiceImpl implements AbsenceService {
 
         final List<String> userIdValues = users
             .stream()
-            .map(User::id)
+            .map(User::userId)
             .map(UserId::value)
             .toList();
 
-        final Map<UserId, UserIdComposite> idCompositeByUserId = users.stream().collect(toMap(User::id, User::idComposite));
+        final Map<UserId, UserIdComposite> idCompositeByUserId = users.stream().collect(toMap(User::userId, User::userIdComposite));
 
         final Map<UserIdComposite, List<Absence>> result = absenceRepository.findAllByTenantIdAndUserIdInAndStartDateLessThanAndEndDateGreaterThanEqual(tenantId, userIdValues, period.toExclusive, period.from)
             .stream()
@@ -104,7 +104,7 @@ class AbsenceServiceImpl implements AbsenceService {
             .collect(groupingBy(Absence::userId));
 
         final Map<UserId, UserIdComposite> idCompositeByUserId = userManagementService.findAllUsers().stream()
-            .collect(toMap(User::id, User::idComposite));
+            .collect(toMap(User::userId, User::userIdComposite));
 
         final Map<UserIdComposite, List<Absence>> result = absenceByUserId.entrySet()
             .stream()

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
@@ -41,7 +41,7 @@ class ReportControllerHelper {
         if (permittedUsers.size() > 1) {
             final List<SelectableUserDto> selectableUserDtos = permittedUsers
                 .stream()
-                .map(user -> userToSelectableUserDto(user, selectedUserLocalIds.contains(user.localId())))
+                .map(user -> userToSelectableUserDto(user, selectedUserLocalIds.contains(user.userLocalId())))
                 .toList();
 
             model.addAttribute("users", selectableUserDtos);
@@ -52,7 +52,7 @@ class ReportControllerHelper {
     }
 
     private static SelectableUserDto userToSelectableUserDto(User user, boolean selected) {
-        return new SelectableUserDto(user.localId().value(), user.givenName() + " " + user.familyName(), selected);
+        return new SelectableUserDto(user.userLocalId().value(), user.givenName() + " " + user.familyName(), selected);
     }
 
     GraphWeekDto toGraphWeekDto(ReportWeek reportWeek, Month monthPivot) {

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportCsvController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportCsvController.java
@@ -2,6 +2,7 @@ package de.focusshift.zeiterfassung.report;
 
 import de.focusshift.zeiterfassung.user.UserId;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
@@ -15,7 +16,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.server.ResponseStatusException;
 import org.threeten.extra.YearWeek;
 
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.DateTimeException;
@@ -58,12 +58,12 @@ class ReportCsvController {
             .orElseThrow(() -> new ResponseStatusException(BAD_REQUEST, "Invalid week."));
 
         final UserId userId = principalToUserId(principal);
-        final List<UserLocalId> userIds = optionalUserIds.orElse(List.of()).stream().map(UserLocalId::new).toList();
+        final List<UserLocalId> userLocalIds = optionalUserIds.orElse(List.of()).stream().map(UserLocalId::new).toList();
         final String fileName = messageSource.getMessage("report.weekly.csv.filename", new Object[]{year, week}, locale);
 
-        final Consumer<PrintWriter> csvWriteConsumer = userIds.isEmpty()
+        final Consumer<PrintWriter> csvWriteConsumer = userLocalIds.isEmpty()
             ? writer -> reportCsvService.writeWeekReportCsv(Year.of(reportYearWeek.getYear()), reportYearWeek.getWeek(), locale, userId, writer)
-            : writer -> reportCsvService.writeWeekReportCsvForUserLocalIds(Year.of(reportYearWeek.getYear()), reportYearWeek.getWeek(), locale, userIds, writer);
+            : writer -> reportCsvService.writeWeekReportCsvForUserLocalIds(Year.of(reportYearWeek.getYear()), reportYearWeek.getWeek(), locale, userLocalIds, writer);
 
         writeCsv(fileName, response, csvWriteConsumer);
     }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
@@ -2,6 +2,7 @@ package de.focusshift.zeiterfassung.report;
 
 import de.focusshift.zeiterfassung.timeentry.PlannedWorkingHours;
 import de.focusshift.zeiterfassung.timeentry.WorkDuration;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 
 import java.time.LocalDate;
@@ -14,9 +15,9 @@ import java.util.stream.Stream;
 
 record ReportDay(
     LocalDate date,
-    Map<UserLocalId, PlannedWorkingHours> plannedWorkingHoursByUser,
-    Map<UserLocalId, List<ReportDayEntry>> reportDayEntriesByUser,
-    Map<UserLocalId, List<DetailDayAbsenceDto>> detailDayAbsencesByUser
+    Map<UserIdComposite, PlannedWorkingHours> plannedWorkingHoursByUser,
+    Map<UserIdComposite, List<ReportDayEntry>> reportDayEntriesByUser,
+    Map<UserIdComposite, List<DetailDayAbsenceDto>> detailDayAbsencesByUser
 
 ) {
 
@@ -29,7 +30,8 @@ record ReportDay(
     }
 
     public PlannedWorkingHours plannedWorkingHoursByUser(UserLocalId userLocalId) {
-        return findValueByFirstKeyMatch(plannedWorkingHoursByUser, userLocalId::equals).orElse(PlannedWorkingHours.ZERO);
+        return findValueByFirstKeyMatch(plannedWorkingHoursByUser, userIdComposite -> userLocalId.equals(userIdComposite.localId()))
+            .orElse(PlannedWorkingHours.ZERO);
     }
 
     public WorkDuration workDuration() {
@@ -42,10 +44,10 @@ record ReportDay(
     }
 
     public WorkDuration workDurationByUser(UserLocalId userLocalId) {
-        return workDurationByUserPredicate(userLocalId::equals);
+        return workDurationByUserPredicate(userIdComposite -> userLocalId.equals(userIdComposite.localId()));
     }
 
-    private WorkDuration workDurationByUserPredicate(Predicate<UserLocalId> predicate) {
+    private WorkDuration workDurationByUserPredicate(Predicate<UserIdComposite> predicate) {
         final List<ReportDayEntry> reportDayEntries = findValueByFirstKeyMatch(reportDayEntriesByUser, predicate).orElse(List.of());
         return calculateWorkDurationFrom(reportDayEntries.stream());
     }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportPermissionService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportPermissionService.java
@@ -43,7 +43,7 @@ class ReportPermissionService {
             return userLocalIds;
         }
 
-        final UserLocalId currentUserLocaleId = currentUserProvider.getCurrentUser().localId();
+        final UserLocalId currentUserLocaleId = currentUserProvider.getCurrentUser().userLocalId();
         if (userLocalIds.contains(currentUserLocaleId)) {
             return List.of(currentUserLocaleId);
         }
@@ -53,10 +53,10 @@ class ReportPermissionService {
 
     List<UserLocalId> findAllPermittedUserLocalIdsForCurrentUser() {
         if (currentUserHasPermissionForAllUsers()) {
-            return userManagementService.findAllUsers().stream().map(User::localId).toList();
+            return userManagementService.findAllUsers().stream().map(User::userLocalId).toList();
         }
 
-        final UserLocalId currentUserLocaleId = currentUserProvider.getCurrentUser().localId();
+        final UserLocalId currentUserLocaleId = currentUserProvider.getCurrentUser().userLocalId();
         return List.of(currentUserLocaleId);
     }
 

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportServiceRaw.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportServiceRaw.java
@@ -69,9 +69,9 @@ class ReportServiceRaw {
             .orElseThrow(() -> new IllegalStateException("could not find user id=%s".formatted(userId)));
 
         return createReportWeek(year, week,
-            period -> Map.of(user.idComposite(), timeEntryService.getEntries(period.from(), period.toExclusive(), userId)),
-            period -> Map.of(user.idComposite(), absenceService.getAbsencesByUserId(userId, period.from(), period.toExclusive())),
-            period -> workingTimeCalendarService.getWorkingTimes(period.from(), period.toExclusive(), List.of(user.localId())));
+            period -> Map.of(user.userIdComposite(), timeEntryService.getEntries(period.from(), period.toExclusive(), userId)),
+            period -> Map.of(user.userIdComposite(), absenceService.getAbsencesByUserId(userId, period.from(), period.toExclusive())),
+            period -> workingTimeCalendarService.getWorkingTimes(period.from(), period.toExclusive(), List.of(user.userLocalId())));
     }
 
     ReportWeek getReportWeek(Year year, int week, List<UserLocalId> userLocalIds) {
@@ -94,9 +94,9 @@ class ReportServiceRaw {
             .orElseThrow(() -> new IllegalStateException("could not find user id=%s".formatted(userId)));
 
         return createReportMonth(yearMonth,
-            period -> timeEntryService.getEntriesByUserLocalIds(period.from(), period.toExclusive(), List.of(user.localId())),
-            period -> Map.of(user.idComposite(), absenceService.getAbsencesByUserId(userId, period.from(), period.toExclusive())),
-            period -> workingTimeCalendarService.getWorkingTimes(period.from(), period.toExclusive(), List.of(user.localId())));
+            period -> timeEntryService.getEntriesByUserLocalIds(period.from(), period.toExclusive(), List.of(user.userLocalId())),
+            period -> Map.of(user.userIdComposite(), absenceService.getAbsencesByUserId(userId, period.from(), period.toExclusive())),
+            period -> workingTimeCalendarService.getWorkingTimes(period.from(), period.toExclusive(), List.of(user.userLocalId())));
     }
 
     ReportMonth getReportMonth(YearMonth yearMonth, List<UserLocalId> userLocalIds) {
@@ -142,7 +142,7 @@ class ReportServiceRaw {
                     entry -> entry.getValue().stream()
                         .filter(isInAbsencePeriod(date))
                         .map(absence -> new DetailDayAbsenceDto(userById.values().stream()
-                            .filter(user -> user.idComposite().equals(entry.getKey()))
+                            .filter(user -> user.userIdComposite().equals(entry.getKey()))
                             .map(User::fullName).findFirst().orElse(""),
                             absence.dayLength().name(), absence.getMessageKey(), absence.color().name()))
                         .toList())
@@ -242,7 +242,7 @@ class ReportServiceRaw {
         final List<UserId> allUserIds = Stream.concat(timeEntriesUserIds.stream(), absencesUserIds.stream()).distinct().toList();
         return userManagementService.findAllUsersByIds(allUserIds)
             .stream()
-            .collect(toMap(User::id, Function.identity()));
+            .collect(toMap(User::userId, Function.identity()));
     }
 
     private ReportWeek reportWeek(final LocalDate startOfWeekDate,

--- a/src/main/java/de/focusshift/zeiterfassung/timeclock/TimeClockService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeclock/TimeClockService.java
@@ -1,6 +1,5 @@
 package de.focusshift.zeiterfassung.timeclock;
 
-import de.focusshift.zeiterfassung.timeentry.TimeEntry;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryService;
 import de.focusshift.zeiterfassung.user.UserId;
 import de.focusshift.zeiterfassung.user.UserSettingsProvider;
@@ -80,16 +79,6 @@ class TimeClockService {
         final ZonedDateTime stoppedAt = timeClockEntity.getStoppedAt() == null ? null : ZonedDateTime.ofInstant(timeClockEntity.getStoppedAt(), ZoneId.of(timeClockEntity.getStoppedAtZoneId()));
 
         return new TimeClock(id, userId, startedAt, timeClockEntity.getComment(), timeClockEntity.isBreak(), Optional.ofNullable(stoppedAt));
-    }
-
-    private static TimeEntry timeClockToTimeEntry(TimeClock timeClock) {
-
-        final UserId userId = timeClock.userId();
-        final ZonedDateTime startedAt = timeClock.startedAt();
-        final ZonedDateTime stoppedAt = timeClock.stoppedAt()
-            .orElseThrow(() -> new IllegalArgumentException("expected timeClock with stoppedAt field."));
-
-        return new TimeEntry(null, userId, timeClock.comment(), startedAt, stoppedAt, timeClock.isBreak());
     }
 
     private static TimeClock prepareTimeClockUpdate(TimeClock existingTimeClock, TimeClockUpdate timeClockUpdate) {

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntry.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntry.java
@@ -1,13 +1,13 @@
 package de.focusshift.zeiterfassung.timeentry;
 
-import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
 
 public record TimeEntry(
     TimeEntryId id,
-    UserId userId,
+    UserIdComposite userIdComposite,
     String comment,
     ZonedDateTime start,
     ZonedDateTime end,

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryEntity.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryEntity.java
@@ -162,4 +162,12 @@ public class TimeEntryEntity extends AbstractTenantAwareEntity {
     public int hashCode() {
         return Objects.hash(id);
     }
+
+    @Override
+    public String toString() {
+        return "TimeEntryEntity{" +
+            "id=" + id +
+            ", owner='" + owner + '\'' +
+            '}';
+    }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryService.java
@@ -1,6 +1,7 @@
 package de.focusshift.zeiterfassung.timeentry;
 
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import jakarta.annotation.Nullable;
 
@@ -40,7 +41,7 @@ public interface TimeEntryService {
      *
      * @return unsorted list of {@linkplain TimeEntry}s grouped by user
      */
-    Map<UserLocalId, List<TimeEntry>> getEntriesForAllUsers(LocalDate from, LocalDate toExclusive);
+    Map<UserIdComposite, List<TimeEntry>> getEntriesForAllUsers(LocalDate from, LocalDate toExclusive);
 
     /**
      * {@linkplain TimeEntry}s for all given users and interval.
@@ -51,7 +52,7 @@ public interface TimeEntryService {
      *
      * @return unsorted list of {@linkplain TimeEntry}s grouped by user
      */
-    Map<UserLocalId, List<TimeEntry>> getEntriesByUserLocalIds(LocalDate from, LocalDate toExclusive, List<UserLocalId> userLocalIds);
+    Map<UserIdComposite, List<TimeEntry>> getEntriesByUserLocalIds(LocalDate from, LocalDate toExclusive, List<UserLocalId> userLocalIds);
 
     /**
      * {@linkplain TimeEntryWeekPage}s for the given user and week of year with sorted {@linkplain TimeEntry}s

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
@@ -95,7 +95,7 @@ class TimeEntryServiceImpl implements TimeEntryService {
 
         final Map<UserId, User> userByUserId = userManagementService.findAllUsers()
             .stream()
-            .collect(toMap(User::id, identity()));
+            .collect(toMap(User::userId, identity()));
 
         return timeEntryRepository.findAllByStartGreaterThanEqualAndStartLessThan(fromInstant, toInstant)
             .stream()
@@ -115,8 +115,8 @@ class TimeEntryServiceImpl implements TimeEntryService {
         final List<String> userIdValues = new ArrayList<>();
         final Map<UserId, User> userByUserId = new HashMap<>();
         for (User user : users) {
-            userIdValues.add(user.idComposite().id().value());
-            userByUserId.put(user.id(), user);
+            userIdValues.add(user.userIdComposite().id().value());
+            userByUserId.put(user.userId(), user);
         }
 
         final Map<UserIdComposite, List<TimeEntry>> result = timeEntryRepository
@@ -127,7 +127,7 @@ class TimeEntryServiceImpl implements TimeEntryService {
             .collect(groupingBy(TimeEntry::userIdComposite));
 
         // add empty list for users without time entries
-        users.forEach(user -> result.computeIfAbsent(user.idComposite(), unused -> List.of()));
+        users.forEach(user -> result.computeIfAbsent(user.userIdComposite(), unused -> List.of()));
 
         return result;
     }
@@ -153,7 +153,7 @@ class TimeEntryServiceImpl implements TimeEntryService {
         final Map<LocalDate, List<Absence>> absencesByDate = absenceService.findAllAbsences(userId, from, toExclusive);
 
         // TODO refactor getEntryWeekPage to accept UserLocalId to replace userManagementService call
-        final UserLocalId userLocalId = user.localId();
+        final UserLocalId userLocalId = user.userLocalId();
         final Map<LocalDate, PlannedWorkingHours> plannedByDate = workingTimeService.getWorkingHoursByUserAndYearWeek(userLocalId, Year.of(year), weekOfYear);
 
         final PlannedWorkingHours weekPlannedHours = plannedByDate.values()
@@ -336,7 +336,7 @@ class TimeEntryServiceImpl implements TimeEntryService {
         final ZonedDateTime startDateTime = ZonedDateTime.ofInstant(start, ZoneId.of(entity.getStartZoneId()));
         final ZonedDateTime endDateTime = ZonedDateTime.ofInstant(end, ZoneId.of(entity.getEndZoneId()));
 
-        final UserIdComposite userIdComposite = user.idComposite();
+        final UserIdComposite userIdComposite = user.userIdComposite();
 
         return new TimeEntry(new TimeEntryId(entity.getId()), userIdComposite, entity.getComment(), startDateTime, endDateTime, entity.isBreak());
     }

--- a/src/main/java/de/focusshift/zeiterfassung/user/HasUserIdComposite.java
+++ b/src/main/java/de/focusshift/zeiterfassung/user/HasUserIdComposite.java
@@ -1,0 +1,16 @@
+package de.focusshift.zeiterfassung.user;
+
+import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+
+public interface HasUserIdComposite {
+
+    UserIdComposite userIdComposite();
+
+    default UserId userId() {
+        return userIdComposite().id();
+    }
+
+    default UserLocalId userLocalId() {
+        return userIdComposite().localId();
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/user/UserIdComposite.java
+++ b/src/main/java/de/focusshift/zeiterfassung/user/UserIdComposite.java
@@ -1,0 +1,12 @@
+package de.focusshift.zeiterfassung.user;
+
+import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+
+/**
+ * Composite of {@linkplain UserId} and {@linkplain UserLocalId}.
+ *
+ * @param id
+ * @param localId
+ */
+public record UserIdComposite(UserId id, UserLocalId localId) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccount.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccount.java
@@ -1,5 +1,7 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
+import de.focusshift.zeiterfassung.user.UserIdComposite;
+
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.Objects;
@@ -13,22 +15,22 @@ import static java.math.RoundingMode.CEILING;
  */
 public final class OvertimeAccount {
 
-    private final UserLocalId userLocalId;
+    private final UserIdComposite userIdComposite;
     private final boolean allowed;
     private final Duration maxAllowedOvertime;
 
-    OvertimeAccount(UserLocalId userLocalId, boolean allowed) {
-        this(userLocalId, allowed, null);
+    OvertimeAccount(UserIdComposite userIdComposite, boolean allowed) {
+        this(userIdComposite, allowed, null);
     }
 
-    OvertimeAccount(UserLocalId userLocalId, boolean allowed, Duration maxAllowedOvertime) {
-        this.userLocalId = userLocalId;
+    OvertimeAccount(UserIdComposite userIdComposite, boolean allowed, Duration maxAllowedOvertime) {
+        this.userIdComposite = userIdComposite;
         this.allowed = allowed;
         this.maxAllowedOvertime = maxAllowedOvertime;
     }
 
-    public UserLocalId getUserLocalId() {
-        return userLocalId;
+    public UserIdComposite getUserIdComposite() {
+        return userIdComposite;
     }
 
     public boolean isAllowed() {
@@ -60,18 +62,18 @@ public final class OvertimeAccount {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         OvertimeAccount that = (OvertimeAccount) o;
-        return userLocalId.equals(that.userLocalId);
+        return userIdComposite.equals(that.userIdComposite);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userLocalId);
+        return Objects.hash(userIdComposite);
     }
 
     @Override
     public String toString() {
         return "OvertimeSettings{" +
-            "userLocalId=" + userLocalId +
+            "userIdComposite=" + userIdComposite +
             ", allowed=" + allowed +
             ", maxAllowedOvertime=" + maxAllowedOvertime +
             '}';

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccount.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccount.java
@@ -1,5 +1,6 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
+import de.focusshift.zeiterfassung.user.HasUserIdComposite;
 import de.focusshift.zeiterfassung.user.UserIdComposite;
 
 import java.math.BigDecimal;
@@ -13,7 +14,7 @@ import static java.math.RoundingMode.CEILING;
  * Describes the overtime account of a user. Like whether overtime is allowed or not.
  * Or how much overtime may be accumulated.
  */
-public final class OvertimeAccount {
+public final class OvertimeAccount implements HasUserIdComposite {
 
     private final UserIdComposite userIdComposite;
     private final boolean allowed;
@@ -29,7 +30,8 @@ public final class OvertimeAccount {
         this.maxAllowedOvertime = maxAllowedOvertime;
     }
 
-    public UserIdComposite getUserIdComposite() {
+    @Override
+    public UserIdComposite userIdComposite() {
         return userIdComposite;
     }
 

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountController.java
@@ -77,7 +77,11 @@ class OvertimeAccountController implements HasLaunchpad, HasTimeClock {
             }
         }
 
-        overtimeAccountService.updateOvertimeAccount(toOvertimeAccount(userId, overtimeAccountDto));
+        final UserLocalId userLocalId = new UserLocalId(userId);
+        final boolean allowed = overtimeAccountDto.isAllowed();
+        final Duration maxAllowedOvertime = hoursToDuration(overtimeAccountDto.getMaxAllowedOvertime());
+
+        overtimeAccountService.updateOvertimeAccount(userLocalId, allowed, maxAllowedOvertime);
 
         return "redirect:/users/%s/overtime-account".formatted(userId);
     }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountController.java
@@ -121,10 +121,6 @@ class OvertimeAccountController implements HasLaunchpad, HasTimeClock {
         return dto;
     }
 
-    private static OvertimeAccount toOvertimeAccount(Long userId, OvertimeAccountDto dto) {
-        return new OvertimeAccount(new UserLocalId(userId), dto.isAllowed(), hoursToDuration(dto.getMaxAllowedOvertime()));
-    }
-
     private static Duration hoursToDuration(Double hours) {
         if (hours == null) {
             return null;

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountService.java
@@ -1,5 +1,9 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
+import jakarta.annotation.Nullable;
+
+import java.time.Duration;
+
 public interface OvertimeAccountService {
 
     /**
@@ -13,8 +17,10 @@ public interface OvertimeAccountService {
     /**
      * Update the {@linkplain OvertimeAccount}
      *
-     * @param overtimeAccount {@linkplain OvertimeAccount} to update
+     * @param userLocalId account of this user should be updated
+     * @param isOvertimeAllowed whether overtime is allowed for the user or not
+     * @param maxAllowedOvertime optionally maximum allowed overtime duration. may be {@code null}.
      * @return the updated {@linkplain OvertimeAccount}
      */
-    OvertimeAccount updateOvertimeAccount(OvertimeAccount overtimeAccount);
+    OvertimeAccount updateOvertimeAccount(UserLocalId userLocalId, boolean isOvertimeAllowed, @Nullable Duration maxAllowedOvertime);
 }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImpl.java
@@ -24,8 +24,8 @@ class OvertimeAccountServiceImpl implements OvertimeAccountService {
         final User user = findUser(userLocalId);
 
         return repository.findById(userLocalId.value())
-            .map(overtimeAccountEntity -> toOvertimeAccount(overtimeAccountEntity, user.idComposite()))
-            .orElseGet(() -> defaultOvertimeAccount(user.idComposite()));
+            .map(overtimeAccountEntity -> toOvertimeAccount(overtimeAccountEntity, user.userIdComposite()))
+            .orElseGet(() -> defaultOvertimeAccount(user.userIdComposite()));
     }
 
     @Override
@@ -38,7 +38,7 @@ class OvertimeAccountServiceImpl implements OvertimeAccountService {
         entity.setAllowed(isOvertimeAllowed);
         entity.setMaxAllowedOvertime(Optional.ofNullable(maxAllowedOvertime).map(Duration::toString).orElse(null));
 
-        return toOvertimeAccount(repository.save(entity), user.idComposite());
+        return toOvertimeAccount(repository.save(entity), user.userIdComposite());
     }
 
     private User findUser(UserLocalId userLocalId) {

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImpl.java
@@ -1,5 +1,6 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import jakarta.annotation.Nullable;
 import org.springframework.stereotype.Service;
 
@@ -10,36 +11,47 @@ import java.util.Optional;
 class OvertimeAccountServiceImpl implements OvertimeAccountService {
 
     private final OvertimeAccountRepository repository;
+    private final UserManagementService userManagementService;
 
-    OvertimeAccountServiceImpl(OvertimeAccountRepository repository) {
+    OvertimeAccountServiceImpl(OvertimeAccountRepository repository, UserManagementService userManagementService) {
         this.repository = repository;
+        this.userManagementService = userManagementService;
     }
 
     @Override
     public OvertimeAccount getOvertimeAccount(UserLocalId userLocalId) {
+
+        final User user = findUser(userLocalId);
+
         return repository.findById(userLocalId.value())
-            .map(OvertimeAccountServiceImpl::toOvertimeAccount)
-            .orElseGet(() -> defaultOvertimeAccount(userLocalId));
+            .map(overtimeAccountEntity -> toOvertimeAccount(overtimeAccountEntity, user.idComposite()))
+            .orElseGet(() -> defaultOvertimeAccount(user.idComposite()));
     }
 
     @Override
     public OvertimeAccount updateOvertimeAccount(UserLocalId userLocalId, boolean isOvertimeAllowed, @Nullable Duration maxAllowedOvertime) {
 
+        final User user = findUser(userLocalId);
         final OvertimeAccountEntity entity = repository.findById(userLocalId.value()).orElseGet(OvertimeAccountEntity::new);
 
         entity.setUserId(userLocalId.value());
         entity.setAllowed(isOvertimeAllowed);
         entity.setMaxAllowedOvertime(Optional.ofNullable(maxAllowedOvertime).map(Duration::toString).orElse(null));
 
-        return toOvertimeAccount(repository.save(entity));
+        return toOvertimeAccount(repository.save(entity), user.idComposite());
     }
 
-    private static OvertimeAccount defaultOvertimeAccount(UserLocalId userLocalId) {
-        return new OvertimeAccount(userLocalId, true);
+    private User findUser(UserLocalId userLocalId) {
+        return userManagementService.findUserByLocalId(userLocalId)
+            .orElseThrow(() -> new IllegalStateException("expected user=%s to exist. But got nothing.".formatted(userLocalId)));
     }
 
-    private static OvertimeAccount toOvertimeAccount(OvertimeAccountEntity entity) {
-        return new OvertimeAccount(new UserLocalId(entity.getUserId()), entity.isAllowed(), toDuration(entity.getMaxAllowedOvertime()));
+    private static OvertimeAccount defaultOvertimeAccount(UserIdComposite userIdComposite) {
+        return new OvertimeAccount(userIdComposite, true);
+    }
+
+    private static OvertimeAccount toOvertimeAccount(OvertimeAccountEntity entity, UserIdComposite userIdComposite) {
+        return new OvertimeAccount(userIdComposite, entity.isAllowed(), toDuration(entity.getMaxAllowedOvertime()));
     }
 
     private static Duration toDuration(String durationValue) {

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImpl.java
@@ -1,8 +1,10 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
+import jakarta.annotation.Nullable;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Optional;
 
 @Service
 class OvertimeAccountServiceImpl implements OvertimeAccountService {
@@ -21,13 +23,13 @@ class OvertimeAccountServiceImpl implements OvertimeAccountService {
     }
 
     @Override
-    public OvertimeAccount updateOvertimeAccount(OvertimeAccount overtimeAccount) {
+    public OvertimeAccount updateOvertimeAccount(UserLocalId userLocalId, boolean isOvertimeAllowed, @Nullable Duration maxAllowedOvertime) {
 
-        final OvertimeAccountEntity entity = repository.findById(overtimeAccount.getUserLocalId().value()).orElseGet(OvertimeAccountEntity::new);
+        final OvertimeAccountEntity entity = repository.findById(userLocalId.value()).orElseGet(OvertimeAccountEntity::new);
 
-        entity.setUserId(overtimeAccount.getUserLocalId().value());
-        entity.setAllowed(overtimeAccount.isAllowed());
-        entity.setMaxAllowedOvertime(overtimeAccount.getMaxAllowedOvertime().map(Duration::toString).orElse(null));
+        entity.setUserId(userLocalId.value());
+        entity.setAllowed(isOvertimeAllowed);
+        entity.setMaxAllowedOvertime(Optional.ofNullable(maxAllowedOvertime).map(Duration::toString).orElse(null));
 
         return toOvertimeAccount(repository.save(entity));
     }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/User.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/User.java
@@ -3,10 +3,19 @@ package de.focusshift.zeiterfassung.usermanagement;
 import de.focusshift.zeiterfassung.security.SecurityRole;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 
 import java.util.Set;
 
-public record User(UserId id, UserLocalId localId, String givenName, String familyName, EMailAddress email, Set<SecurityRole> authorities) {
+public record User(UserIdComposite idComposite, String givenName, String familyName, EMailAddress email, Set<SecurityRole> authorities) {
+
+    public UserId id() {
+        return idComposite.id();
+    }
+
+    public UserLocalId localId() {
+        return idComposite.localId();
+    }
 
     public String fullName() {
         return givenName + " " + familyName;

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/User.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/User.java
@@ -2,20 +2,18 @@ package de.focusshift.zeiterfassung.usermanagement;
 
 import de.focusshift.zeiterfassung.security.SecurityRole;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
-import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.HasUserIdComposite;
 import de.focusshift.zeiterfassung.user.UserIdComposite;
 
 import java.util.Set;
 
-public record User(UserIdComposite idComposite, String givenName, String familyName, EMailAddress email, Set<SecurityRole> authorities) {
-
-    public UserId id() {
-        return idComposite.id();
-    }
-
-    public UserLocalId localId() {
-        return idComposite.localId();
-    }
+public record User(
+    UserIdComposite userIdComposite,
+    String givenName,
+    String familyName,
+    EMailAddress email,
+    Set<SecurityRole> authorities
+) implements HasUserIdComposite {
 
     public String fullName() {
         return givenName + " " + familyName;

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/UserLocalId.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/UserLocalId.java
@@ -1,7 +1,7 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
 /**
- * Value identifying a user of the zeiterfassung application.
+ * Value identifying a user of the zeiterfassung application. This value is only unique for one exact tenant.
  */
 public record UserLocalId(Long value) {
 }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/UserManagementController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/UserManagementController.java
@@ -78,7 +78,7 @@ class UserManagementController implements HasTimeClock, HasLaunchpad {
     }
 
     static UserDto userToDto(User user) {
-        return new UserDto(user.localId().value(), user.givenName(), user.familyName(), user.givenName() + " " + user.familyName(), user.email().value());
+        return new UserDto(user.userLocalId().value(), user.givenName(), user.familyName(), user.givenName() + " " + user.familyName(), user.email().value());
     }
 
     static boolean hasAuthority(SecurityRole securityRole, OidcUser principal) {

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/UserManagementService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/UserManagementService.java
@@ -4,7 +4,6 @@ import de.focusshift.zeiterfassung.user.UserId;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public interface UserManagementService {
@@ -19,7 +18,5 @@ public interface UserManagementService {
 
     List<User> findAllUsersByIds(Collection<UserId> ids);
 
-    Map<UserId, UserLocalId> findAllUserLocalIdsGroupedByUserId();
-
-    List<User> findAllUsersByLocalIds(List<UserLocalId> localIds);
+    List<User> findAllUsersByLocalIds(Collection<UserLocalId> localIds);
 }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/UserManagementServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/UserManagementServiceImpl.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.usermanagement;
 import de.focusshift.zeiterfassung.tenancy.user.TenantUser;
 import de.focusshift.zeiterfassung.tenancy.user.TenantUserService;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -69,6 +70,11 @@ class UserManagementServiceImpl implements UserManagementService {
     }
 
     private static User tenantUserToUser(TenantUser tenantUser) {
-        return new User(new UserId(tenantUser.id()), new UserLocalId(tenantUser.localId()), tenantUser.givenName(), tenantUser.familyName(), tenantUser.eMail(), tenantUser.authorities());
+
+        final UserId userId = new UserId(tenantUser.id());
+        final UserLocalId userLocalId = new UserLocalId(tenantUser.localId());
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
+        return new User(userIdComposite, tenantUser.givenName(), tenantUser.familyName(), tenantUser.eMail(), tenantUser.authorities());
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/UserManagementServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/UserManagementServiceImpl.java
@@ -8,10 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-
-import static java.util.stream.Collectors.toMap;
 
 @Service
 class UserManagementServiceImpl implements UserManagementService {
@@ -48,14 +45,7 @@ class UserManagementServiceImpl implements UserManagementService {
     }
 
     @Override
-    public Map<UserId, UserLocalId> findAllUserLocalIdsGroupedByUserId() {
-        return mapToUser(tenantUserService.findAllUsers())
-            .stream()
-            .collect(toMap(User::id, User::localId));
-    }
-
-    @Override
-    public List<User> findAllUsersByLocalIds(List<UserLocalId> localIds) {
+    public List<User> findAllUsersByLocalIds(Collection<UserLocalId> localIds) {
         return mapToUser(tenantUserService.findAllUsersByLocalId(localIds));
     }
 

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImpl.java
@@ -74,20 +74,20 @@ class WorkTimeServiceImpl implements WorkingTimeService {
     }
 
     @Override
-    public WorkingTime updateWorkingTime(WorkingTime workingTime) {
+    public WorkingTime updateWorkingTime(UserLocalId userLocalId, WorkWeekUpdate workWeekUpdate) {
 
-        final WorkingTimeEntity entity = repository.findByUserId(workingTime.getUserId().value()).orElseGet(WorkingTimeEntity::new);
+        final WorkingTimeEntity entity = repository.findByUserId(userLocalId.value()).orElseGet(WorkingTimeEntity::new);
 
-        entity.setMonday(toDurationString(workingTime.getMonday()));
-        entity.setTuesday(toDurationString(workingTime.getTuesday()));
-        entity.setWednesday(toDurationString(workingTime.getWednesday()));
-        entity.setThursday(toDurationString(workingTime.getThursday()));
-        entity.setFriday(toDurationString(workingTime.getFriday()));
-        entity.setSaturday(toDurationString(workingTime.getSaturday()));
-        entity.setSunday(toDurationString(workingTime.getSunday()));
+        entity.setMonday(toDurationString(workWeekUpdate.monday()));
+        entity.setTuesday(toDurationString(workWeekUpdate.tuesday()));
+        entity.setWednesday(toDurationString(workWeekUpdate.wednesday()));
+        entity.setThursday(toDurationString(workWeekUpdate.thursday()));
+        entity.setFriday(toDurationString(workWeekUpdate.friday()));
+        entity.setSaturday(toDurationString(workWeekUpdate.saturday()));
+        entity.setSunday(toDurationString(workWeekUpdate.sunday()));
 
         if (entity.getId() == null) {
-            entity.setUserId(workingTime.getUserId().value());
+            entity.setUserId(userLocalId.value());
         }
 
         return entityToWorkingTime(repository.save(entity));

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImpl.java
@@ -40,8 +40,8 @@ class WorkTimeServiceImpl implements WorkingTimeService {
         final User user = findUser(userLocalId);
 
         return repository.findByUserId(userLocalId.value())
-            .map(workingTimeEntity -> entityToWorkingTime(workingTimeEntity, user.idComposite()))
-            .orElseGet(() -> defaultWorkingTime(user.idComposite()));
+            .map(workingTimeEntity -> entityToWorkingTime(workingTimeEntity, user.userIdComposite()))
+            .orElseGet(() -> defaultWorkingTime(user.userIdComposite()));
     }
 
     @Override
@@ -85,7 +85,7 @@ class WorkTimeServiceImpl implements WorkingTimeService {
             entity.setUserId(userLocalId.value());
         }
 
-        return entityToWorkingTime(repository.save(entity), user.idComposite());
+        return entityToWorkingTime(repository.save(entity), user.userIdComposite());
     }
 
     private Map<UserIdComposite, WorkingTime> getWorkingTime(Collection<User> users) {
@@ -93,17 +93,17 @@ class WorkTimeServiceImpl implements WorkingTimeService {
         final List<Long> localIdValues = new ArrayList<>();
         final Map<Long, UserIdComposite> userIdCompositeByLocalIdValue = new HashMap<>();
         for (User user : users) {
-            localIdValues.add(user.localId().value());
-            userIdCompositeByLocalIdValue.put(user.localId().value(), user.idComposite());
+            localIdValues.add(user.userLocalId().value());
+            userIdCompositeByLocalIdValue.put(user.userLocalId().value(), user.userIdComposite());
         }
 
         final Map<UserIdComposite, WorkingTime> result = repository.findAllByUserIdIsIn(localIdValues)
             .stream()
             .map(workingTimeEntity -> entityToWorkingTime(workingTimeEntity, userIdCompositeByLocalIdValue.get(workingTimeEntity.getUserId())))
-            .collect(toMap(WorkingTime::getUserIdComposite, identity()));
+            .collect(toMap(WorkingTime::userIdComposite, identity()));
 
         for (User user : users) {
-            result.computeIfAbsent(user.idComposite(), this::defaultWorkingTime);
+            result.computeIfAbsent(user.userIdComposite(), this::defaultWorkingTime);
         }
 
         return result;

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkWeekUpdate.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkWeekUpdate.java
@@ -1,0 +1,144 @@
+package de.focusshift.zeiterfassung.usermanagement;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.Optional;
+
+import static java.math.BigDecimal.ONE;
+import static java.math.RoundingMode.DOWN;
+import static java.math.RoundingMode.HALF_EVEN;
+import static java.time.DayOfWeek.FRIDAY;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.DayOfWeek.THURSDAY;
+import static java.time.DayOfWeek.TUESDAY;
+import static java.time.DayOfWeek.WEDNESDAY;
+
+public record WorkWeekUpdate(
+    Optional<WorkDay> monday,
+    Optional<WorkDay> tuesday,
+    Optional<WorkDay> wednesday,
+    Optional<WorkDay> thursday,
+    Optional<WorkDay> friday,
+    Optional<WorkDay> saturday,
+    Optional<WorkDay> sunday
+) {
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final EnumMap<DayOfWeek, Duration> workDays = new EnumMap<>(DayOfWeek.class);
+
+        public Builder monday(Duration duration) {
+            this.workDays.put(MONDAY, duration);
+            return this;
+        }
+
+        public Builder monday(double hours) {
+            return this.monday(BigDecimal.valueOf(hours));
+        }
+
+        public Builder monday(BigDecimal hours) {
+            return this.monday(hoursToDuration(hours));
+        }
+
+        public Builder tuesday(Duration duration) {
+            this.workDays.put(TUESDAY, duration);
+            return this;
+        }
+
+        public Builder tuesday(double hours) {
+            return this.tuesday(BigDecimal.valueOf(hours));
+        }
+
+        public Builder tuesday(BigDecimal hours) {
+            return this.tuesday(hoursToDuration(hours));
+        }
+
+        public Builder wednesday(Duration duration) {
+            this.workDays.put(WEDNESDAY, duration);
+            return this;
+        }
+
+        public Builder wednesday(double hours) {
+            return this.wednesday(BigDecimal.valueOf(hours));
+        }
+
+        public Builder wednesday(BigDecimal hours) {
+            return this.wednesday(hoursToDuration(hours));
+        }
+
+        public Builder thursday(Duration duration) {
+            this.workDays.put(THURSDAY, duration);
+            return this;
+        }
+
+        public Builder thursday(double hours) {
+            return this.thursday(BigDecimal.valueOf(hours));
+        }
+
+        public Builder thursday(BigDecimal hours) {
+            return this.thursday(hoursToDuration(hours));
+        }
+
+        public Builder friday(Duration duration) {
+            this.workDays.put(FRIDAY, duration);
+            return this;
+        }
+
+        public Builder friday(double hours) {
+            return this.friday(BigDecimal.valueOf(hours));
+        }
+
+        public Builder friday(BigDecimal hours) {
+            return this.friday(hoursToDuration(hours));
+        }
+
+        public Builder saturday(Duration duration) {
+            this.workDays.put(SATURDAY, duration);
+            return this;
+        }
+
+        public Builder saturday(double hours) {
+            return this.saturday(BigDecimal.valueOf(hours));
+        }
+
+        public Builder saturday(BigDecimal hours) {
+            return this.saturday(hoursToDuration(hours));
+        }
+
+        public Builder sunday(Duration duration) {
+            this.workDays.put(SUNDAY, duration);
+            return this;
+        }
+
+        public Builder sunday(double hours) {
+            return this.sunday(BigDecimal.valueOf(hours));
+        }
+
+        public Builder sunday(BigDecimal hours) {
+            return this.sunday(hoursToDuration(hours));
+        }
+
+        public WorkWeekUpdate build() {
+            return new WorkWeekUpdate(getWorkDay(MONDAY), getWorkDay(TUESDAY), getWorkDay(WEDNESDAY),
+                getWorkDay(THURSDAY), getWorkDay(FRIDAY), getWorkDay(SATURDAY), getWorkDay(SUNDAY));
+        }
+
+        private Optional<WorkDay> getWorkDay(DayOfWeek dayOfWeek) {
+            final Duration hours = workDays.get(dayOfWeek);
+            return hours == null ? Optional.empty() : Optional.of(new WorkDay(dayOfWeek, hours));
+        }
+
+        private static Duration hoursToDuration(BigDecimal hours) {
+            final int hoursPart = hours.setScale(0, DOWN).abs().intValue();
+            final int minutesPart = hours.remainder(ONE).multiply(BigDecimal.valueOf(60)).setScale(0, HALF_EVEN).abs().intValueExact();
+            return Duration.ofHours(hoursPart).plusMinutes(minutesPart);
+        }
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTime.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTime.java
@@ -1,6 +1,6 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
-import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.HasUserIdComposite;
 import de.focusshift.zeiterfassung.user.UserIdComposite;
 
 import java.math.BigDecimal;
@@ -31,7 +31,7 @@ import static java.util.stream.Collectors.toSet;
 /**
  * Contractual working time. This representation has no context of absences like public holidays.
  */
-public final class WorkingTime {
+public final class WorkingTime implements HasUserIdComposite {
 
     private final UserIdComposite userIdComposite;
     private final WorkDay monday;
@@ -55,16 +55,9 @@ public final class WorkingTime {
         this.sunday = sunday;
     }
 
-    public UserIdComposite getUserIdComposite() {
+    @Override
+    public UserIdComposite userIdComposite() {
         return userIdComposite;
-    }
-
-    public UserLocalId getUserLocalId() {
-        return userIdComposite.localId();
-    }
-
-    public UserId getUserId() {
-        return userIdComposite.id();
     }
 
     /**

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTime.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTime.java
@@ -1,5 +1,8 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
+import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
+
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.Duration;
@@ -30,7 +33,7 @@ import static java.util.stream.Collectors.toSet;
  */
 public final class WorkingTime {
 
-    private final UserLocalId userId;
+    private final UserIdComposite userIdComposite;
     private final WorkDay monday;
     private final WorkDay tuesday;
     private final WorkDay wednesday;
@@ -39,10 +42,10 @@ public final class WorkingTime {
     private final WorkDay saturday;
     private final WorkDay sunday;
 
-    private WorkingTime(UserLocalId userId, WorkDay monday, WorkDay tuesday, WorkDay wednesday, WorkDay thursday,
+    private WorkingTime(UserIdComposite userIdComposite, WorkDay monday, WorkDay tuesday, WorkDay wednesday, WorkDay thursday,
                         WorkDay friday, WorkDay saturday, WorkDay sunday) {
 
-        this.userId = userId;
+        this.userIdComposite = userIdComposite;
         this.monday = monday;
         this.tuesday = tuesday;
         this.wednesday = wednesday;
@@ -52,8 +55,16 @@ public final class WorkingTime {
         this.sunday = sunday;
     }
 
-    public UserLocalId getUserId() {
-        return userId;
+    public UserIdComposite getUserIdComposite() {
+        return userIdComposite;
+    }
+
+    public UserLocalId getUserLocalId() {
+        return userIdComposite.localId();
+    }
+
+    public UserId getUserId() {
+        return userIdComposite.id();
     }
 
     /**
@@ -175,18 +186,18 @@ public final class WorkingTime {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         WorkingTime that = (WorkingTime) o;
-        return Objects.equals(userId, that.userId);
+        return Objects.equals(userIdComposite, that.userIdComposite);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(userIdComposite);
     }
 
     @Override
     public String toString() {
         return "WorkingTime{" +
-            "userId=" + userId +
+            "userIdComposite=" + userIdComposite +
             ", monday=" + monday +
             ", tuesday=" + tuesday +
             ", wednesday=" + wednesday +
@@ -202,11 +213,11 @@ public final class WorkingTime {
     }
 
     public static class Builder {
-        private UserLocalId userId;
+        private UserIdComposite userIdComposite;
         private final EnumMap<DayOfWeek, Duration> workDays = new EnumMap<>(DayOfWeek.class);
 
-        public Builder userId(UserLocalId userId) {
-            this.userId = userId;
+        public Builder userIdComposite(UserIdComposite userIdComposite) {
+            this.userIdComposite = userIdComposite;
             return this;
         }
 
@@ -302,7 +313,7 @@ public final class WorkingTime {
         }
 
         public WorkingTime build() {
-            return new WorkingTime(userId, getWorkDay(MONDAY), getWorkDay(TUESDAY), getWorkDay(WEDNESDAY),
+            return new WorkingTime(userIdComposite, getWorkDay(MONDAY), getWorkDay(TUESDAY), getWorkDay(WEDNESDAY),
                 getWorkDay(THURSDAY), getWorkDay(FRIDAY), getWorkDay(SATURDAY), getWorkDay(SUNDAY));
         }
 

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeCalendarService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeCalendarService.java
@@ -1,12 +1,14 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
+import de.focusshift.zeiterfassung.user.UserIdComposite;
+
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Map;
 
 public interface WorkingTimeCalendarService {
 
-    Map<UserLocalId, WorkingTimeCalendar> getWorkingTimes(LocalDate from, LocalDate toExclusive);
+    Map<UserIdComposite, WorkingTimeCalendar> getWorkingTimes(LocalDate from, LocalDate toExclusive);
 
-    Map<UserLocalId, WorkingTimeCalendar> getWorkingTimes(LocalDate from, LocalDate toExclusive, Collection<UserLocalId> userLocalIds);
+    Map<UserIdComposite, WorkingTimeCalendar> getWorkingTimes(LocalDate from, LocalDate toExclusive, Collection<UserLocalId> userLocalIds);
 }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeCalendarServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeCalendarServiceImpl.java
@@ -1,6 +1,7 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
 import de.focusshift.zeiterfassung.timeentry.PlannedWorkingHours;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -19,20 +20,20 @@ class WorkingTimeCalendarServiceImpl implements WorkingTimeCalendarService {
     }
 
     @Override
-    public Map<UserLocalId, WorkingTimeCalendar> getWorkingTimes(LocalDate from, LocalDate toExclusive) {
+    public Map<UserIdComposite, WorkingTimeCalendar> getWorkingTimes(LocalDate from, LocalDate toExclusive) {
         return entitiesToWorkingTime(from, toExclusive, workingTimeService.getAllWorkingTimeByUsers());
     }
 
     @Override
-    public Map<UserLocalId, WorkingTimeCalendar> getWorkingTimes(LocalDate from, LocalDate toExclusive, Collection<UserLocalId> userLocalIds) {
+    public Map<UserIdComposite, WorkingTimeCalendar> getWorkingTimes(LocalDate from, LocalDate toExclusive, Collection<UserLocalId> userLocalIds) {
         return entitiesToWorkingTime(from, toExclusive, workingTimeService.getWorkingTimeByUsers(userLocalIds));
     }
 
-    private Map<UserLocalId, WorkingTimeCalendar> entitiesToWorkingTime(LocalDate from, LocalDate toExclusive, Map<UserLocalId, WorkingTime> workingTimes) {
+    private Map<UserIdComposite, WorkingTimeCalendar> entitiesToWorkingTime(LocalDate from, LocalDate toExclusive, Map<UserIdComposite, WorkingTime> workingTimes) {
 
-        final HashMap<UserLocalId, WorkingTimeCalendar> result = new HashMap<>();
+        final HashMap<UserIdComposite, WorkingTimeCalendar> result = new HashMap<>();
 
-        for (Map.Entry<UserLocalId, WorkingTime> entry : workingTimes.entrySet()) {
+        for (Map.Entry<UserIdComposite, WorkingTime> entry : workingTimes.entrySet()) {
             final WorkingTimeCalendar workingTimeCalendar = toWorkingTimeCalendar(from, toExclusive, entry.getValue());
             result.put(entry.getKey(), workingTimeCalendar);
         }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeController.java
@@ -141,9 +141,8 @@ class WorkingTimeController implements HasTimeClock, HasLaunchpad {
             }
         }
 
-        final WorkingTime workingTime = dtoToWorkingTime(workingTimeDto);
-
-        workingTimeService.updateWorkingTime(workingTime);
+        final WorkWeekUpdate workWeekUpdate = dtoToWorkWeekUpdate(workingTimeDto);
+        workingTimeService.updateWorkingTime(new UserLocalId(userId), workWeekUpdate);
 
         return "redirect:/users/%s/working-time".formatted(userId);
     }
@@ -196,9 +195,9 @@ class WorkingTimeController implements HasTimeClock, HasLaunchpad {
             .build();
     }
 
-    private WorkingTime dtoToWorkingTime(WorkingTimeDto workingTimeDto) {
+    private WorkWeekUpdate dtoToWorkWeekUpdate(WorkingTimeDto workingTimeDto) {
 
-        final WorkingTime.Builder builder = WorkingTime.builder();
+        final WorkWeekUpdate.Builder builder = WorkWeekUpdate.builder();
 
         final Map<String, Supplier<Double>> values = Map.of(
             "monday", workingTimeDto::getWorkingTimeMonday,
@@ -231,8 +230,6 @@ class WorkingTimeController implements HasTimeClock, HasLaunchpad {
             setter.get(day).accept(hours);
         }
 
-        return builder
-            .userId(new UserLocalId(workingTimeDto.getUserId()))
-            .build();
+        return builder.build();
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeController.java
@@ -190,7 +190,7 @@ class WorkingTimeController implements HasTimeClock, HasLaunchpad {
         }
 
         return builder
-            .userId(workingTime.getUserIdComposite().localId().value())
+            .userId(workingTime.userIdComposite().localId().value())
             .workday(workingTime.getWorkingDays().stream().map(WorkDay::dayOfWeek).toList())
             .build();
     }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeController.java
@@ -190,7 +190,7 @@ class WorkingTimeController implements HasTimeClock, HasLaunchpad {
         }
 
         return builder
-            .userId(workingTime.getUserId().value())
+            .userId(workingTime.getUserIdComposite().localId().value())
             .workday(workingTime.getWorkingDays().stream().map(WorkDay::dayOfWeek).toList())
             .build();
     }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeService.java
@@ -35,8 +35,9 @@ public interface WorkingTimeService {
     /**
      * Update the {@linkplain WorkingTime}
      *
-     * @param workingTime {@linkplain WorkingTime} to update
+     * @param userLocalId account of this user should be updated
+     * @param workWeekUpdate new working time values
      * @return the updated {@linkplain WorkingTime}
      */
-    WorkingTime updateWorkingTime(WorkingTime workingTime);
+    WorkingTime updateWorkingTime(UserLocalId userLocalId, WorkWeekUpdate workWeekUpdate);
 }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeService.java
@@ -1,6 +1,7 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
 import de.focusshift.zeiterfassung.timeentry.PlannedWorkingHours;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 
 import java.time.LocalDate;
 import java.time.Year;
@@ -18,9 +19,9 @@ public interface WorkingTimeService {
      */
     WorkingTime getWorkingTimeByUser(UserLocalId userLocalId);
 
-    Map<UserLocalId, WorkingTime> getWorkingTimeByUsers(Collection<UserLocalId> userLocalIds);
+    Map<UserIdComposite, WorkingTime> getWorkingTimeByUsers(Collection<UserLocalId> userLocalIds);
 
-    Map<UserLocalId, WorkingTime> getAllWorkingTimeByUsers();
+    Map<UserIdComposite, WorkingTime> getAllWorkingTimeByUsers();
 
     /**
      * Get {@linkplain PlannedWorkingHours}. Note that public holidays and other absences are not considered.

--- a/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceServiceImplTest.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.absence;
 import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
 import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.user.UserSettingsProvider;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
@@ -129,9 +130,10 @@ class AbsenceServiceImplTest {
 
         final UserId userId = new UserId(UUID.randomUUID().toString());
         final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
 
         when(userManagementService.findAllUsersByLocalIds(List.of(userLocalId))).thenReturn(List.of(
-            new User(userId, userLocalId, null, null, null, Set.of()))
+            new User(userIdComposite, null, null, null, Set.of()))
         );
 
         final List<String> userIdsValues = List.of(userId.value());
@@ -157,12 +159,14 @@ class AbsenceServiceImplTest {
 
         final UserId userId_1 = new UserId(UUID.randomUUID().toString());
         final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
         final UserId userId_2 = new UserId(UUID.randomUUID().toString());
         final UserLocalId userLocalId_2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
 
         when(userManagementService.findAllUsersByLocalIds(List.of(userLocalId_1, userLocalId_2))).thenReturn(List.of(
-            new User(userId_1, userLocalId_1, "Bruce", null, null, Set.of()),
-            new User(userId_2, userLocalId_2, "Alfred", null, null, Set.of())
+            new User(userIdComposite_1, "Bruce", null, null, Set.of()),
+            new User(userIdComposite_2, "Alfred", null, null, Set.of())
         ));
 
         final Instant absence_1_start = Instant.from(from.plusDays(1).atStartOfDay().atZone(berlin));

--- a/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceServiceImplTest.java
@@ -2,6 +2,7 @@ package de.focusshift.zeiterfassung.absence;
 
 import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
 import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
+import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.UserId;
 import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.user.UserSettingsProvider;
@@ -141,8 +142,8 @@ class AbsenceServiceImplTest {
         when(repository.findAllByTenantIdAndUserIdInAndStartDateLessThanAndEndDateGreaterThanEqual("tenant", userIdsValues, toExclusiveStartOfDay, fromStartOfDay))
             .thenReturn(List.of());
 
-        final Map<UserLocalId, List<Absence>> actual = sut.getAbsencesByUserIds(List.of(userLocalId), from, toExclusive);
-        assertThat(actual).containsEntry(userLocalId, List.of());
+        final Map<UserIdComposite, List<Absence>> actual = sut.getAbsencesByUserIds(List.of(userLocalId), from, toExclusive);
+        assertThat(actual).containsEntry(userIdComposite, List.of());
     }
 
     @Test
@@ -202,13 +203,13 @@ class AbsenceServiceImplTest {
         when(repository.findAllByTenantIdAndUserIdInAndStartDateLessThanAndEndDateGreaterThanEqual("tenant", List.of(userId_1.value(), userId_2.value()), toExclusiveStartOfDay, fromStartOfDay))
             .thenReturn(List.of(absenceEntity_1, absenceEntity_2_1, absenceEntity_2_2));
 
-        final Map<UserLocalId, List<Absence>> actual = sut.getAbsencesByUserIds(List.of(userLocalId_1, userLocalId_2), from, toExclusive);
+        final Map<UserIdComposite, List<Absence>> actual = sut.getAbsencesByUserIds(List.of(userLocalId_1, userLocalId_2), from, toExclusive);
 
         assertThat(actual).containsExactlyInAnyOrderEntriesOf(Map.of(
-            userLocalId_1, List.of(
+            userIdComposite_1, List.of(
                 new Absence(userId_1, absence_1_start.atZone(berlin), absence_1_end.atZone(berlin), FULL, new AbsenceType(OTHER, 1000L), YELLOW)
             ),
-            userLocalId_2, List.of(
+            userIdComposite_2, List.of(
                 new Absence(userId_2, absence_2_1_start.atZone(berlin), absence_2_1_end.atZone(berlin), MORNING, new AbsenceType(OTHER, 2000L), VIOLET),
                 new Absence(userId_2, absence_2_2_start.atZone(berlin), absence_2_2_end.atZone(berlin), NOON, new AbsenceType(OTHER, 3000L), CYAN)
             )
@@ -229,15 +230,15 @@ class AbsenceServiceImplTest {
 
         final UserId userId = new UserId(UUID.randomUUID().toString());
         final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "", "", new EMailAddress(""), Set.of());
+        when(userManagementService.findAllUsers()).thenReturn(List.of(user));
 
         when(repository.findAllByTenantIdAndStartDateLessThanAndEndDateGreaterThanEqual("tenant", toExclusiveStartOfDay, fromStartOfDay))
             .thenReturn(List.of());
 
-        when(userManagementService.findAllUserLocalIdsGroupedByUserId())
-            .thenReturn(Map.of(userId, userLocalId));
-
-        final Map<UserLocalId, List<Absence>> actual = sut.getAbsencesForAllUsers(from, toExclusive);
-        assertThat(actual).containsExactlyInAnyOrderEntriesOf(Map.of(userLocalId, List.of()));
+        final Map<UserIdComposite, List<Absence>> actual = sut.getAbsencesForAllUsers(from, toExclusive);
+        assertThat(actual).containsExactlyInAnyOrderEntriesOf(Map.of(userIdComposite, List.of()));
     }
 
     @Test
@@ -254,8 +255,15 @@ class AbsenceServiceImplTest {
 
         final UserId userId_1 = new UserId(UUID.randomUUID().toString());
         final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "", "", new EMailAddress(""), Set.of());
+
         final UserId userId_2 = new UserId(UUID.randomUUID().toString());
         final UserLocalId userLocalId_2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+        final User user_2 = new User(userIdComposite_2, "", "", new EMailAddress(""), Set.of());
+
+        when(userManagementService.findAllUsers()).thenReturn(List.of(user_1, user_2));
 
         final Instant absence_1_start = Instant.from(from.plusDays(1).atStartOfDay().atZone(berlin));
         final Instant absence_1_end = Instant.from(from.plusDays(1).atStartOfDay().atZone(berlin));
@@ -290,18 +298,12 @@ class AbsenceServiceImplTest {
         when(repository.findAllByTenantIdAndStartDateLessThanAndEndDateGreaterThanEqual("tenant", toExclusiveStartOfDay, fromStartOfDay))
             .thenReturn(List.of(absenceEntity_1, absenceEntity_2_1, absenceEntity_2_2));
 
-        when(userManagementService.findAllUserLocalIdsGroupedByUserId())
-            .thenReturn(Map.of(
-                userId_1, userLocalId_1,
-                userId_2, userLocalId_2
-            ));
-
-        final Map<UserLocalId, List<Absence>> actual = sut.getAbsencesForAllUsers(from, toExclusive);
+        final Map<UserIdComposite, List<Absence>> actual = sut.getAbsencesForAllUsers(from, toExclusive);
         assertThat(actual).containsExactlyInAnyOrderEntriesOf(Map.of(
-            userLocalId_1, List.of(
+            userIdComposite_1, List.of(
                 new Absence(userId_1, absence_1_start.atZone(berlin), absence_1_end.atZone(berlin), FULL, new AbsenceType(OTHER, 1000L), YELLOW)
             ),
-            userLocalId_2, List.of(
+            userIdComposite_2, List.of(
                 new Absence(userId_2, absence_2_1_start.atZone(berlin), absence_2_1_end.atZone(berlin), MORNING, new AbsenceType(OTHER, 2000L), VIOLET),
                 new Absence(userId_2, absence_2_2_start.atZone(berlin), absence_2_2_end.atZone(berlin), NOON, new AbsenceType(OTHER, 3000L), CYAN)
             )

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceIT.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.report;
 import de.focusshift.zeiterfassung.TestContainersBase;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
@@ -37,7 +38,9 @@ class ReportCsvServiceIT extends TestContainersBase {
         final PrintWriter printWriter = mock(PrintWriter.class);
 
         final UserId userId = new UserId("user");
-        final User user = new User(userId, new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
         when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
 

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
@@ -92,7 +92,7 @@ class ReportCsvServiceTest {
         final ZonedDateTime from = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
         final ZonedDateTime to = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 30), ZONE_ID_BERLIN);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, false);
-        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(reportDayEntry)), Map.of());
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
 
         when(reportService.getReportWeek(Year.of(2021), 1, batmanId))
             .thenReturn(new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDay)));
@@ -125,13 +125,13 @@ class ReportCsvServiceTest {
         final ZonedDateTime d1_2_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d1_2_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d1_2_ReportDayEntry = new ReportDayEntry(batman, "hard work", d1_2_From, d1_2_To, false);
-        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
+        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
 
         // day two
         final ZonedDateTime d2_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d2_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d2_1_ReportDayEntry = new ReportDayEntry(batman, "hard work", d2_1_From, d2_1_To, false);
-        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(d2_1_ReportDayEntry)), Map.of());
+        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(d2_1_ReportDayEntry)), Map.of());
 
 
         when(reportService.getReportWeek(Year.of(2021), 1, batmanId))
@@ -183,7 +183,7 @@ class ReportCsvServiceTest {
         final ZonedDateTime from = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
         final ZonedDateTime to = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 30), ZONE_ID_BERLIN);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, false);
-        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(reportDayEntry)), Map.of());
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
 
         final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDay));
         final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of());
@@ -222,13 +222,13 @@ class ReportCsvServiceTest {
         final ZonedDateTime d1_2_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d1_2_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d1_2_ReportDayEntry = new ReportDayEntry(batman, "hard work", d1_2_From, d1_2_To, false);
-        final ReportDay w1_reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
+        final ReportDay w1_reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
 
         // week two, day one
         final ZonedDateTime d2_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d2_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d2_1_ReportDayEntry = new ReportDayEntry(batman, "hard work", d2_1_From, d2_1_To, false);
-        final ReportDay w2_reportDay = new ReportDay(LocalDate.of(2021, 1, 5), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(d2_1_ReportDayEntry)), Map.of());
+        final ReportDay w2_reportDay = new ReportDay(LocalDate.of(2021, 1, 5), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(d2_1_ReportDayEntry)), Map.of());
 
         final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(w1_reportDay));
         final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of(w2_reportDay));

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
@@ -4,6 +4,7 @@ import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.timeentry.PlannedWorkingHours;
 import de.focusshift.zeiterfassung.user.DateFormatter;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,20 +84,23 @@ class ReportCsvServiceTest {
 
         mockDateFormatter("dd.MM.yyyy");
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
         final ZonedDateTime from = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
         final ZonedDateTime to = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 30), ZONE_ID_BERLIN);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, false);
-        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batman.localId(), PlannedWorkingHours.EIGHT), Map.of(batman.localId(), List.of(reportDayEntry)), Map.of());
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(reportDayEntry)), Map.of());
 
-        when(reportService.getReportWeek(Year.of(2021), 1, new UserId("batman")))
+        when(reportService.getReportWeek(Year.of(2021), 1, batmanId))
             .thenReturn(new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDay)));
 
         final StringWriter stringWriter = new StringWriter();
         final PrintWriter printWriter = new PrintWriter(stringWriter);
 
-        sut.writeWeekReportCsv(Year.of(2021), 1, Locale.GERMAN, new UserId("batman"), printWriter);
+        sut.writeWeekReportCsv(Year.of(2021), 1, Locale.GERMAN, batmanId, printWriter);
 
         assertThat(stringWriter).hasToString("""
             report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.workedHours;report.csv.header.comment;report.csv.header.break
@@ -109,7 +113,10 @@ class ReportCsvServiceTest {
 
         mockDateFormatter("dd.MM.yyyy");
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
         // day one
         final ZonedDateTime d1_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
@@ -118,22 +125,22 @@ class ReportCsvServiceTest {
         final ZonedDateTime d1_2_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d1_2_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d1_2_ReportDayEntry = new ReportDayEntry(batman, "hard work", d1_2_From, d1_2_To, false);
-        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batman.localId(), PlannedWorkingHours.EIGHT), Map.of(batman.localId(), List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
+        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
 
         // day two
         final ZonedDateTime d2_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d2_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d2_1_ReportDayEntry = new ReportDayEntry(batman, "hard work", d2_1_From, d2_1_To, false);
-        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), Map.of(batman.localId(), PlannedWorkingHours.EIGHT), Map.of(batman.localId(), List.of(d2_1_ReportDayEntry)), Map.of());
+        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(d2_1_ReportDayEntry)), Map.of());
 
 
-        when(reportService.getReportWeek(Year.of(2021), 1, new UserId("batman")))
+        when(reportService.getReportWeek(Year.of(2021), 1, batmanId))
             .thenReturn(new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDayOne, reportDayTwo)));
 
         final StringWriter stringWriter = new StringWriter();
         final PrintWriter printWriter = new PrintWriter(stringWriter);
 
-        sut.writeWeekReportCsv(Year.of(2021), 1, Locale.GERMAN, new UserId("batman"), printWriter);
+        sut.writeWeekReportCsv(Year.of(2021), 1, Locale.GERMAN, batmanId, printWriter);
 
         assertThat(stringWriter).hasToString("""
             report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.workedHours;report.csv.header.comment;report.csv.header.break
@@ -168,12 +175,15 @@ class ReportCsvServiceTest {
 
         mockDateFormatter("dd.MM.yyyy");
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
         final ZonedDateTime from = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
         final ZonedDateTime to = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 30), ZONE_ID_BERLIN);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, false);
-        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batman.localId(), PlannedWorkingHours.EIGHT), Map.of(batman.localId(), List.of(reportDayEntry)), Map.of());
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(reportDayEntry)), Map.of());
 
         final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDay));
         final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of());
@@ -181,13 +191,13 @@ class ReportCsvServiceTest {
         final ReportWeek fourthWeek = new ReportWeek(LocalDate.of(2021, 1, 18), List.of());
         final ReportWeek fifthWeek = new ReportWeek(LocalDate.of(2021, 1, 25), List.of());
 
-        when(reportService.getReportMonth(YearMonth.of(2021, 1), new UserId("batman")))
+        when(reportService.getReportMonth(YearMonth.of(2021, 1), batmanId))
             .thenReturn(new ReportMonth(YearMonth.of(2021, 1), List.of(firstWeek, secondWeek, thirdWeek, fourthWeek, fifthWeek)));
 
         final StringWriter stringWriter = new StringWriter();
         final PrintWriter printWriter = new PrintWriter(stringWriter);
 
-        sut.writeMonthReportCsv(YearMonth.of(2021, 1), Locale.GERMAN, new UserId("batman"), printWriter);
+        sut.writeMonthReportCsv(YearMonth.of(2021, 1), Locale.GERMAN, batmanId, printWriter);
 
         assertThat(stringWriter).hasToString("""
             report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.workedHours;report.csv.header.comment;report.csv.header.break
@@ -200,7 +210,10 @@ class ReportCsvServiceTest {
 
         mockDateFormatter("dd.MM.yyyy");
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
         // week one, day one
         final ZonedDateTime d1_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
@@ -209,13 +222,13 @@ class ReportCsvServiceTest {
         final ZonedDateTime d1_2_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d1_2_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d1_2_ReportDayEntry = new ReportDayEntry(batman, "hard work", d1_2_From, d1_2_To, false);
-        final ReportDay w1_reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batman.localId(), PlannedWorkingHours.EIGHT), Map.of(batman.localId(), List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
+        final ReportDay w1_reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
 
         // week two, day one
         final ZonedDateTime d2_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d2_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d2_1_ReportDayEntry = new ReportDayEntry(batman, "hard work", d2_1_From, d2_1_To, false);
-        final ReportDay w2_reportDay = new ReportDay(LocalDate.of(2021, 1, 5), Map.of(batman.localId(), PlannedWorkingHours.EIGHT), Map.of(batman.localId(), List.of(d2_1_ReportDayEntry)), Map.of());
+        final ReportDay w2_reportDay = new ReportDay(LocalDate.of(2021, 1, 5), Map.of(batmanLocalId, PlannedWorkingHours.EIGHT), Map.of(batmanLocalId, List.of(d2_1_ReportDayEntry)), Map.of());
 
         final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(w1_reportDay));
         final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of(w2_reportDay));
@@ -223,13 +236,13 @@ class ReportCsvServiceTest {
         final ReportWeek fourthWeek = new ReportWeek(LocalDate.of(2021, 1, 18), List.of());
         final ReportWeek fifthWeek = new ReportWeek(LocalDate.of(2021, 1, 25), List.of());
 
-        when(reportService.getReportMonth(YearMonth.of(2021, 1), new UserId("batman")))
+        when(reportService.getReportMonth(YearMonth.of(2021, 1), batmanId))
             .thenReturn(new ReportMonth(YearMonth.of(2021, 1), List.of(firstWeek, secondWeek, thirdWeek, fourthWeek, fifthWeek)));
 
         final StringWriter stringWriter = new StringWriter();
         final PrintWriter printWriter = new PrintWriter(stringWriter);
 
-        sut.writeMonthReportCsv(YearMonth.of(2021, 1), Locale.GERMAN, new UserId("batman"), printWriter);
+        sut.writeMonthReportCsv(YearMonth.of(2021, 1), Locale.GERMAN, batmanId, printWriter);
 
         assertThat(stringWriter).hasToString("""
             report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.workedHours;report.csv.header.comment;report.csv.header.break

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportDayEntryTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportDayEntryTest.java
@@ -2,6 +2,7 @@ package de.focusshift.zeiterfassung.report;
 
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.Test;
@@ -21,11 +22,9 @@ class ReportDayEntryTest {
     @Test
     void ensureWorkDurationIsZeroIfBreak() {
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
-
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, true);
+        final ReportDayEntry reportDayEntry = new ReportDayEntry(anyUser(), "hard work", from, to, true);
 
         assertThat(reportDayEntry.workDuration().duration()).isEqualTo(Duration.ZERO);
     }
@@ -33,13 +32,20 @@ class ReportDayEntryTest {
     @Test
     void ensureWorkDurationIsCorrectItNotABreak() {
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
-
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, false);
+        final ReportDayEntry reportDayEntry = new ReportDayEntry(anyUser(), "hard work", from, to, false);
 
         assertThat(reportDayEntry.workDuration().duration()).isEqualTo(Duration.ofHours(1));
+    }
+
+    private static User anyUser() {
+
+        final UserId userId = new UserId("uuid");
+        final UserLocalId userLocalId = new UserLocalId(1337L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
+        return new User(userIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
     }
 
     private static ZonedDateTime dateTime(int year, int month, int dayOfMonth, int hour, int minute) {

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
@@ -35,7 +35,7 @@ class ReportDayTest {
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, true);
 
-        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batman.localId(), PlannedWorkingHours.EIGHT), Map.of(batman.localId(), List.of(reportDayEntry)), Map.of());
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
 
         assertThat(reportDay.workDuration().duration()).isEqualTo(Duration.ZERO);
     }

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.report;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.timeentry.PlannedWorkingHours;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,10 @@ class ReportDayTest {
     @Test
     void ensureToRemoveBreaks() {
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.report;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.DateFormatter;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.BeforeEach;
@@ -153,10 +154,13 @@ class ReportMonthControllerTest {
     @Test
     void ensureMonthReportUserFilterRelatedUrlsAreNotAddedWhenCurrentUserHasNoPermission() throws Exception {
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
         when(reportPermissionService.findAllPermittedUsersForCurrentUser())
-            .thenReturn(List.of(new User(new UserId("batman"), new UserLocalId(1L), "", "", new EMailAddress(""), Set.of())));
+            .thenReturn(List.of(new User(userIdComposite, "", "", new EMailAddress(""), Set.of())));
 
-        when(reportService.getReportMonth(YearMonth.of(2022, 1), new UserId("batman")))
+        when(reportService.getReportMonth(YearMonth.of(2022, 1), userId))
             .thenReturn(anyReportMonth());
 
         perform(get("/report/year/2022/month/1").with(oidcLogin().userInfoToken(userInfo -> userInfo.subject("batman"))))
@@ -166,9 +170,20 @@ class ReportMonthControllerTest {
     @Test
     void ensureMonthReportUserFilterRelatedUrls() throws Exception {
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
-        final User joker = new User(new UserId("joker"), new UserLocalId(2L), "Jack", "Napier", new EMailAddress(""), Set.of());
-        final User robin = new User(new UserId("robin"), new UserLocalId(3L), "Dick", "Grayson", new EMailAddress(""), Set.of());
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        final UserId jokerId = new UserId("joker");
+        final UserLocalId jokerLocalId = new UserLocalId(2L);
+        final UserIdComposite jokerIdComposite = new UserIdComposite(jokerId, jokerLocalId);
+        final User joker = new User(jokerIdComposite, "Jack", "Napier", new EMailAddress(""), Set.of());
+
+        final UserId robinId = new UserId("robin");
+        final UserLocalId robinLocalId = new UserLocalId(3L);
+        final UserIdComposite robinIdComposite = new UserIdComposite(robinId, robinLocalId);
+        final User robin = new User(robinIdComposite, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
         when(reportPermissionService.findAllPermittedUsersForCurrentUser())
             .thenReturn(List.of(batman, joker, robin));
@@ -190,9 +205,20 @@ class ReportMonthControllerTest {
     @Test
     void ensureMonthReportUserFilterRelatedUrlsForEveryone() throws Exception {
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
-        final User joker = new User(new UserId("joker"), new UserLocalId(2L), "Jack", "Napier", new EMailAddress(""), Set.of());
-        final User robin = new User(new UserId("robin"), new UserLocalId(3L), "Dick", "Grayson", new EMailAddress(""), Set.of());
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        final UserId jokerId = new UserId("joker");
+        final UserLocalId jokerLocalId = new UserLocalId(2L);
+        final UserIdComposite jokerIdComposite = new UserIdComposite(jokerId, jokerLocalId);
+        final User joker = new User(jokerIdComposite, "Jack", "Napier", new EMailAddress(""), Set.of());
+
+        final UserId robinId = new UserId("robin");
+        final UserLocalId robinLocalId = new UserLocalId(3L);
+        final UserIdComposite robinIdComposite = new UserIdComposite(robinId, robinLocalId);
+        final User robin = new User(robinIdComposite, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
         when(reportPermissionService.findAllPermittedUsersForCurrentUser())
             .thenReturn(List.of(batman, joker, robin));
@@ -218,9 +244,20 @@ class ReportMonthControllerTest {
     @Test
     void ensureMonthReportUserFilterRelatedUrlsForWithSelectedUser() throws Exception {
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
-        final User joker = new User(new UserId("joker"), new UserLocalId(2L), "Jack", "Napier", new EMailAddress(""), Set.of());
-        final User robin = new User(new UserId("robin"), new UserLocalId(3L), "Dick", "Grayson", new EMailAddress(""), Set.of());
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        final UserId jokerId = new UserId("joker");
+        final UserLocalId jokerLocalId = new UserLocalId(2L);
+        final UserIdComposite jokerIdComposite = new UserIdComposite(jokerId, jokerLocalId);
+        final User joker = new User(jokerIdComposite, "Jack", "Napier", new EMailAddress(""), Set.of());
+
+        final UserId robinId = new UserId("robin");
+        final UserLocalId robinLocalId = new UserLocalId(3L);
+        final UserIdComposite robinIdComposite = new UserIdComposite(robinId, robinLocalId);
+        final User robin = new User(robinIdComposite, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
         when(reportPermissionService.findAllPermittedUsersForCurrentUser())
             .thenReturn(List.of(batman, joker, robin));

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthTest.java
@@ -57,24 +57,22 @@ class ReportMonthTest {
         final LocalDate saturday = firstDateOfWeek.plusDays(5);
         final LocalDate sunday = firstDateOfWeek.plusDays(6);
 
-        final UserLocalId userLocalId = user.localId();
-
         return new ReportWeek(firstDateOfWeek, List.of(
             // january
-            new ReportDay(firstDateOfWeek, Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(tuesday, Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
+            new ReportDay(firstDateOfWeek, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
+            new ReportDay(tuesday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
             // february
-            new ReportDay(wednesday, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of(
+            new ReportDay(wednesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of(
+            new ReportDay(thursday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of(
+            new ReportDay(friday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of()), Map.of())
+            new ReportDay(saturday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of()), Map.of())
         ));
     }
 
@@ -87,26 +85,24 @@ class ReportMonthTest {
         final LocalDate saturday = firstDateOfWeek.plusDays(5);
         final LocalDate sunday = firstDateOfWeek.plusDays(6);
 
-        final UserLocalId userLocalId = user.localId();
-
         return new ReportWeek(firstDateOfWeek, List.of(
-            new ReportDay(firstDateOfWeek, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of(
+            new ReportDay(firstDateOfWeek, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(firstDateOfWeek, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(firstDateOfWeek, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of(
+            new ReportDay(tuesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(tuesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(tuesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(wednesday, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of(
+            new ReportDay(wednesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of(
+            new ReportDay(thursday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of(
+            new ReportDay(friday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of())
+            new ReportDay(saturday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of())
         ));
     }
 
@@ -119,22 +115,20 @@ class ReportMonthTest {
         final LocalDate saturday = firstDateOfWeek.plusDays(5);
         final LocalDate sunday = firstDateOfWeek.plusDays(6);
 
-        final UserLocalId userLocalId = user.localId();
-
         return new ReportWeek(firstDateOfWeek, List.of(
             // february
-            new ReportDay(firstDateOfWeek, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of(
+            new ReportDay(firstDateOfWeek, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, Map.of(userLocalId, PlannedWorkingHours.EIGHT), Map.of(userLocalId, List.of(
+            new ReportDay(tuesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
             // march
-            new ReportDay(wednesday, Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(thursday, Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(friday, Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(saturday, Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of())
+            new ReportDay(wednesday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
+            new ReportDay(thursday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
+            new ReportDay(friday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
+            new ReportDay(saturday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of())
         ));
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthTest.java
@@ -59,20 +59,20 @@ class ReportMonthTest {
 
         return new ReportWeek(firstDateOfWeek, List.of(
             // january
-            new ReportDay(firstDateOfWeek, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
-            new ReportDay(tuesday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
+            new ReportDay(firstDateOfWeek, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(tuesday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
             // february
-            new ReportDay(wednesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(wednesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(thursday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(friday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of()), Map.of())
+            new ReportDay(saturday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
     }
 
@@ -86,23 +86,23 @@ class ReportMonthTest {
         final LocalDate sunday = firstDateOfWeek.plusDays(6);
 
         return new ReportWeek(firstDateOfWeek, List.of(
-            new ReportDay(firstDateOfWeek, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(firstDateOfWeek, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(firstDateOfWeek, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(firstDateOfWeek, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(tuesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(tuesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(tuesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(wednesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(wednesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(thursday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(friday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of())
+            new ReportDay(saturday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
     }
 
@@ -117,18 +117,18 @@ class ReportMonthTest {
 
         return new ReportWeek(firstDateOfWeek, List.of(
             // february
-            new ReportDay(firstDateOfWeek, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(firstDateOfWeek, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(tuesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
             // march
-            new ReportDay(wednesday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
-            new ReportDay(thursday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
-            new ReportDay(friday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
-            new ReportDay(saturday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of())
+            new ReportDay(wednesday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(thursday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(friday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(saturday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthTest.java
@@ -4,6 +4,7 @@ import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.timeentry.PlannedWorkingHours;
 import de.focusshift.zeiterfassung.timeentry.WorkDuration;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,10 @@ class ReportMonthTest {
     @Test
     void ensureAverageDayWorkDuration() {
 
-        final User user = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        final UserId userId = new UserId("uuid");
+        final UserLocalId userLocalId = new UserLocalId(1337L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
         final LocalTime timeStart = LocalTime.of(8, 0);
         final LocalTime timeEnd = timeStart.plusHours(8);

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportPermissionServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportPermissionServiceTest.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.report;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.CurrentUserProvider;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
@@ -72,13 +73,16 @@ class ReportPermissionServiceTest {
         when(currentUserProvider.getCurrentAuthentication())
             .thenReturn(new TestingAuthenticationToken("", "", List.of()));
 
+        final UserId userId = new UserId("");
+        final UserLocalId userLocalId = new UserLocalId(2L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
         when(currentUserProvider.getCurrentUser())
-            .thenReturn(new User(new UserId(""), new UserLocalId(2L), "", "", new EMailAddress(""), Set.of()));
+            .thenReturn(new User(userIdComposite, "", "", new EMailAddress(""), Set.of()));
 
         final List<UserLocalId> actual = sut.filterUserLocalIdsByCurrentUserHasPermissionFor(
-            List.of(new UserLocalId(1L), new UserLocalId(2L), new UserLocalId(3L)));
+            List.of(new UserLocalId(1L), userLocalId, new UserLocalId(3L)));
 
-        assertThat(actual).containsOnly(new UserLocalId(2L));
+        assertThat(actual).containsOnly(userLocalId);
     }
 
     @Test
@@ -87,8 +91,11 @@ class ReportPermissionServiceTest {
         when(currentUserProvider.getCurrentAuthentication())
             .thenReturn(new TestingAuthenticationToken("", "", List.of()));
 
+        final UserId userId = new UserId("");
+        final UserLocalId userLocalId = new UserLocalId(2L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
         when(currentUserProvider.getCurrentUser())
-            .thenReturn(new User(new UserId(""), new UserLocalId(2L), "", "", new EMailAddress(""), Set.of()));
+            .thenReturn(new User(userIdComposite, "", "", new EMailAddress(""), Set.of()));
 
         final List<UserLocalId> actual = sut.filterUserLocalIdsByCurrentUserHasPermissionFor(
             List.of(new UserLocalId(1L), new UserLocalId(3L)));
@@ -102,15 +109,27 @@ class ReportPermissionServiceTest {
         when(currentUserProvider.getCurrentAuthentication())
             .thenReturn(new TestingAuthenticationToken("", "", List.of(ZEITERFASSUNG_VIEW_REPORT_ALL.authority())));
 
+        final UserId userId_1 = new UserId("");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+
+        final UserId userId_2 = new UserId("");
+        final UserLocalId userLocalId_2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+
+        final UserId userId_3 = new UserId("");
+        final UserLocalId userLocalId_3 = new UserLocalId(3L);
+        final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
+
         when(userManagementService.findAllUsers())
             .thenReturn(List.of(
-                new User(new UserId(""), new UserLocalId(1L), "", "", new EMailAddress(""), Set.of()),
-                new User(new UserId(""), new UserLocalId(2L), "", "", new EMailAddress(""), Set.of()),
-                new User(new UserId(""), new UserLocalId(3L), "", "", new EMailAddress(""), Set.of())
+                new User(userIdComposite_1, "", "", new EMailAddress(""), Set.of()),
+                new User(userIdComposite_2, "", "", new EMailAddress(""), Set.of()),
+                new User(userIdComposite_3, "", "", new EMailAddress(""), Set.of())
             ));
 
         assertThat(sut.findAllPermittedUserLocalIdsForCurrentUser())
-            .containsExactly(new UserLocalId(1L), new UserLocalId(2L), new UserLocalId(3L));
+            .containsExactly(userLocalId_1, userLocalId_2, userLocalId_3);
     }
 
     @Test
@@ -119,10 +138,13 @@ class ReportPermissionServiceTest {
         when(currentUserProvider.getCurrentAuthentication())
             .thenReturn(new TestingAuthenticationToken("", "", List.of()));
 
+        final UserId userId = new UserId("");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
         when(currentUserProvider.getCurrentUser())
-            .thenReturn(new User(new UserId(""), new UserLocalId(2L), "", "", new EMailAddress(""), Set.of()));
+            .thenReturn(new User(userIdComposite, "", "", new EMailAddress(""), Set.of()));
 
-        assertThat(sut.findAllPermittedUserLocalIdsForCurrentUser()).containsOnly(new UserLocalId(2L));
+        assertThat(sut.findAllPermittedUserLocalIdsForCurrentUser()).containsOnly(userLocalId);
     }
 
     @Test
@@ -131,10 +153,22 @@ class ReportPermissionServiceTest {
         when(currentUserProvider.getCurrentAuthentication())
             .thenReturn(new TestingAuthenticationToken("", "", List.of(ZEITERFASSUNG_VIEW_REPORT_ALL.authority())));
 
+        final UserId userId_1 = new UserId("");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+
+        final UserId userId_2 = new UserId("");
+        final UserLocalId userLocalId_2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+
+        final UserId userId_3 = new UserId("");
+        final UserLocalId userLocalId_3 = new UserLocalId(3L);
+        final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
+
         final List<User> userList = List.of(
-            new User(new UserId(""), new UserLocalId(1L), "", "", new EMailAddress(""), Set.of()),
-            new User(new UserId(""), new UserLocalId(2L), "", "", new EMailAddress(""), Set.of()),
-            new User(new UserId(""), new UserLocalId(3L), "", "", new EMailAddress(""), Set.of())
+            new User(userIdComposite_1, "", "", new EMailAddress(""), Set.of()),
+            new User(userIdComposite_2, "", "", new EMailAddress(""), Set.of()),
+            new User(userIdComposite_3, "", "", new EMailAddress(""), Set.of())
         );
 
         when(userManagementService.findAllUsers()).thenReturn(userList);
@@ -148,10 +182,12 @@ class ReportPermissionServiceTest {
         when(currentUserProvider.getCurrentAuthentication())
             .thenReturn(new TestingAuthenticationToken("", "", List.of()));
 
-        when(currentUserProvider.getCurrentUser())
-            .thenReturn(new User(new UserId(""), new UserLocalId(2L), "", "", new EMailAddress(""), Set.of()));
+        final UserId userId = new UserId("");
+        final UserLocalId userLocalId = new UserLocalId(2L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "", "", new EMailAddress(""), Set.of());
+        when(currentUserProvider.getCurrentUser()).thenReturn(user);
 
-        assertThat(sut.findAllPermittedUsersForCurrentUser())
-            .containsOnly(new User(new UserId(""), new UserLocalId(2L), "", "", new EMailAddress(""), Set.of()));
+        assertThat(sut.findAllPermittedUsersForCurrentUser()).containsOnly(user);
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
@@ -107,11 +107,11 @@ class ReportServiceRawTest {
 
         final ZonedDateTime firstFrom = dateTime(2021, 1, 4, 10, 0);
         final ZonedDateTime firstTo = dateTime(2021, 1, 4, 11, 0);
-        final TimeEntry firstTimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work", firstFrom, firstTo, false);
+        final TimeEntry firstTimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work", firstFrom, firstTo, false);
 
         final ZonedDateTime secondFrom = dateTime(2021, 1, 7, 8, 0);
         final ZonedDateTime secondTo = dateTime(2021, 1, 7, 11, 0);
-        final TimeEntry secondTimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work", secondFrom, secondTo, false);
+        final TimeEntry secondTimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work", secondFrom, secondTo, false);
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
@@ -142,11 +142,11 @@ class ReportServiceRawTest {
 
         final ZonedDateTime morningFrom = dateTime(2021, 1, 5, 10, 0);
         final ZonedDateTime morningTo = dateTime(2021, 1, 5, 11, 0);
-        final TimeEntry morningTimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work in the morning", morningFrom, morningTo, false);
+        final TimeEntry morningTimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work in the morning", morningFrom, morningTo, false);
 
         final ZonedDateTime noonFrom = dateTime(2021, 1, 5, 15, 0);
         final ZonedDateTime noonTo = dateTime(2021, 1, 5, 19, 0);
-        final TimeEntry noonTimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work in the noon", noonFrom, noonTo, false);
+        final TimeEntry noonTimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work in the noon", noonFrom, noonTo, false);
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
@@ -177,7 +177,7 @@ class ReportServiceRawTest {
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 22, 0);
         final ZonedDateTime to = dateTime(2021, 1, 5, 3, 0);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work in the night", from, to, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work in the night", from, to, false);
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
@@ -260,37 +260,37 @@ class ReportServiceRawTest {
 
         final ZonedDateTime w1_d1_From = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime w1_d1_To = dateTime(2021, 1, 4, 2, 0);
-        final TimeEntry w1_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w1_d1", w1_d1_From, w1_d1_To, false);
+        final TimeEntry w1_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w1_d1", w1_d1_From, w1_d1_To, false);
         final ZonedDateTime w1_d2_From = dateTime(2021, 1, 5, 3, 0);
         final ZonedDateTime w1_d2_To = dateTime(2021, 1, 5, 4, 0);
-        final TimeEntry w1_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w1_d2", w1_d2_From, w1_d2_To, false);
+        final TimeEntry w1_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w1_d2", w1_d2_From, w1_d2_To, false);
 
         final ZonedDateTime w2_d1_From = dateTime(2021, 1, 11, 1, 0);
         final ZonedDateTime w2_d1_To = dateTime(2021, 1, 11, 3, 0);
-        final TimeEntry w2_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w2_d1", w2_d1_From, w2_d1_To, false);
+        final TimeEntry w2_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w2_d1", w2_d1_From, w2_d1_To, false);
         final ZonedDateTime w2_d2_From = dateTime(2021, 1, 12, 4, 0);
         final ZonedDateTime w2_d2_To = dateTime(2021, 1, 12, 6, 0);
-        final TimeEntry w2_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w2_d2", w2_d2_From, w2_d2_To, false);
+        final TimeEntry w2_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w2_d2", w2_d2_From, w2_d2_To, false);
 
         final ZonedDateTime w3_d1_From = dateTime(2021, 1, 18, 1, 0);
         final ZonedDateTime w3_d1_To = dateTime(2021, 1, 18, 4, 0);
-        final TimeEntry w3_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w3_d1", w3_d1_From, w3_d1_To, false);
+        final TimeEntry w3_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w3_d1", w3_d1_From, w3_d1_To, false);
         final ZonedDateTime w3_d2_From = dateTime(2021, 1, 19, 5, 0);
         final ZonedDateTime w3_d2_To = dateTime(2021, 1, 19, 8, 0);
-        final TimeEntry w3_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w3_d2", w3_d2_From, w3_d2_To, false);
+        final TimeEntry w3_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w3_d2", w3_d2_From, w3_d2_To, false);
 
         final ZonedDateTime w4_d1_From = dateTime(2021, 1, 25, 1, 0);
         final ZonedDateTime w4_d1_To = dateTime(2021, 1, 25, 5, 0);
-        final TimeEntry w4_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w4_d1", w4_d1_From, w4_d1_To, false);
+        final TimeEntry w4_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w4_d1", w4_d1_From, w4_d1_To, false);
         final ZonedDateTime w4_d2_From = dateTime(2021, 1, 26, 6, 0);
         final ZonedDateTime w4_d2_To = dateTime(2021, 1, 26, 10, 0);
-        final TimeEntry w4_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w4_d2", w4_d2_From, w4_d2_To, false);
+        final TimeEntry w4_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w4_d2", w4_d2_From, w4_d2_To, false);
 
         when(userDateService.localDateToFirstDateOfWeek(LocalDate.of(2021, 1, 1)))
             .thenReturn(LocalDate.of(2020, 12, 28));
 
         when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1), List.of(user.localId())))
-            .thenReturn(Map.of(user.localId(), List.of(w1_d1_TimeEntry, w1_d2_TimeEntry, w2_d1_TimeEntry, w2_d2_TimeEntry, w3_d1_TimeEntry, w3_d2_TimeEntry, w4_d1_TimeEntry, w4_d2_TimeEntry)));
+            .thenReturn(Map.of(user.idComposite(), List.of(w1_d1_TimeEntry, w1_d2_TimeEntry, w2_d1_TimeEntry, w2_d2_TimeEntry, w3_d1_TimeEntry, w3_d2_TimeEntry, w4_d1_TimeEntry, w4_d2_TimeEntry)));
 
         when(userManagementService.findAllUsersByIds(List.of(user.id()))).thenReturn(List.of(user));
 

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
@@ -7,6 +7,7 @@ import de.focusshift.zeiterfassung.timeentry.TimeEntryId;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryService;
 import de.focusshift.zeiterfassung.user.UserDateService;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
@@ -67,23 +68,21 @@ class ReportServiceRawTest {
     @Test
     void ensureReportWeekFirstDateOfWeekIsMonday() {
 
-        final UserId userId = new UserId("batman");
-        final User user = new User(userId, new UserLocalId(1L), "givenName", "familyName", new EMailAddress(""), Set.of());
-        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+        final User user = anyUser();
+        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
 
-        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, userId);
+        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.id());
         assertThat(actualReportWeek.firstDateOfWeek().getDayOfWeek()).isEqualTo(MONDAY);
     }
 
     @Test
     void ensureReportWeekWithoutTimeEntriesFirstWeekOfYear() {
 
-        final UserId userId = new UserId("batman");
-        final User user = new User(userId, new UserLocalId(1L), "givenName", "familyName", new EMailAddress(""), Set.of());
-        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+        final User user = anyUser();
+        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
@@ -91,7 +90,7 @@ class ReportServiceRawTest {
         when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), new UserId("batman")))
             .thenReturn(List.of());
 
-        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, userId);
+        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.id());
 
         assertThat(actualReportWeek.reportDays()).hasSize(7);
 
@@ -103,27 +102,26 @@ class ReportServiceRawTest {
     @Test
     void ensureReportWeekWithOneTimeEntryADay() {
 
-        final UserId userId = new UserId("batman");
-        final User user = new User(userId, new UserLocalId(1L), "givenName", "familyName", new EMailAddress(""), Set.of());
-        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+        final User user = anyUser();
+        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
 
         final ZonedDateTime firstFrom = dateTime(2021, 1, 4, 10, 0);
         final ZonedDateTime firstTo = dateTime(2021, 1, 4, 11, 0);
-        final TimeEntry firstTimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work", firstFrom, firstTo, false);
+        final TimeEntry firstTimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work", firstFrom, firstTo, false);
 
         final ZonedDateTime secondFrom = dateTime(2021, 1, 7, 8, 0);
         final ZonedDateTime secondTo = dateTime(2021, 1, 7, 11, 0);
-        final TimeEntry secondTimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work", secondFrom, secondTo, false);
+        final TimeEntry secondTimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work", secondFrom, secondTo, false);
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
 
-        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), userId))
+        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), user.id()))
             .thenReturn(List.of(firstTimeEntry, secondTimeEntry));
 
-        when(userManagementService.findAllUsersByIds(List.of(userId))).thenReturn(List.of(user));
+        when(userManagementService.findAllUsersByIds(List.of(user.id()))).thenReturn(List.of(user));
 
-        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, userId);
+        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.id());
 
         assertThat(actualReportWeek.reportDays()).hasSize(7);
 
@@ -139,25 +137,24 @@ class ReportServiceRawTest {
     @Test
     void ensureReportWeekWithMultipleTimeEntriesADay() {
 
-        final UserId userId = new UserId("batman");
-        final User user = new User(userId, new UserLocalId(1L), "givenName", "familyName", new EMailAddress(""), Set.of());
-        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+        final User user = anyUser();
+        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
 
         final ZonedDateTime morningFrom = dateTime(2021, 1, 5, 10, 0);
         final ZonedDateTime morningTo = dateTime(2021, 1, 5, 11, 0);
-        final TimeEntry morningTimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work in the morning", morningFrom, morningTo, false);
+        final TimeEntry morningTimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work in the morning", morningFrom, morningTo, false);
 
         final ZonedDateTime noonFrom = dateTime(2021, 1, 5, 15, 0);
         final ZonedDateTime noonTo = dateTime(2021, 1, 5, 19, 0);
-        final TimeEntry noonTimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work in the noon", noonFrom, noonTo, false);
+        final TimeEntry noonTimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work in the noon", noonFrom, noonTo, false);
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
 
-        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), userId))
+        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), user.id()))
             .thenReturn(List.of(morningTimeEntry, noonTimeEntry));
 
-        when(userManagementService.findAllUsersByIds(List.of(userId))).thenReturn(List.of(user));
+        when(userManagementService.findAllUsersByIds(List.of(user.id()))).thenReturn(List.of(user));
 
         final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, new UserId("batman"));
 
@@ -175,23 +172,22 @@ class ReportServiceRawTest {
     @Test
     void ensureReportWeekWithTimeEntryTouchingNextDayIsReportedForStartingDate() {
 
-        final UserId userId = new UserId("batman");
-        final User user = new User(userId, new UserLocalId(1L), "givenName", "familyName", new EMailAddress(""), Set.of());
-        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+        final User user = anyUser();
+        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 22, 0);
         final ZonedDateTime to = dateTime(2021, 1, 5, 3, 0);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work in the night", from, to, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work in the night", from, to, false);
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
 
-        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), userId))
+        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), user.id()))
             .thenReturn(List.of(timeEntry));
 
-        when(userManagementService.findAllUsersByIds(List.of(userId))).thenReturn(List.of(user));
+        when(userManagementService.findAllUsersByIds(List.of(user.id()))).thenReturn(List.of(user));
 
-        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, userId);
+        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.id());
 
         assertThat(actualReportWeek.reportDays()).hasSize(7);
 
@@ -211,18 +207,16 @@ class ReportServiceRawTest {
     @Test
     void ensureReportMonthFirstDayOfEveryWeekIsMonday() {
 
-        final UserId userId = new UserId("batman");
-        final UserLocalId localId = new UserLocalId(1L);
-        final User user = new User(userId, localId, "givenName", "familyName", new EMailAddress(""), Set.of());
-        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+        final User user = anyUser();
+        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
 
         when(userDateService.localDateToFirstDateOfWeek(LocalDate.of(2021, 1, 1)))
             .thenReturn(LocalDate.of(2020, 12, 28));
 
-        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1), List.of(localId)))
+        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1), List.of(user.localId())))
             .thenReturn(Map.of());
 
-        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 1), userId);
+        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 1), user.id());
 
         assertThat(actualReportMonth.weeks()).hasSize(5);
 
@@ -234,18 +228,16 @@ class ReportServiceRawTest {
     @Test
     void ensureReportMonthDecemberWithoutTimeEntries() {
 
-        final UserId userId = new UserId("batman");
-        final UserLocalId localId = new UserLocalId(1L);
-        final User user = new User(userId, localId, "givenName", "familyName", new EMailAddress(""), Set.of());
-        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+        final User user = anyUser();
+        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
 
         when(userDateService.localDateToFirstDateOfWeek(LocalDate.of(2021, 12, 1)))
             .thenReturn(LocalDate.of(2021, 11, 29));
 
-        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 12, 1), LocalDate.of(2022, 1, 1), List.of(localId)))
+        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 12, 1), LocalDate.of(2022, 1, 1), List.of(user.localId())))
             .thenReturn(Map.of());
 
-        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 12), userId);
+        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 12), user.id());
 
         assertThat(actualReportMonth.yearMonth()).isEqualTo(YearMonth.of(2021, 12));
         assertThat(actualReportMonth.weeks()).hasSize(5);
@@ -263,48 +255,46 @@ class ReportServiceRawTest {
     @Test
     void ensureReportMonthDecemberWithOneTimeEntryAWeek() {
 
-        final UserId userId = new UserId("batman");
-        final UserLocalId localId = new UserLocalId(1L);
-        final User user = new User(userId, localId, "givenName", "familyName", new EMailAddress(""), Set.of());
-        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+        final User user = anyUser();
+        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
 
         final ZonedDateTime w1_d1_From = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime w1_d1_To = dateTime(2021, 1, 4, 2, 0);
-        final TimeEntry w1_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work w1_d1", w1_d1_From, w1_d1_To, false);
+        final TimeEntry w1_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w1_d1", w1_d1_From, w1_d1_To, false);
         final ZonedDateTime w1_d2_From = dateTime(2021, 1, 5, 3, 0);
         final ZonedDateTime w1_d2_To = dateTime(2021, 1, 5, 4, 0);
-        final TimeEntry w1_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work w1_d2", w1_d2_From, w1_d2_To, false);
+        final TimeEntry w1_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w1_d2", w1_d2_From, w1_d2_To, false);
 
         final ZonedDateTime w2_d1_From = dateTime(2021, 1, 11, 1, 0);
         final ZonedDateTime w2_d1_To = dateTime(2021, 1, 11, 3, 0);
-        final TimeEntry w2_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work w2_d1", w2_d1_From, w2_d1_To, false);
+        final TimeEntry w2_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w2_d1", w2_d1_From, w2_d1_To, false);
         final ZonedDateTime w2_d2_From = dateTime(2021, 1, 12, 4, 0);
         final ZonedDateTime w2_d2_To = dateTime(2021, 1, 12, 6, 0);
-        final TimeEntry w2_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work w2_d2", w2_d2_From, w2_d2_To, false);
+        final TimeEntry w2_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w2_d2", w2_d2_From, w2_d2_To, false);
 
         final ZonedDateTime w3_d1_From = dateTime(2021, 1, 18, 1, 0);
         final ZonedDateTime w3_d1_To = dateTime(2021, 1, 18, 4, 0);
-        final TimeEntry w3_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work w3_d1", w3_d1_From, w3_d1_To, false);
+        final TimeEntry w3_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w3_d1", w3_d1_From, w3_d1_To, false);
         final ZonedDateTime w3_d2_From = dateTime(2021, 1, 19, 5, 0);
         final ZonedDateTime w3_d2_To = dateTime(2021, 1, 19, 8, 0);
-        final TimeEntry w3_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work w3_d2", w3_d2_From, w3_d2_To, false);
+        final TimeEntry w3_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w3_d2", w3_d2_From, w3_d2_To, false);
 
         final ZonedDateTime w4_d1_From = dateTime(2021, 1, 25, 1, 0);
         final ZonedDateTime w4_d1_To = dateTime(2021, 1, 25, 5, 0);
-        final TimeEntry w4_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work w4_d1", w4_d1_From, w4_d1_To, false);
+        final TimeEntry w4_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w4_d1", w4_d1_From, w4_d1_To, false);
         final ZonedDateTime w4_d2_From = dateTime(2021, 1, 26, 6, 0);
         final ZonedDateTime w4_d2_To = dateTime(2021, 1, 26, 10, 0);
-        final TimeEntry w4_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work w4_d2", w4_d2_From, w4_d2_To, false);
+        final TimeEntry w4_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.id(), "hard work w4_d2", w4_d2_From, w4_d2_To, false);
 
         when(userDateService.localDateToFirstDateOfWeek(LocalDate.of(2021, 1, 1)))
             .thenReturn(LocalDate.of(2020, 12, 28));
 
-        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1), List.of(localId)))
-            .thenReturn(Map.of(localId, List.of(w1_d1_TimeEntry, w1_d2_TimeEntry, w2_d1_TimeEntry, w2_d2_TimeEntry, w3_d1_TimeEntry, w3_d2_TimeEntry, w4_d1_TimeEntry, w4_d2_TimeEntry)));
+        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1), List.of(user.localId())))
+            .thenReturn(Map.of(user.localId(), List.of(w1_d1_TimeEntry, w1_d2_TimeEntry, w2_d1_TimeEntry, w2_d2_TimeEntry, w3_d1_TimeEntry, w3_d2_TimeEntry, w4_d1_TimeEntry, w4_d2_TimeEntry)));
 
-        when(userManagementService.findAllUsersByIds(List.of(userId))).thenReturn(List.of(user));
+        when(userManagementService.findAllUsersByIds(List.of(user.id()))).thenReturn(List.of(user));
 
-        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 1), userId);
+        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 1), user.id());
 
         assertThat(actualReportMonth.yearMonth()).isEqualTo(YearMonth.of(2021, 1));
         assertThat(actualReportMonth.weeks()).hasSize(5);
@@ -314,6 +304,15 @@ class ReportServiceRawTest {
         assertThat(actualReportMonth.weeks().get(2).workDuration().duration()).isEqualTo(Duration.ofHours(4));
         assertThat(actualReportMonth.weeks().get(3).workDuration().duration()).isEqualTo(Duration.ofHours(6));
         assertThat(actualReportMonth.weeks().get(4).workDuration().duration()).isEqualTo(Duration.ofHours(8));
+    }
+
+    private static User anyUser() {
+
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
+        return new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
     }
 
     private static ZonedDateTime dateTime(int year, int month, int dayOfMonth, int hour, int minute) {

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
@@ -69,12 +69,12 @@ class ReportServiceRawTest {
     void ensureReportWeekFirstDateOfWeekIsMonday() {
 
         final User user = anyUser();
-        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
+        when(userManagementService.findUserById(user.userId())).thenReturn(Optional.of(user));
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
 
-        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.id());
+        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.userId());
         assertThat(actualReportWeek.firstDateOfWeek().getDayOfWeek()).isEqualTo(MONDAY);
     }
 
@@ -82,7 +82,7 @@ class ReportServiceRawTest {
     void ensureReportWeekWithoutTimeEntriesFirstWeekOfYear() {
 
         final User user = anyUser();
-        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
+        when(userManagementService.findUserById(user.userId())).thenReturn(Optional.of(user));
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
@@ -90,7 +90,7 @@ class ReportServiceRawTest {
         when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), new UserId("batman")))
             .thenReturn(List.of());
 
-        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.id());
+        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.userId());
 
         assertThat(actualReportWeek.reportDays()).hasSize(7);
 
@@ -103,25 +103,25 @@ class ReportServiceRawTest {
     void ensureReportWeekWithOneTimeEntryADay() {
 
         final User user = anyUser();
-        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
+        when(userManagementService.findUserById(user.userId())).thenReturn(Optional.of(user));
 
         final ZonedDateTime firstFrom = dateTime(2021, 1, 4, 10, 0);
         final ZonedDateTime firstTo = dateTime(2021, 1, 4, 11, 0);
-        final TimeEntry firstTimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work", firstFrom, firstTo, false);
+        final TimeEntry firstTimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work", firstFrom, firstTo, false);
 
         final ZonedDateTime secondFrom = dateTime(2021, 1, 7, 8, 0);
         final ZonedDateTime secondTo = dateTime(2021, 1, 7, 11, 0);
-        final TimeEntry secondTimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work", secondFrom, secondTo, false);
+        final TimeEntry secondTimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work", secondFrom, secondTo, false);
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
 
-        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), user.id()))
+        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), user.userId()))
             .thenReturn(List.of(firstTimeEntry, secondTimeEntry));
 
-        when(userManagementService.findAllUsersByIds(List.of(user.id()))).thenReturn(List.of(user));
+        when(userManagementService.findAllUsersByIds(List.of(user.userId()))).thenReturn(List.of(user));
 
-        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.id());
+        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.userId());
 
         assertThat(actualReportWeek.reportDays()).hasSize(7);
 
@@ -138,23 +138,23 @@ class ReportServiceRawTest {
     void ensureReportWeekWithMultipleTimeEntriesADay() {
 
         final User user = anyUser();
-        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
+        when(userManagementService.findUserById(user.userId())).thenReturn(Optional.of(user));
 
         final ZonedDateTime morningFrom = dateTime(2021, 1, 5, 10, 0);
         final ZonedDateTime morningTo = dateTime(2021, 1, 5, 11, 0);
-        final TimeEntry morningTimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work in the morning", morningFrom, morningTo, false);
+        final TimeEntry morningTimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work in the morning", morningFrom, morningTo, false);
 
         final ZonedDateTime noonFrom = dateTime(2021, 1, 5, 15, 0);
         final ZonedDateTime noonTo = dateTime(2021, 1, 5, 19, 0);
-        final TimeEntry noonTimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work in the noon", noonFrom, noonTo, false);
+        final TimeEntry noonTimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work in the noon", noonFrom, noonTo, false);
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
 
-        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), user.id()))
+        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), user.userId()))
             .thenReturn(List.of(morningTimeEntry, noonTimeEntry));
 
-        when(userManagementService.findAllUsersByIds(List.of(user.id()))).thenReturn(List.of(user));
+        when(userManagementService.findAllUsersByIds(List.of(user.userId()))).thenReturn(List.of(user));
 
         final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, new UserId("batman"));
 
@@ -173,21 +173,21 @@ class ReportServiceRawTest {
     void ensureReportWeekWithTimeEntryTouchingNextDayIsReportedForStartingDate() {
 
         final User user = anyUser();
-        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
+        when(userManagementService.findUserById(user.userId())).thenReturn(Optional.of(user));
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 22, 0);
         final ZonedDateTime to = dateTime(2021, 1, 5, 3, 0);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work in the night", from, to, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work in the night", from, to, false);
 
         when(userDateService.firstDayOfWeek(Year.of(2021), 1))
             .thenReturn(LocalDate.of(2021, 1, 4));
 
-        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), user.id()))
+        when(timeEntryService.getEntries(LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 11), user.userId()))
             .thenReturn(List.of(timeEntry));
 
-        when(userManagementService.findAllUsersByIds(List.of(user.id()))).thenReturn(List.of(user));
+        when(userManagementService.findAllUsersByIds(List.of(user.userId()))).thenReturn(List.of(user));
 
-        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.id());
+        final ReportWeek actualReportWeek = sut.getReportWeek(Year.of(2021), 1, user.userId());
 
         assertThat(actualReportWeek.reportDays()).hasSize(7);
 
@@ -208,15 +208,15 @@ class ReportServiceRawTest {
     void ensureReportMonthFirstDayOfEveryWeekIsMonday() {
 
         final User user = anyUser();
-        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
+        when(userManagementService.findUserById(user.userId())).thenReturn(Optional.of(user));
 
         when(userDateService.localDateToFirstDateOfWeek(LocalDate.of(2021, 1, 1)))
             .thenReturn(LocalDate.of(2020, 12, 28));
 
-        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1), List.of(user.localId())))
+        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1), List.of(user.userLocalId())))
             .thenReturn(Map.of());
 
-        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 1), user.id());
+        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 1), user.userId());
 
         assertThat(actualReportMonth.weeks()).hasSize(5);
 
@@ -229,15 +229,15 @@ class ReportServiceRawTest {
     void ensureReportMonthDecemberWithoutTimeEntries() {
 
         final User user = anyUser();
-        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
+        when(userManagementService.findUserById(user.userId())).thenReturn(Optional.of(user));
 
         when(userDateService.localDateToFirstDateOfWeek(LocalDate.of(2021, 12, 1)))
             .thenReturn(LocalDate.of(2021, 11, 29));
 
-        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 12, 1), LocalDate.of(2022, 1, 1), List.of(user.localId())))
+        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 12, 1), LocalDate.of(2022, 1, 1), List.of(user.userLocalId())))
             .thenReturn(Map.of());
 
-        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 12), user.id());
+        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 12), user.userId());
 
         assertThat(actualReportMonth.yearMonth()).isEqualTo(YearMonth.of(2021, 12));
         assertThat(actualReportMonth.weeks()).hasSize(5);
@@ -256,45 +256,45 @@ class ReportServiceRawTest {
     void ensureReportMonthDecemberWithOneTimeEntryAWeek() {
 
         final User user = anyUser();
-        when(userManagementService.findUserById(user.id())).thenReturn(Optional.of(user));
+        when(userManagementService.findUserById(user.userId())).thenReturn(Optional.of(user));
 
         final ZonedDateTime w1_d1_From = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime w1_d1_To = dateTime(2021, 1, 4, 2, 0);
-        final TimeEntry w1_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w1_d1", w1_d1_From, w1_d1_To, false);
+        final TimeEntry w1_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work w1_d1", w1_d1_From, w1_d1_To, false);
         final ZonedDateTime w1_d2_From = dateTime(2021, 1, 5, 3, 0);
         final ZonedDateTime w1_d2_To = dateTime(2021, 1, 5, 4, 0);
-        final TimeEntry w1_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w1_d2", w1_d2_From, w1_d2_To, false);
+        final TimeEntry w1_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work w1_d2", w1_d2_From, w1_d2_To, false);
 
         final ZonedDateTime w2_d1_From = dateTime(2021, 1, 11, 1, 0);
         final ZonedDateTime w2_d1_To = dateTime(2021, 1, 11, 3, 0);
-        final TimeEntry w2_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w2_d1", w2_d1_From, w2_d1_To, false);
+        final TimeEntry w2_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work w2_d1", w2_d1_From, w2_d1_To, false);
         final ZonedDateTime w2_d2_From = dateTime(2021, 1, 12, 4, 0);
         final ZonedDateTime w2_d2_To = dateTime(2021, 1, 12, 6, 0);
-        final TimeEntry w2_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w2_d2", w2_d2_From, w2_d2_To, false);
+        final TimeEntry w2_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work w2_d2", w2_d2_From, w2_d2_To, false);
 
         final ZonedDateTime w3_d1_From = dateTime(2021, 1, 18, 1, 0);
         final ZonedDateTime w3_d1_To = dateTime(2021, 1, 18, 4, 0);
-        final TimeEntry w3_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w3_d1", w3_d1_From, w3_d1_To, false);
+        final TimeEntry w3_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work w3_d1", w3_d1_From, w3_d1_To, false);
         final ZonedDateTime w3_d2_From = dateTime(2021, 1, 19, 5, 0);
         final ZonedDateTime w3_d2_To = dateTime(2021, 1, 19, 8, 0);
-        final TimeEntry w3_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w3_d2", w3_d2_From, w3_d2_To, false);
+        final TimeEntry w3_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work w3_d2", w3_d2_From, w3_d2_To, false);
 
         final ZonedDateTime w4_d1_From = dateTime(2021, 1, 25, 1, 0);
         final ZonedDateTime w4_d1_To = dateTime(2021, 1, 25, 5, 0);
-        final TimeEntry w4_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w4_d1", w4_d1_From, w4_d1_To, false);
+        final TimeEntry w4_d1_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work w4_d1", w4_d1_From, w4_d1_To, false);
         final ZonedDateTime w4_d2_From = dateTime(2021, 1, 26, 6, 0);
         final ZonedDateTime w4_d2_To = dateTime(2021, 1, 26, 10, 0);
-        final TimeEntry w4_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.idComposite(), "hard work w4_d2", w4_d2_From, w4_d2_To, false);
+        final TimeEntry w4_d2_TimeEntry = new TimeEntry(new TimeEntryId(1L), user.userIdComposite(), "hard work w4_d2", w4_d2_From, w4_d2_To, false);
 
         when(userDateService.localDateToFirstDateOfWeek(LocalDate.of(2021, 1, 1)))
             .thenReturn(LocalDate.of(2020, 12, 28));
 
-        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1), List.of(user.localId())))
-            .thenReturn(Map.of(user.idComposite(), List.of(w1_d1_TimeEntry, w1_d2_TimeEntry, w2_d1_TimeEntry, w2_d2_TimeEntry, w3_d1_TimeEntry, w3_d2_TimeEntry, w4_d1_TimeEntry, w4_d2_TimeEntry)));
+        when(timeEntryService.getEntriesByUserLocalIds(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1), List.of(user.userLocalId())))
+            .thenReturn(Map.of(user.userIdComposite(), List.of(w1_d1_TimeEntry, w1_d2_TimeEntry, w2_d1_TimeEntry, w2_d2_TimeEntry, w3_d1_TimeEntry, w3_d2_TimeEntry, w4_d1_TimeEntry, w4_d2_TimeEntry)));
 
-        when(userManagementService.findAllUsersByIds(List.of(user.id()))).thenReturn(List.of(user));
+        when(userManagementService.findAllUsersByIds(List.of(user.userId()))).thenReturn(List.of(user));
 
-        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 1), user.id());
+        final ReportMonth actualReportMonth = sut.getReportMonth(YearMonth.of(2021, 1), user.userId());
 
         assertThat(actualReportMonth.yearMonth()).isEqualTo(YearMonth.of(2021, 1));
         assertThat(actualReportMonth.weeks()).hasSize(5);

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
@@ -156,7 +156,7 @@ class ReportWeekControllerTest {
         final User user = anyUser();
         when(reportPermissionService.findAllPermittedUsersForCurrentUser()).thenReturn(List.of(user));
 
-        when(reportService.getReportWeek(Year.of(2022), 1, user.id()))
+        when(reportService.getReportWeek(Year.of(2022), 1, user.userId()))
             .thenReturn(anyReportWeek());
 
         perform(get("/report/year/2022/week/1").with(oidcLogin().userInfoToken(userInfo -> userInfo.subject("batman"))))

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.report;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.DateFormatter;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.BeforeEach;
@@ -152,10 +153,10 @@ class ReportWeekControllerTest {
     @Test
     void ensureWeekReportUserFilterRelatedUrlsAreNotAddedWhenCurrentUserHasNoPermission() throws Exception {
 
-        when(reportPermissionService.findAllPermittedUsersForCurrentUser())
-            .thenReturn(List.of(new User(new UserId("batman"), new UserLocalId(1L), "", "", new EMailAddress(""), Set.of())));
+        final User user = anyUser();
+        when(reportPermissionService.findAllPermittedUsersForCurrentUser()).thenReturn(List.of(user));
 
-        when(reportService.getReportWeek(Year.of(2022), 1, new UserId("batman")))
+        when(reportService.getReportWeek(Year.of(2022), 1, user.id()))
             .thenReturn(anyReportWeek());
 
         perform(get("/report/year/2022/week/1").with(oidcLogin().userInfoToken(userInfo -> userInfo.subject("batman"))))
@@ -165,14 +166,25 @@ class ReportWeekControllerTest {
     @Test
     void ensureWeekReportUserFilterRelatedUrls() throws Exception {
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
-        final User joker = new User(new UserId("joker"), new UserLocalId(2L), "Jack", "Napier", new EMailAddress(""), Set.of());
-        final User robin = new User(new UserId("robin"), new UserLocalId(3L), "Dick", "Grayson", new EMailAddress(""), Set.of());
+        final UserId userId_1 = new UserId("batman");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        final UserId userId_2 = new UserId("joker");
+        final UserLocalId userLocalId_2 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+        final User user_2 = new User(userIdComposite_2, "Jack", "Napier", new EMailAddress(""), Set.of());
+
+        final UserId userId_3 = new UserId("robin");
+        final UserLocalId userLocalId_3 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
+        final User user_3 = new User(userIdComposite_3, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
         when(reportPermissionService.findAllPermittedUsersForCurrentUser())
-            .thenReturn(List.of(batman, joker, robin));
+            .thenReturn(List.of(user_1, user_2, user_3));
 
-        when(reportService.getReportWeek(Year.of(2022), 1, new UserId("batman")))
+        when(reportService.getReportWeek(Year.of(2022), 1, userId_1))
             .thenReturn(anyReportWeek());
 
         perform(get("/report/year/2022/week/1").with(oidcLogin().userInfoToken(userInfo -> userInfo.subject("batman"))))
@@ -189,12 +201,23 @@ class ReportWeekControllerTest {
     @Test
     void ensureWeekReportUserFilterRelatedUrlsForEveryone() throws Exception {
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
-        final User joker = new User(new UserId("joker"), new UserLocalId(2L), "Jack", "Napier", new EMailAddress(""), Set.of());
-        final User robin = new User(new UserId("robin"), new UserLocalId(3L), "Dick", "Grayson", new EMailAddress(""), Set.of());
+        final UserId userId_1 = new UserId("batman");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        final UserId userId_2 = new UserId("joker");
+        final UserLocalId userLocalId_2 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+        final User user_2 = new User(userIdComposite_2, "Jack", "Napier", new EMailAddress(""), Set.of());
+
+        final UserId userId_3 = new UserId("robin");
+        final UserLocalId userLocalId_3 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
+        final User user_3 = new User(userIdComposite_3, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
         when(reportPermissionService.findAllPermittedUsersForCurrentUser())
-            .thenReturn(List.of(batman, joker, robin));
+            .thenReturn(List.of(user_1, user_2, user_3));
 
         when(reportService.getReportWeekForAllUsers(Year.of(2022), 1))
             .thenReturn(anyReportWeek());
@@ -217,14 +240,25 @@ class ReportWeekControllerTest {
     @Test
     void ensureWeekReportUserFilterRelatedUrlsForWithSelectedUser() throws Exception {
 
-        final User batman = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
-        final User joker = new User(new UserId("joker"), new UserLocalId(2L), "Jack", "Napier", new EMailAddress(""), Set.of());
-        final User robin = new User(new UserId("robin"), new UserLocalId(3L), "Dick", "Grayson", new EMailAddress(""), Set.of());
+        final UserId userId_1 = new UserId("batman");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        final UserId userId_2 = new UserId("joker");
+        final UserLocalId userLocalId_2 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+        final User user_2 = new User(userIdComposite_2, "Jack", "Napier", new EMailAddress(""), Set.of());
+
+        final UserId userId_3 = new UserId("robin");
+        final UserLocalId userLocalId_3 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
+        final User user_3 = new User(userIdComposite_3, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
         when(reportPermissionService.findAllPermittedUsersForCurrentUser())
-            .thenReturn(List.of(batman, joker, robin));
+            .thenReturn(List.of(user_1, user_2, user_3));
 
-        when(reportService.getReportWeek(Year.of(2022), 1, List.of(new UserLocalId(2L), new UserLocalId(3L))))
+        when(reportService.getReportWeek(Year.of(2022), 1, List.of(userLocalId_2, userLocalId_3)))
             .thenReturn(anyReportWeek());
 
         perform(
@@ -241,9 +275,20 @@ class ReportWeekControllerTest {
             .andExpect(model().attribute("allUsersSelected", false))
             .andExpect(model().attribute("userReportFilterUrl", "/report/year/2022/week/1"));
     }
+
+    private static User anyUser() {
+
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
+        return new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+    }
+
     private static ReportWeek anyReportWeek() {
         return new ReportWeek(LocalDate.of(2022, 1, 1), List.of());
     }
+
     private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {
         return standaloneSetup(sut)
             .addFilters(new SecurityContextPersistenceFilter())

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
@@ -172,12 +172,12 @@ class ReportWeekControllerTest {
         final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
         final UserId userId_2 = new UserId("joker");
-        final UserLocalId userLocalId_2 = new UserLocalId(1L);
+        final UserLocalId userLocalId_2 = new UserLocalId(2L);
         final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
         final User user_2 = new User(userIdComposite_2, "Jack", "Napier", new EMailAddress(""), Set.of());
 
         final UserId userId_3 = new UserId("robin");
-        final UserLocalId userLocalId_3 = new UserLocalId(1L);
+        final UserLocalId userLocalId_3 = new UserLocalId(3L);
         final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
         final User user_3 = new User(userIdComposite_3, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
@@ -207,12 +207,12 @@ class ReportWeekControllerTest {
         final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
         final UserId userId_2 = new UserId("joker");
-        final UserLocalId userLocalId_2 = new UserLocalId(1L);
+        final UserLocalId userLocalId_2 = new UserLocalId(2L);
         final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
         final User user_2 = new User(userIdComposite_2, "Jack", "Napier", new EMailAddress(""), Set.of());
 
         final UserId userId_3 = new UserId("robin");
-        final UserLocalId userLocalId_3 = new UserLocalId(1L);
+        final UserLocalId userLocalId_3 = new UserLocalId(3L);
         final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
         final User user_3 = new User(userIdComposite_3, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
@@ -246,12 +246,12 @@ class ReportWeekControllerTest {
         final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
         final UserId userId_2 = new UserId("joker");
-        final UserLocalId userLocalId_2 = new UserLocalId(1L);
+        final UserLocalId userLocalId_2 = new UserLocalId(2L);
         final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
         final User user_2 = new User(userIdComposite_2, "Jack", "Napier", new EMailAddress(""), Set.of());
 
         final UserId userId_3 = new UserId("robin");
-        final UserLocalId userLocalId_3 = new UserLocalId(1L);
+        final UserLocalId userLocalId_3 = new UserLocalId(3L);
         final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
         final User user_3 = new User(userIdComposite_3, "Dick", "Grayson", new EMailAddress(""), Set.of());
 

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekTest.java
@@ -4,6 +4,7 @@ import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.timeentry.PlannedWorkingHours;
 import de.focusshift.zeiterfassung.timeentry.WorkDuration;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,10 @@ class ReportWeekTest {
     @Test
     void ensureAverageDayWorkDuration() {
 
-        final User user = new User(new UserId("batman"), new UserLocalId(1L), "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
         final LocalTime timeStart = LocalTime.of(8, 0);
         final LocalTime timeEnd = timeStart.plusHours(8);

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekTest.java
@@ -32,15 +32,17 @@ class ReportWeekTest {
     @Test
     void ensureAverageDayWorkDurationIsEmptyWhenAllReportDaysHasNotPlannedWorkingHours() {
 
+        final UserId userId = new UserId("uuid");
         final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
 
         final ReportWeek sut = new ReportWeek(LocalDate.of(2023, 2, 13), List.of(
-            new ReportDay(LocalDate.of(2023, 2, 13), Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 14), Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 15), Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 16), Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 17), Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 18), Map.of(userLocalId, PlannedWorkingHours.ZERO), Map.of(userLocalId, List.of()), Map.of())
+            new ReportDay(LocalDate.of(2023, 2, 13), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 14), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 15), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 16), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 17), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 18), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of())
         ));
 
         assertThat(sut.averageDayWorkDuration()).isEqualTo(WorkDuration.ZERO);
@@ -66,23 +68,23 @@ class ReportWeekTest {
         final LocalDate sunday = monday.plusDays(6);
 
         final ReportWeek sut = new ReportWeek(monday, List.of(
-            new ReportDay(monday, Map.of(user.localId(), PlannedWorkingHours.EIGHT), Map.of(user.localId(), List.of(
+            new ReportDay(monday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(monday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(monday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, Map.of(user.localId(), PlannedWorkingHours.EIGHT), Map.of(user.localId(), List.of(
+            new ReportDay(tuesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(tuesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(tuesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(wednesday, Map.of(user.localId(), PlannedWorkingHours.EIGHT), Map.of(user.localId(), List.of(
+            new ReportDay(wednesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, Map.of(user.localId(), PlannedWorkingHours.EIGHT), Map.of(user.localId(), List.of(
+            new ReportDay(thursday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, Map.of(user.localId(), PlannedWorkingHours.EIGHT), Map.of(user.localId(), List.of(
+            new ReportDay(friday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, Map.of(user.localId(), PlannedWorkingHours.ZERO), Map.of(user.localId(), List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(user.localId(), PlannedWorkingHours.ZERO), Map.of(user.localId(), List.of()), Map.of())
+            new ReportDay(saturday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of())
         ));
 
         final WorkDuration actual = sut.averageDayWorkDuration();

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekTest.java
@@ -68,23 +68,23 @@ class ReportWeekTest {
         final LocalDate sunday = monday.plusDays(6);
 
         final ReportWeek sut = new ReportWeek(monday, List.of(
-            new ReportDay(monday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(monday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(monday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(monday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(tuesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(tuesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(tuesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(wednesday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(wednesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(thursday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, Map.of(user.idComposite(), PlannedWorkingHours.EIGHT), Map.of(user.idComposite(), List.of(
+            new ReportDay(friday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(user.idComposite(), PlannedWorkingHours.ZERO), Map.of(user.idComposite(), List.of()), Map.of())
+            new ReportDay(saturday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
 
         final WorkDuration actual = sut.averageDayWorkDuration();

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryControllerTest.java
@@ -7,8 +7,10 @@ import de.focusshift.zeiterfassung.absence.DayLength;
 import de.focusshift.zeiterfassung.user.DateFormatter;
 import de.focusshift.zeiterfassung.user.MonthFormat;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.user.UserSettingsProvider;
 import de.focusshift.zeiterfassung.user.YearFormat;
+import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,10 +66,14 @@ class TimeEntryControllerTest {
     @Test
     void ensureTimeEntriesForYearAndWeekOfYear() throws Exception {
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
         final ZoneId zoneIdBerlin = ZoneId.of("Europe/Berlin");
         final ZonedDateTime expectedStart = ZonedDateTime.of(2022, 9, 22, 14, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime expectedEnd = ZonedDateTime.of(2022, 9, 22, 15, 0, 0, 0, zoneIdBerlin);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), new UserId("batman"), "hack the planet", expectedStart, expectedEnd, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hack the planet", expectedStart, expectedEnd, false);
         final ZonedDateTime absenceStart = ZonedDateTime.of(2022, 9, 22, 14, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime absenceEnd = ZonedDateTime.of(2022, 9, 22, 15, 0, 0, 0, zoneIdBerlin);
         final Absence absence = new Absence(new UserId("batman"), absenceStart, absenceEnd, DayLength.FULL, AbsenceType.HOLIDAY, AbsenceColor.BLUE);
@@ -146,10 +152,14 @@ class TimeEntryControllerTest {
     @Test
     void ensureTimeEntriesForYearAndWeekOfYearWithTurboFrame() throws Exception {
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
         final ZoneId zoneIdBerlin = ZoneId.of("Europe/Berlin");
         final ZonedDateTime expectedStart = ZonedDateTime.of(2022, 9, 22, 14, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime expectedEnd = ZonedDateTime.of(2022, 9, 22, 15, 0, 0, 0, zoneIdBerlin);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), new UserId("batman"), "hack the planet", expectedStart, expectedEnd, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hack the planet", expectedStart, expectedEnd, false);
 
         final TimeEntryDay timeEntryDay = new TimeEntryDay(LocalDate.of(2022, 9, 19), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());
         final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(LocalDate.of(2022, 9, 19), PlannedWorkingHours.EIGHT, List.of(timeEntryDay));
@@ -536,16 +546,20 @@ class TimeEntryControllerTest {
     @Test
     void ensureTimeEntryEditForAjax() throws Exception {
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
         final ZoneId zoneIdBerlin = ZoneId.of("Europe/Berlin");
         when(userSettingsProvider.zoneId()).thenReturn(zoneIdBerlin);
 
         final ZonedDateTime start = ZonedDateTime.of(2022, 9, 28, 20, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime end = ZonedDateTime.of(2022, 9, 28, 21, 15, 0, 0, zoneIdBerlin);
-        final TimeEntry timeEntryToEdit = new TimeEntry(new TimeEntryId(1337L), new UserId("batman"), "hard work extended", start, end, false);
+        final TimeEntry timeEntryToEdit = new TimeEntry(new TimeEntryId(1337L), userIdComposite, "hard work extended", start, end, false);
 
         final ZonedDateTime startOtherDay = ZonedDateTime.of(2022, 9, 29, 14, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime endOtherDay = ZonedDateTime.of(2022, 9, 29, 15, 0, 0, 0, zoneIdBerlin);
-        final TimeEntry timeEntryOtherDay = new TimeEntry(new TimeEntryId(1L), new UserId("batman"), "hack the planet", startOtherDay, endOtherDay, false);
+        final TimeEntry timeEntryOtherDay = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hack the planet", startOtherDay, endOtherDay, false);
 
         final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(
             LocalDate.of(2022, 9, 26),
@@ -659,11 +673,15 @@ class TimeEntryControllerTest {
     @Test
     void ensureTimeEntryEditWithValidationError() throws Exception {
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
         final ZoneId zoneIdBerlin = ZoneId.of("Europe/Berlin");
 
         final ZonedDateTime expectedStart = ZonedDateTime.of(2022, 9, 22, 14, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime expectedEnd = ZonedDateTime.of(2022, 9, 22, 15, 0, 0, 0, zoneIdBerlin);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), new UserId("batman"), "hack the planet", expectedStart, expectedEnd, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hack the planet", expectedStart, expectedEnd, false);
 
         final TimeEntryDay timeEntryDay = new TimeEntryDay(LocalDate.of(2022, 9, 19), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());
         final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(LocalDate.of(2022, 9, 19), PlannedWorkingHours.EIGHT, List.of(timeEntryDay));
@@ -748,11 +766,15 @@ class TimeEntryControllerTest {
     @Test
     void ensureDelete() throws Exception {
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
         final ZoneId zoneIdBerlin = ZoneId.of("Europe/Berlin");
 
         final ZonedDateTime start = ZonedDateTime.of(2022, 9, 28, 20, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime end = ZonedDateTime.of(2022, 9, 28, 21, 15, 0, 0, zoneIdBerlin);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1337L), new UserId("batman"), "hard work extended", start, end, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1337L), userIdComposite, "hard work extended", start, end, false);
 
         when(timeEntryService.findTimeEntry(1337)).thenReturn(Optional.of(timeEntry));
 
@@ -770,16 +792,19 @@ class TimeEntryControllerTest {
     @Test
     void ensureDeleteWithAjax() throws Exception {
 
-        final ZoneId zoneIdBerlin = ZoneId.of("Europe/Berlin");
         final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
+        final ZoneId zoneIdBerlin = ZoneId.of("Europe/Berlin");
 
         final ZonedDateTime start = ZonedDateTime.of(2022, 9, 28, 20, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime end = ZonedDateTime.of(2022, 9, 28, 21, 15, 0, 0, zoneIdBerlin);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work", start, end, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hard work", start, end, false);
 
         final ZonedDateTime start2 = ZonedDateTime.of(2022, 9, 28, 16, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime end2 = ZonedDateTime.of(2022, 9, 28, 17, 30, 0, 0, zoneIdBerlin);
-        final TimeEntry timeEntry2 = new TimeEntry(new TimeEntryId(2L), userId, "hack the planet", start2, end2, false);
+        final TimeEntry timeEntry2 = new TimeEntry(new TimeEntryId(2L), userIdComposite, "hack the planet", start2, end2, false);
 
         when(timeEntryService.findTimeEntry(1L)).thenReturn(Optional.of(timeEntry));
 
@@ -849,12 +874,15 @@ class TimeEntryControllerTest {
     @Test
     void ensureDeleteWithAjaxLastTimeEntryOfDay() throws Exception {
 
-        final ZoneId zoneIdBerlin = ZoneId.of("Europe/Berlin");
         final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
+        final ZoneId zoneIdBerlin = ZoneId.of("Europe/Berlin");
 
         final ZonedDateTime start = ZonedDateTime.of(2022, 9, 28, 20, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime end = ZonedDateTime.of(2022, 9, 28, 21, 15, 0, 0, zoneIdBerlin);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userId, "hard work", start, end, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hard work", start, end, false);
 
         when(timeEntryService.findTimeEntry(1L)).thenReturn(Optional.of(timeEntry));
 

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
@@ -90,11 +90,17 @@ class TimeEntryServiceImplTest {
 
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(entity));
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final Optional<TimeEntry> actual = sut.findTimeEntry(42L);
         assertThat(actual).isPresent();
         assertThat(actual.get()).satisfies(timeEntry -> {
             assertThat(timeEntry.id()).isEqualTo(new TimeEntryId(42L));
-            assertThat(timeEntry.userId()).isEqualTo(new UserId("batman"));
+            assertThat(timeEntry.userIdComposite()).isEqualTo(userIdComposite);
             assertThat(timeEntry.comment()).isEmpty();
             assertThat(timeEntry.start()).isEqualTo(ZonedDateTime.of(entryStart, ZONE_ID_UTC));
             assertThat(timeEntry.end()).isEqualTo(ZonedDateTime.of(entryEnd, ZONE_ID_UTC));
@@ -125,15 +131,21 @@ class TimeEntryServiceImplTest {
             return entity;
         });
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final TimeEntry actual = sut.createTimeEntry(
-            new UserId("batman"),
+            userId,
             "hard work",
             ZonedDateTime.of(entryStart, ZONE_ID_UTC),
             ZonedDateTime.of(entryEnd, ZONE_ID_UTC),
             false
         );
 
-        assertThat(actual).isEqualTo(new TimeEntry(new TimeEntryId(1L), new UserId("batman"), "hard work", ZonedDateTime.of(entryStart, ZONE_ID_UTC), ZonedDateTime.of(entryEnd, ZONE_ID_UTC), false));
+        assertThat(actual).isEqualTo(new TimeEntry(new TimeEntryId(1L), userIdComposite, "hard work", ZonedDateTime.of(entryStart, ZONE_ID_UTC), ZonedDateTime.of(entryEnd, ZONE_ID_UTC), false));
 
         final ArgumentCaptor<TimeEntryEntity> captor = ArgumentCaptor.forClass(TimeEntryEntity.class);
         verify(timeEntryRepository).save(captor.capture());
@@ -182,6 +194,12 @@ class TimeEntryServiceImplTest {
 
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(entity));
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         assertThatExceptionOfType(TimeEntryUpdateNotPlausibleException.class).isThrownBy(
             () -> sut.updateTimeEntry(new TimeEntryId(42L), "", now, now, duration, false)
         );
@@ -213,6 +231,12 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(existingEntity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final ZonedDateTime newStart = ZonedDateTime.ofInstant(entryStart.toInstant(UTC), ZONE_ID_UTC).plusMinutes(30);
         final ZonedDateTime sameEnd = ZonedDateTime.ofInstant(entryEnd.toInstant(UTC), ZONE_ID_UTC);
         final Duration sameDuration = Duration.ofHours(2);
@@ -220,7 +244,7 @@ class TimeEntryServiceImplTest {
         final TimeEntry actualUpdatedTimeEntry = sut.updateTimeEntry(new TimeEntryId(42L), "", newStart, sameEnd, sameDuration, false);
 
         assertThat(actualUpdatedTimeEntry.id()).isEqualTo(new TimeEntryId(42L));
-        assertThat(actualUpdatedTimeEntry.userId()).isEqualTo(new UserId("batman"));
+        assertThat(actualUpdatedTimeEntry.userIdComposite()).isEqualTo(userIdComposite);
         assertThat(actualUpdatedTimeEntry.comment()).isEmpty();
         assertThat(actualUpdatedTimeEntry.start()).isEqualTo(newStart);
         assertThat(actualUpdatedTimeEntry.end()).isEqualTo(sameEnd);
@@ -269,6 +293,12 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(existingEntity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final ZonedDateTime newStart = ZonedDateTime.ofInstant(entryStart.toInstant(UTC), ZONE_ID_UTC).minusMinutes(30);
         final ZonedDateTime newEnd = ZonedDateTime.ofInstant(entryEnd.toInstant(UTC), ZONE_ID_UTC).plusMinutes(30);
         final Duration sameDuration = Duration.ofHours(2);
@@ -276,7 +306,7 @@ class TimeEntryServiceImplTest {
         final TimeEntry actualUpdatedTimeEntry = sut.updateTimeEntry(new TimeEntryId(42L), "", newStart, newEnd, sameDuration, false);
 
         assertThat(actualUpdatedTimeEntry.id()).isEqualTo(new TimeEntryId(42L));
-        assertThat(actualUpdatedTimeEntry.userId()).isEqualTo(new UserId("batman"));
+        assertThat(actualUpdatedTimeEntry.userIdComposite()).isEqualTo(userIdComposite);
         assertThat(actualUpdatedTimeEntry.comment()).isEmpty();
         assertThat(actualUpdatedTimeEntry.start()).isEqualTo(newStart);
         assertThat(actualUpdatedTimeEntry.end()).isEqualTo(newEnd);
@@ -325,6 +355,12 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(existingEntity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final ZonedDateTime newStart = ZonedDateTime.ofInstant(entryStart.toInstant(UTC), ZONE_ID_UTC).minusMinutes(30);
         final ZonedDateTime sameEnd = ZonedDateTime.ofInstant(entryEnd.toInstant(UTC), ZONE_ID_UTC);
         final Duration newDuration = Duration.ofHours(3);
@@ -332,7 +368,7 @@ class TimeEntryServiceImplTest {
         final TimeEntry actualUpdatedTimeEntry = sut.updateTimeEntry(new TimeEntryId(42L), "", newStart, sameEnd, newDuration, false);
 
         assertThat(actualUpdatedTimeEntry.id()).isEqualTo(new TimeEntryId(42L));
-        assertThat(actualUpdatedTimeEntry.userId()).isEqualTo(new UserId("batman"));
+        assertThat(actualUpdatedTimeEntry.userIdComposite()).isEqualTo(userIdComposite);
         assertThat(actualUpdatedTimeEntry.comment()).isEmpty();
         assertThat(actualUpdatedTimeEntry.start()).isEqualTo(newStart);
         assertThat(actualUpdatedTimeEntry.end()).isEqualTo(newStart.plusHours(3));
@@ -381,6 +417,12 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(existingEntity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final ZonedDateTime sameStart = ZonedDateTime.ofInstant(entryStart.toInstant(UTC), ZONE_ID_UTC);
         final ZonedDateTime newEnd = ZonedDateTime.ofInstant(entryEnd.toInstant(UTC), ZONE_ID_UTC).minusMinutes(30);
         final Duration sameDuration = Duration.ofHours(2);
@@ -388,7 +430,7 @@ class TimeEntryServiceImplTest {
         final TimeEntry actualUpdatedTimeEntry = sut.updateTimeEntry(new TimeEntryId(42L), "", sameStart, newEnd, sameDuration, false);
 
         assertThat(actualUpdatedTimeEntry.id()).isEqualTo(new TimeEntryId(42L));
-        assertThat(actualUpdatedTimeEntry.userId()).isEqualTo(new UserId("batman"));
+        assertThat(actualUpdatedTimeEntry.userIdComposite()).isEqualTo(userIdComposite);
         assertThat(actualUpdatedTimeEntry.comment()).isEmpty();
         assertThat(actualUpdatedTimeEntry.start()).isEqualTo(sameStart);
         assertThat(actualUpdatedTimeEntry.end()).isEqualTo(newEnd);
@@ -437,6 +479,12 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(existingEntity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final ZonedDateTime sameStart = ZonedDateTime.ofInstant(entryStart.toInstant(UTC), ZONE_ID_UTC);
         final ZonedDateTime newEnd = ZonedDateTime.ofInstant(entryEnd.toInstant(UTC), ZONE_ID_UTC).minusMinutes(30);
         final Duration newDuration = Duration.ofHours(3);
@@ -444,7 +492,7 @@ class TimeEntryServiceImplTest {
         final TimeEntry actualUpdatedTimeEntry = sut.updateTimeEntry(new TimeEntryId(42L), "", sameStart, newEnd, newDuration, false);
 
         assertThat(actualUpdatedTimeEntry.id()).isEqualTo(new TimeEntryId(42L));
-        assertThat(actualUpdatedTimeEntry.userId()).isEqualTo(new UserId("batman"));
+        assertThat(actualUpdatedTimeEntry.userIdComposite()).isEqualTo(userIdComposite);
         assertThat(actualUpdatedTimeEntry.comment()).isEmpty();
         assertThat(actualUpdatedTimeEntry.start()).isEqualTo(newEnd.minusHours(3));
         assertThat(actualUpdatedTimeEntry.end()).isEqualTo(newEnd);
@@ -493,6 +541,12 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(existingEntity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final ZonedDateTime sameStart = ZonedDateTime.ofInstant(entryStart.toInstant(UTC), ZONE_ID_UTC);
         final ZonedDateTime sameEnd = ZonedDateTime.ofInstant(entryEnd.toInstant(UTC), ZONE_ID_UTC);
         final Duration newDuration = Duration.ofHours(4);
@@ -500,7 +554,7 @@ class TimeEntryServiceImplTest {
         final TimeEntry actualUpdatedTimeEntry = sut.updateTimeEntry(new TimeEntryId(42L), "", sameStart, sameEnd, newDuration, false);
 
         assertThat(actualUpdatedTimeEntry.id()).isEqualTo(new TimeEntryId(42L));
-        assertThat(actualUpdatedTimeEntry.userId()).isEqualTo(new UserId("batman"));
+        assertThat(actualUpdatedTimeEntry.userIdComposite()).isEqualTo(userIdComposite);
         assertThat(actualUpdatedTimeEntry.comment()).isEmpty();
         assertThat(actualUpdatedTimeEntry.start()).isEqualTo(sameStart);
         assertThat(actualUpdatedTimeEntry.end()).isEqualTo(sameStart.plusMinutes(newDuration.toMinutes()));
@@ -547,6 +601,12 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(entity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final ZonedDateTime newStart = previousStart.minusHours(1).atZone(ZONE_ID_UTC);
         final ZonedDateTime newEnd = previousEnd.plusHours(1).atZone(ZONE_ID_UTC);
         final Duration newDuration = Duration.ofHours(3);
@@ -554,7 +614,7 @@ class TimeEntryServiceImplTest {
         final TimeEntry actualUpdatedTimeEntry = sut.updateTimeEntry(new TimeEntryId(42L), "", newStart, newEnd, newDuration, false);
 
         assertThat(actualUpdatedTimeEntry.id()).isEqualTo(new TimeEntryId(42L));
-        assertThat(actualUpdatedTimeEntry.userId()).isEqualTo(new UserId("batman"));
+        assertThat(actualUpdatedTimeEntry.userIdComposite()).isEqualTo(userIdComposite);
         assertThat(actualUpdatedTimeEntry.comment()).isEmpty();
         assertThat(actualUpdatedTimeEntry.start()).isEqualTo(newStart);
         assertThat(actualUpdatedTimeEntry.end()).isEqualTo(newEnd);
@@ -601,6 +661,12 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(entity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final ZonedDateTime newEnd = previousEnd.plusHours(1).atZone(ZONE_ID_UTC);
         final Duration newDuration = Duration.ofHours(3);
 
@@ -641,6 +707,12 @@ class TimeEntryServiceImplTest {
 
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(entity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
+
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
 
         final ZonedDateTime newStart = previousStart.minusHours(1).atZone(ZONE_ID_UTC);
         final Duration newDuration = Duration.ofHours(3);
@@ -688,6 +760,12 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(entity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final ZonedDateTime newStart = previousStart.minusHours(1).atZone(ZONE_ID_UTC);
         final ZonedDateTime newEnd = previousEnd.plusHours(1).atZone(ZONE_ID_UTC);
 
@@ -729,6 +807,12 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findById(42L)).thenReturn(Optional.of(existingEntity));
         when(timeEntryRepository.save(any(TimeEntryEntity.class))).thenAnswer(returnsFirstArg());
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
         final ZonedDateTime sameStart = ZonedDateTime.ofInstant(entryStart.toInstant(UTC), ZONE_ID_UTC);
         final ZonedDateTime sameEnd = ZonedDateTime.ofInstant(entryEnd.toInstant(UTC), ZONE_ID_UTC);
         final Duration sameDuration = Duration.ofHours(2);
@@ -736,7 +820,7 @@ class TimeEntryServiceImplTest {
         final TimeEntry actualUpdatedTimeEntry = sut.updateTimeEntry(new TimeEntryId(42L), "", sameStart, sameEnd, sameDuration, true);
 
         assertThat(actualUpdatedTimeEntry.id()).isEqualTo(new TimeEntryId(42L));
-        assertThat(actualUpdatedTimeEntry.userId()).isEqualTo(new UserId("batman"));
+        assertThat(actualUpdatedTimeEntry.userIdComposite()).isEqualTo(userIdComposite);
         assertThat(actualUpdatedTimeEntry.comment()).isEmpty();
         assertThat(actualUpdatedTimeEntry.start()).isEqualTo(sameStart);
         assertThat(actualUpdatedTimeEntry.end()).isEqualTo(sameEnd);
@@ -787,11 +871,9 @@ class TimeEntryServiceImplTest {
 
         final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
         final User pinguin = new User(pinguinIdComposite, "ping", "uin", new EMailAddress("pinguin@example.org"), Set.of());
+        when(userManagementService.findAllUsers()).thenReturn(List.of(batman, pinguin));
 
-        when(userManagementService.findAllUsersByIds(Set.of(batmanId, pinguinId)))
-            .thenReturn(List.of(batman, pinguin));
-
-        final Map<UserLocalId, List<TimeEntry>> actual = sut.getEntriesForAllUsers(from, toExclusive);
+        final Map<UserIdComposite, List<TimeEntry>> actual = sut.getEntriesForAllUsers(from, toExclusive);
 
         final ZonedDateTime expectedStart = ZonedDateTime.of(entryStart, ZONE_ID_UTC);
         final ZonedDateTime expectedEnd = ZonedDateTime.of(entryEnd, ZONE_ID_UTC);
@@ -801,14 +883,14 @@ class TimeEntryServiceImplTest {
 
         assertThat(actual)
             .hasSize(2)
-            .hasEntrySatisfying(batmanLocalId, timeEntries -> {
+            .hasEntrySatisfying(batmanIdComposite, timeEntries -> {
                 assertThat(timeEntries).containsExactly(
-                    new TimeEntry(new TimeEntryId(1L), batmanId, "hard work", expectedStart, expectedEnd, false)
+                    new TimeEntry(new TimeEntryId(1L), batmanIdComposite, "hard work", expectedStart, expectedEnd, false)
                 );
             })
-            .hasEntrySatisfying(pinguinLocalId, timeEntries -> {
+            .hasEntrySatisfying(pinguinIdComposite, timeEntries -> {
                 assertThat(timeEntries).containsExactly(
-                    new TimeEntry(new TimeEntryId(2L), pinguinId, "deserved break", expectedBreakStart, expectedBreakEnd, true)
+                    new TimeEntry(new TimeEntryId(2L), pinguinIdComposite, "deserved break", expectedBreakStart, expectedBreakEnd, true)
                 );
             });
     }
@@ -844,7 +926,7 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThan(List.of("uuid-1", "uuid-2"), from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
             .thenReturn(List.of(timeEntryEntity, timeEntryBreakEntity));
 
-        final Map<UserLocalId, List<TimeEntry>> actual = sut.getEntriesByUserLocalIds(from, toExclusive, List.of(batmanLocalId, robinLocalId));
+        final Map<UserIdComposite, List<TimeEntry>> actual = sut.getEntriesByUserLocalIds(from, toExclusive, List.of(batmanLocalId, robinLocalId));
 
         final ZonedDateTime expectedStart = ZonedDateTime.of(entryStart, ZONE_ID_UTC);
         final ZonedDateTime expectedEnd = ZonedDateTime.of(entryEnd, ZONE_ID_UTC);
@@ -854,14 +936,14 @@ class TimeEntryServiceImplTest {
 
         assertThat(actual)
             .hasSize(2)
-            .hasEntrySatisfying(batmanLocalId, timeEntries -> {
+            .hasEntrySatisfying(batmanIdComposite, timeEntries -> {
                 assertThat(timeEntries).containsExactly(
-                    new TimeEntry(new TimeEntryId(1L), batmanId, "hard work", expectedStart, expectedEnd, false)
+                    new TimeEntry(new TimeEntryId(1L), batmanIdComposite, "hard work", expectedStart, expectedEnd, false)
                 );
             })
-            .hasEntrySatisfying(robinLocalId, timeEntries -> {
+            .hasEntrySatisfying(robinIdComposite, timeEntries -> {
                 assertThat(timeEntries).containsExactly(
-                    new TimeEntry(new TimeEntryId(2L), robinId, "deserved break", expectedBreakStart, expectedBreakEnd, true)
+                    new TimeEntry(new TimeEntryId(2L), robinIdComposite, "deserved break", expectedBreakStart, expectedBreakEnd, true)
                 );
             });
     }
@@ -869,21 +951,23 @@ class TimeEntryServiceImplTest {
     @Test
     void ensureGetEntriesByUserLocalIdsReturnsValuesForEveryAskedUserLocalId() {
 
-        final UserLocalId batmanLocalId = new UserLocalId(1L);
-
-        when(userManagementService.findAllUsersByLocalIds(List.of(batmanLocalId))).thenReturn(List.of());
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findAllUsersByLocalIds(List.of(userLocalId))).thenReturn(List.of(user));
 
         final LocalDate from = LocalDate.of(2023, 1, 1);
         final LocalDate toExclusive = LocalDate.of(2023, 2, 1);
 
-        when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThan(List.of(), from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
+        when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThan(List.of("batman"), from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
             .thenReturn(List.of());
 
-        final Map<UserLocalId, List<TimeEntry>> actual = sut.getEntriesByUserLocalIds(from, toExclusive, List.of(batmanLocalId));
+        final Map<UserIdComposite, List<TimeEntry>> actual = sut.getEntriesByUserLocalIds(from, toExclusive, List.of(userLocalId));
 
         assertThat(actual)
             .hasSize(1)
-            .hasEntrySatisfying(batmanLocalId, timeEntries -> {
+            .hasEntrySatisfying(userIdComposite, timeEntries -> {
                 assertThat(timeEntries).isEmpty();
             });
     }
@@ -911,7 +995,13 @@ class TimeEntryServiceImplTest {
         when(timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThan("batman", periodStartInstant, periodEndInstant))
             .thenReturn(List.of(timeEntryEntity, timeEntryBreakEntity, timeEntryEntity2));
 
-        final List<TimeEntry> actualEntries = sut.getEntries(periodFrom, periodToExclusive, new UserId("batman"));
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
+        final List<TimeEntry> actualEntries = sut.getEntries(periodFrom, periodToExclusive, userId);
 
         final ZonedDateTime expectedStart = ZonedDateTime.of(entryStart, ZONE_ID_UTC);
         final ZonedDateTime expectedEnd = ZonedDateTime.of(entryEnd, ZONE_ID_UTC);
@@ -923,9 +1013,9 @@ class TimeEntryServiceImplTest {
         final ZonedDateTime expectedEnd2 = ZonedDateTime.of(entryEnd2, ZONE_ID_UTC);
 
         assertThat(actualEntries).containsExactly(
-            new TimeEntry(new TimeEntryId(2L), new UserId("batman"), "deserved break", expectedBreakStart, expectedBreakEnd, true),
-            new TimeEntry(new TimeEntryId(1L), new UserId("batman"), "hard work", expectedStart, expectedEnd, false),
-            new TimeEntry(new TimeEntryId(3L), new UserId("batman"), "waking up *zzzz", expectedStart2, expectedEnd2, false)
+            new TimeEntry(new TimeEntryId(2L), userIdComposite, "deserved break", expectedBreakStart, expectedBreakEnd, true),
+            new TimeEntry(new TimeEntryId(1L), userIdComposite, "hard work", expectedStart, expectedEnd, false),
+            new TimeEntry(new TimeEntryId(3L), userIdComposite, "waking up *zzzz", expectedStart2, expectedEnd2, false)
         );
     }
 
@@ -1020,8 +1110,8 @@ class TimeEntryServiceImplTest {
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(
-                                new TimeEntry(new TimeEntryId(2L), batmanId, "deserved break", timeEntryBreakStart, timeEntryBreakEnd, true),
-                                new TimeEntry(new TimeEntryId(1L), batmanId, "hack the planet!", timeEntryStart, timeEntryEnd, false)
+                                new TimeEntry(new TimeEntryId(2L), batmanIdComposite, "deserved break", timeEntryBreakStart, timeEntryBreakEnd, true),
+                                new TimeEntry(new TimeEntryId(1L), batmanIdComposite, "hack the planet!", timeEntryStart, timeEntryEnd, false)
                             ),
                             List.of()
                         ),
@@ -1097,7 +1187,7 @@ class TimeEntryServiceImplTest {
                             PlannedWorkingHours.ZERO,
                             ShouldWorkingHours.ZERO,
                             List.of(
-                                new TimeEntry(new TimeEntryId(2L), batmanId, "hack the planet, second time!", lastDayOfWeekTimeEntryStart, lastDayOfWeekTimeEntryEnd, false)
+                                new TimeEntry(new TimeEntryId(2L), batmanIdComposite, "hack the planet, second time!", lastDayOfWeekTimeEntryStart, lastDayOfWeekTimeEntryEnd, false)
                             ),
                             List.of()
                         ),
@@ -1141,7 +1231,7 @@ class TimeEntryServiceImplTest {
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(
-                                new TimeEntry(new TimeEntryId(1L), batmanId, "hack the planet!", firstDayOfWeekTimeEntryStart, firstDayOfWeekTimeEntryEnd, false)
+                                new TimeEntry(new TimeEntryId(1L), batmanIdComposite, "hack the planet!", firstDayOfWeekTimeEntryStart, firstDayOfWeekTimeEntryEnd, false)
                             ),
                             List.of()
                         )

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryTest.java
@@ -1,6 +1,8 @@
 package de.focusshift.zeiterfassung.timeentry;
 
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
+import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -16,11 +18,9 @@ class TimeEntryTest {
     @Test
     void ensureWorkDurationIsZeroIfBreak() {
 
-        final UserId batman = new UserId("batman");
-
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), batman, "hard work", from, to, true);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), anyUserIdComposite(), "hard work", from, to, true);
 
         assertThat(timeEntry.workDuration().duration()).isEqualTo(Duration.ZERO);
     }
@@ -28,15 +28,18 @@ class TimeEntryTest {
     @Test
     void ensureWorkDurationIsCorrectItNotABreak() {
 
-        final UserId batman = new UserId("batman");
-
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), batman, "hard work", from, to, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), anyUserIdComposite(), "hard work", from, to, false);
 
         assertThat(timeEntry.workDuration().duration()).isEqualTo(Duration.ofHours(1));
     }
 
+    private UserIdComposite anyUserIdComposite() {
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        return new UserIdComposite(userId, userLocalId);
+    }
 
     private static ZonedDateTime dateTime(int year, int month, int dayOfMonth, int hour, int minute) {
         return ZonedDateTime.of(LocalDateTime.of(year, month, dayOfMonth, hour, minute), ZONE_ID_BERLIN);

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryWeekTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryWeekTest.java
@@ -1,6 +1,8 @@
 package de.focusshift.zeiterfassung.timeentry;
 
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
+import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -21,13 +23,17 @@ class TimeEntryWeekTest {
 
         final LocalDate startOfWeek = LocalDate.of(2022, 1, 4);
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
         final ZonedDateTime firstStart = ZonedDateTime.of(LocalDateTime.of(2022, 1, 4, 9, 0, 0), ZONE_ID_BERLIN);
         final ZonedDateTime firstEnd = ZonedDateTime.of(LocalDateTime.of(2022, 1, 4, 11, 30, 0), ZONE_ID_BERLIN);
-        final TimeEntry firstTimeEntry = new TimeEntry(new TimeEntryId(1L), new UserId("batman"), "hard work first day", firstStart, firstEnd, false);
+        final TimeEntry firstTimeEntry = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hard work first day", firstStart, firstEnd, false);
 
         final ZonedDateTime secondStart = ZonedDateTime.of(LocalDateTime.of(2022, 1, 5, 17, 15, 0), ZONE_ID_BERLIN);
         final ZonedDateTime secondEnd = ZonedDateTime.of(LocalDateTime.of(2022, 1, 5, 17, 30, 0), ZONE_ID_BERLIN);
-        final TimeEntry secondTimeEntry = new TimeEntry(new TimeEntryId(2L), new UserId("batman"), "hard work second day", secondStart, secondEnd, false);
+        final TimeEntry secondTimeEntry = new TimeEntry(new TimeEntryId(2L), userIdComposite, "hard work second day", secondStart, secondEnd, false);
 
         final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(startOfWeek, PlannedWorkingHours.EIGHT, List.of(new TimeEntryDay(startOfWeek, PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(firstTimeEntry, secondTimeEntry), List.of())));
 
@@ -40,10 +46,14 @@ class TimeEntryWeekTest {
 
         final LocalDate startOfWeek = LocalDate.of(2022, 1, 4);
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
         final ZonedDateTime start = ZonedDateTime.of(LocalDateTime.of(2022, 1, 9, 23, 0, 0), ZONE_ID_BERLIN);
         final ZonedDateTime end = ZonedDateTime.of(LocalDateTime.of(2022, 1, 10, 2, 0, 0), ZONE_ID_BERLIN);
 
-        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), new UserId("batman"), "hard work in the night", start, end, false);
+        final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hard work in the night", start, end, false);
 
         final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(startOfWeek, PlannedWorkingHours.EIGHT, List.of(new TimeEntryDay(startOfWeek, PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of())));
 

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountControllerTest.java
@@ -69,7 +69,7 @@ class OvertimeAccountControllerTest {
         final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanIdComposite, true, Duration.ofHours(10).plusMinutes(30));
         when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         final UserDto expectedSelectedUser = new UserDto(1337, "Bruce", "Wayne", "Bruce Wayne", "batman@example.org");
@@ -111,7 +111,7 @@ class OvertimeAccountControllerTest {
         final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanIdComposite, true, Duration.ofHours(10).plusMinutes(30));
         when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         perform(
@@ -137,7 +137,7 @@ class OvertimeAccountControllerTest {
         final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanIdComposite, true, Duration.ofHours(10).plusMinutes(30));
         when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         final UserDto expectedSelectedUser = new UserDto(1337, "Bruce", "Wayne", "Bruce Wayne", "batman@example.org");
@@ -171,7 +171,7 @@ class OvertimeAccountControllerTest {
         final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
         when(userManagementService.findAllUsers("awesome-query")).thenReturn(List.of(batman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanIdComposite, true, Duration.ofHours(10).plusMinutes(30));
         when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         perform(
@@ -194,7 +194,7 @@ class OvertimeAccountControllerTest {
         final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
         when(userManagementService.findAllUsers("awesome-query")).thenReturn(List.of(batman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanIdComposite, true, Duration.ofHours(10).plusMinutes(30));
         when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         perform(
@@ -223,7 +223,7 @@ class OvertimeAccountControllerTest {
         when(userManagementService.findAllUsers("super")).thenReturn(List.of(superman));
         when(userManagementService.findUserByLocalId(batmanLocalId)).thenReturn(Optional.of(batman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanIdComposite, true, Duration.ofHours(10).plusMinutes(30));
         when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         final UserDto expectedSelectedUser = new UserDto(1337, "Bruce", "Wayne", "Bruce Wayne", "batman@example.org");
@@ -259,7 +259,7 @@ class OvertimeAccountControllerTest {
         when(userManagementService.findAllUsers("super")).thenReturn(List.of(superman));
         when(userManagementService.findUserByLocalId(batmanLocalId)).thenReturn(Optional.of(batman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanIdComposite, true, Duration.ofHours(10).plusMinutes(30));
         when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         final UserDto expectedSelectedUser = new UserDto(1337, "Bruce", "Wayne", "Bruce Wayne", "batman@example.org");

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountControllerTest.java
@@ -2,6 +2,7 @@ package de.focusshift.zeiterfassung.usermanagement;
 
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.web.DoubleFormatter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,14 +57,20 @@ class OvertimeAccountControllerTest {
     @Test
     void ensureSimpleGet() throws Exception {
 
-        final UserLocalId batmanId = new UserLocalId(1337L);
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
 
-        final User batman = new User(new UserId("batman"), batmanId, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("superman"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId supermanId = new UserId("superman");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanId, true, Duration.ofHours(10).plusMinutes(30));
-        when(overtimeAccountService.getOvertimeAccount(batmanId)).thenReturn(overtimeAccount);
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         final UserDto expectedSelectedUser = new UserDto(1337, "Bruce", "Wayne", "Bruce Wayne", "batman@example.org");
 
@@ -92,14 +99,20 @@ class OvertimeAccountControllerTest {
     })
     void ensureSimpleGetAllowedToEditX(String authority, boolean editWorkingTime, boolean editOvertimeAccount) throws Exception {
 
-        final UserLocalId batmanId = new UserLocalId(1337L);
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
 
-        final User batman = new User(new UserId("batman"), batmanId, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("superman"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId supermanId = new UserId("superman");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanId, true, Duration.ofHours(10).plusMinutes(30));
-        when(overtimeAccountService.getOvertimeAccount(batmanId)).thenReturn(overtimeAccount);
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         perform(
             get("/users/1337/overtime-account")
@@ -112,14 +125,20 @@ class OvertimeAccountControllerTest {
     @Test
     void ensureSimpleGetWithJavaScript() throws Exception {
 
-        final UserLocalId batmanId = new UserLocalId(1337L);
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
 
-        final User batman = new User(new UserId("batman"), batmanId, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("superman"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId supermanId = new UserId("superman");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanId, true, Duration.ofHours(10).plusMinutes(30));
-        when(overtimeAccountService.getOvertimeAccount(batmanId)).thenReturn(overtimeAccount);
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         final UserDto expectedSelectedUser = new UserDto(1337, "Bruce", "Wayne", "Bruce Wayne", "batman@example.org");
 
@@ -145,13 +164,15 @@ class OvertimeAccountControllerTest {
     @Test
     void ensureSearch() throws Exception {
 
-        final UserLocalId batmanId = new UserLocalId(1337L);
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
 
-        final User batman = new User(new UserId("batman"), batmanId, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
         when(userManagementService.findAllUsers("awesome-query")).thenReturn(List.of(batman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanId, true, Duration.ofHours(10).plusMinutes(30));
-        when(overtimeAccountService.getOvertimeAccount(batmanId)).thenReturn(overtimeAccount);
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         perform(
             get("/users/1337/overtime-account")
@@ -166,13 +187,15 @@ class OvertimeAccountControllerTest {
     @Test
     void ensureSearchWithJavaScript() throws Exception {
 
-        final UserLocalId batmanId = new UserLocalId(1337L);
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
 
-        final User batman = new User(new UserId("batman"), batmanId, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
         when(userManagementService.findAllUsers("awesome-query")).thenReturn(List.of(batman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanId, true, Duration.ofHours(10).plusMinutes(30));
-        when(overtimeAccountService.getOvertimeAccount(batmanId)).thenReturn(overtimeAccount);
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         perform(
             get("/users/1337/overtime-account")
@@ -187,15 +210,21 @@ class OvertimeAccountControllerTest {
     @Test
     void ensureSearchWithSelectedUserNotInQuery() throws Exception {
 
-        final UserLocalId batmanId = new UserLocalId(1337L);
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
 
-        final User batman = new User(new UserId("batman"), batmanId, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("superman"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId supermanId = new UserId("superman");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("super")).thenReturn(List.of(superman));
-        when(userManagementService.findUserByLocalId(new UserLocalId(1337L))).thenReturn(Optional.of(batman));
+        when(userManagementService.findUserByLocalId(batmanLocalId)).thenReturn(Optional.of(batman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanId, true, Duration.ofHours(10).plusMinutes(30));
-        when(overtimeAccountService.getOvertimeAccount(batmanId)).thenReturn(overtimeAccount);
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         final UserDto expectedSelectedUser = new UserDto(1337, "Bruce", "Wayne", "Bruce Wayne", "batman@example.org");
 
@@ -217,15 +246,21 @@ class OvertimeAccountControllerTest {
     @Test
     void ensureSearchWithSelectedUserNotInQueryWithJavaScript() throws Exception {
 
-        final UserLocalId batmanId = new UserLocalId(1337L);
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
 
-        final User batman = new User(new UserId("batman"), batmanId, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("superman"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId supermanId = new UserId("superman");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("super")).thenReturn(List.of(superman));
-        when(userManagementService.findUserByLocalId(new UserLocalId(1337L))).thenReturn(Optional.of(batman));
+        when(userManagementService.findUserByLocalId(batmanLocalId)).thenReturn(Optional.of(batman));
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanId, true, Duration.ofHours(10).plusMinutes(30));
-        when(overtimeAccountService.getOvertimeAccount(batmanId)).thenReturn(overtimeAccount);
+        final OvertimeAccount overtimeAccount = new OvertimeAccount(batmanLocalId, true, Duration.ofHours(10).plusMinutes(30));
+        when(overtimeAccountService.getOvertimeAccount(batmanLocalId)).thenReturn(overtimeAccount);
 
         final UserDto expectedSelectedUser = new UserDto(1337, "Bruce", "Wayne", "Bruce Wayne", "batman@example.org");
 
@@ -281,10 +316,16 @@ class OvertimeAccountControllerTest {
     @Test
     void ensurePostWithValidationError() throws Exception {
 
-        final UserLocalId batmanId = new UserLocalId(1337L);
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
 
-        final User batman = new User(new UserId("batman"), batmanId, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("superman"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId supermanId = new UserId("superman");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         final UserDto expectedSelectedUser = new UserDto(1337, "Bruce", "Wayne", "Bruce Wayne", "batman@example.org");
@@ -318,8 +359,11 @@ class OvertimeAccountControllerTest {
     })
     void ensurePostWithValidationErrorAllowedToEditX(String authority, boolean editWorkingTime, boolean editOvertimeAccount) throws Exception {
 
-        final UserLocalId batmanId = new UserLocalId(1337L);
-        final User batman = new User(new UserId("batman"), batmanId, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman));
 
         perform(
@@ -335,10 +379,16 @@ class OvertimeAccountControllerTest {
     @Test
     void ensurePostWithValidationErrorWithJavaScript() throws Exception {
 
-        final UserLocalId batmanId = new UserLocalId(1337L);
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
 
-        final User batman = new User(new UserId("batman"), batmanId, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("superman"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId supermanId = new UserId("superman");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         final UserDto expectedSelectedUser = new UserDto(1337, "Bruce", "Wayne", "Bruce Wayne", "batman@example.org");

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountControllerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.format.support.FormattingConversionService;
@@ -25,7 +24,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -260,14 +258,7 @@ class OvertimeAccountControllerTest {
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/users/1337/overtime-account"));
 
-        final ArgumentCaptor<OvertimeAccount> captor = ArgumentCaptor.forClass(OvertimeAccount.class);
-        verify(overtimeAccountService).updateOvertimeAccount(captor.capture());
-
-        final OvertimeAccount actualOvertimeAccount = captor.getValue();
-        assertThat(actualOvertimeAccount).isNotNull();
-        assertThat(actualOvertimeAccount.getUserLocalId()).isEqualTo(new UserLocalId(1337L));
-        assertThat(actualOvertimeAccount.isAllowed()).isTrue();
-        assertThat(actualOvertimeAccount.getMaxAllowedOvertime()).hasValue(Duration.ofHours(5).plusMinutes(15));
+        verify(overtimeAccountService).updateOvertimeAccount(new UserLocalId(1337L), true, Duration.ofHours(5).plusMinutes(15));
     }
 
     @ParameterizedTest
@@ -284,14 +275,7 @@ class OvertimeAccountControllerTest {
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/users/1337/overtime-account"));
 
-        final ArgumentCaptor<OvertimeAccount> captor = ArgumentCaptor.forClass(OvertimeAccount.class);
-        verify(overtimeAccountService).updateOvertimeAccount(captor.capture());
-
-        final OvertimeAccount actualOvertimeAccount = captor.getValue();
-        assertThat(actualOvertimeAccount).isNotNull();
-        assertThat(actualOvertimeAccount.getUserLocalId()).isEqualTo(new UserLocalId(1337L));
-        assertThat(actualOvertimeAccount.isAllowed()).isTrue();
-        assertThat(actualOvertimeAccount.getMaxAllowedOvertime()).hasValue(Duration.ofHours(5).plusMinutes(15));
+        verify(overtimeAccountService).updateOvertimeAccount(new UserLocalId(1337L), true, Duration.ofHours(5).plusMinutes(15));
     }
 
     @Test

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImplTest.java
@@ -54,7 +54,7 @@ class OvertimeAccountServiceImplTest {
         final OvertimeAccount overtimeAccount = sut.getOvertimeAccount(userLocalId);
 
         assertThat(overtimeAccount).isNotNull();
-        assertThat(overtimeAccount.getUserIdComposite()).isEqualTo(userIdComposite);
+        assertThat(overtimeAccount.userIdComposite()).isEqualTo(userIdComposite);
         assertThat(overtimeAccount.isAllowed()).isTrue();
         assertThat(overtimeAccount.getMaxAllowedOvertime()).hasValue(Duration.ofHours(1337));
     }
@@ -73,7 +73,7 @@ class OvertimeAccountServiceImplTest {
         final OvertimeAccount overtimeAccount = sut.getOvertimeAccount(userLocalId);
 
         assertThat(overtimeAccount).isNotNull();
-        assertThat(overtimeAccount.getUserIdComposite()).isEqualTo(userIdComposite);
+        assertThat(overtimeAccount.userIdComposite()).isEqualTo(userIdComposite);
         assertThat(overtimeAccount.isAllowed()).isTrue();
         assertThat(overtimeAccount.getMaxAllowedOvertime()).isEmpty();
     }
@@ -97,7 +97,7 @@ class OvertimeAccountServiceImplTest {
 
         final OvertimeAccount actualUpdatedOvertimeAccount = sut.updateOvertimeAccount(userLocalId, false, Duration.ofHours(10));
 
-        assertThat(actualUpdatedOvertimeAccount.getUserIdComposite()).isEqualTo(userIdComposite);
+        assertThat(actualUpdatedOvertimeAccount.userIdComposite()).isEqualTo(userIdComposite);
 
         final ArgumentCaptor<OvertimeAccountEntity> captor = ArgumentCaptor.forClass(OvertimeAccountEntity.class);
         verify(repository).save(captor.capture());
@@ -126,7 +126,7 @@ class OvertimeAccountServiceImplTest {
 
         final OvertimeAccount actualUpdatedOvertimeAccount = sut.updateOvertimeAccount(userLocalId, false, null);
 
-        assertThat(actualUpdatedOvertimeAccount.getUserIdComposite()).isEqualTo(userIdComposite);
+        assertThat(actualUpdatedOvertimeAccount.userIdComposite()).isEqualTo(userIdComposite);
 
         final ArgumentCaptor<OvertimeAccountEntity> captor = ArgumentCaptor.forClass(OvertimeAccountEntity.class);
         verify(repository).save(captor.capture());
@@ -149,7 +149,7 @@ class OvertimeAccountServiceImplTest {
 
         final OvertimeAccount actualUpdatedOvertime = sut.updateOvertimeAccount(userLocalId, false, Duration.ofHours(10));
 
-        assertThat(actualUpdatedOvertime.getUserIdComposite()).isEqualTo(userIdComposite);
+        assertThat(actualUpdatedOvertime.userIdComposite()).isEqualTo(userIdComposite);
 
         final ArgumentCaptor<OvertimeAccountEntity> captor = ArgumentCaptor.forClass(OvertimeAccountEntity.class);
         verify(repository).save(captor.capture());

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImplTest.java
@@ -71,9 +71,7 @@ class OvertimeAccountServiceImplTest {
         when(repository.findById(42L)).thenReturn(Optional.of(existingEntity));
         when(repository.save(any())).thenAnswer(returnsFirstArg());
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(new UserLocalId(42L), false, Duration.ofHours(10));
-
-        sut.updateOvertimeAccount(overtimeAccount);
+        sut.updateOvertimeAccount(new UserLocalId(42L), false, Duration.ofHours(10));
 
         final ArgumentCaptor<OvertimeAccountEntity> captor = ArgumentCaptor.forClass(OvertimeAccountEntity.class);
         verify(repository).save(captor.capture());
@@ -94,9 +92,7 @@ class OvertimeAccountServiceImplTest {
         when(repository.findById(42L)).thenReturn(Optional.of(existingEntity));
         when(repository.save(any())).thenAnswer(returnsFirstArg());
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(new UserLocalId(42L), false);
-
-        sut.updateOvertimeAccount(overtimeAccount);
+        sut.updateOvertimeAccount(new UserLocalId(42L), false, null);
 
         final ArgumentCaptor<OvertimeAccountEntity> captor = ArgumentCaptor.forClass(OvertimeAccountEntity.class);
         verify(repository).save(captor.capture());
@@ -111,9 +107,7 @@ class OvertimeAccountServiceImplTest {
         when(repository.findById(42L)).thenReturn(Optional.empty());
         when(repository.save(any())).thenAnswer(returnsFirstArg());
 
-        final OvertimeAccount overtimeAccount = new OvertimeAccount(new UserLocalId(42L), false, Duration.ofHours(10));
-
-        sut.updateOvertimeAccount(overtimeAccount);
+        sut.updateOvertimeAccount(new UserLocalId(42L), false, Duration.ofHours(10));
 
         final ArgumentCaptor<OvertimeAccountEntity> captor = ArgumentCaptor.forClass(OvertimeAccountEntity.class);
         verify(repository).save(captor.capture());

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/OvertimeAccountServiceImplTest.java
@@ -1,5 +1,8 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
+import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
+import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
@@ -23,26 +27,34 @@ class OvertimeAccountServiceImplTest {
 
     @Mock
     private OvertimeAccountRepository repository;
+    @Mock
+    private UserManagementService userManagementService;
 
     @BeforeEach
     void setUp() {
-        sut = new OvertimeAccountServiceImpl(repository);
+        sut = new OvertimeAccountServiceImpl(repository, userManagementService);
     }
 
     @Test
     void ensureGetOvertimeAccount() {
 
+        final UserId userId = new UserId("uuid-1");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user_1 = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserByLocalId(userLocalId)).thenReturn(Optional.of(user_1));
+
         final OvertimeAccountEntity entity = new OvertimeAccountEntity();
-        entity.setUserId(42L);
+        entity.setUserId(userLocalId.value());
         entity.setAllowed(true);
         entity.setMaxAllowedOvertime("PT1337H");
 
-        when(repository.findById(42L)).thenReturn(Optional.of(entity));
+        when(repository.findById(userLocalId.value())).thenReturn(Optional.of(entity));
 
-        final OvertimeAccount overtimeAccount = sut.getOvertimeAccount(new UserLocalId(42L));
+        final OvertimeAccount overtimeAccount = sut.getOvertimeAccount(userLocalId);
 
         assertThat(overtimeAccount).isNotNull();
-        assertThat(overtimeAccount.getUserLocalId()).isEqualTo(new UserLocalId(42L));
+        assertThat(overtimeAccount.getUserIdComposite()).isEqualTo(userIdComposite);
         assertThat(overtimeAccount.isAllowed()).isTrue();
         assertThat(overtimeAccount.getMaxAllowedOvertime()).hasValue(Duration.ofHours(1337));
     }
@@ -50,12 +62,18 @@ class OvertimeAccountServiceImplTest {
     @Test
     void ensureGetOvertimeAccountReturnsDefaultWhenNothingExistsInDatabase() {
 
-        when(repository.findById(42L)).thenReturn(Optional.empty());
+        final UserId userId = new UserId("uuid-1");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user_1 = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserByLocalId(userLocalId)).thenReturn(Optional.of(user_1));
 
-        final OvertimeAccount overtimeAccount = sut.getOvertimeAccount(new UserLocalId(42L));
+        when(repository.findById(userLocalId.value())).thenReturn(Optional.empty());
+
+        final OvertimeAccount overtimeAccount = sut.getOvertimeAccount(userLocalId);
 
         assertThat(overtimeAccount).isNotNull();
-        assertThat(overtimeAccount.getUserLocalId()).isEqualTo(new UserLocalId(42L));
+        assertThat(overtimeAccount.getUserIdComposite()).isEqualTo(userIdComposite);
         assertThat(overtimeAccount.isAllowed()).isTrue();
         assertThat(overtimeAccount.getMaxAllowedOvertime()).isEmpty();
     }
@@ -63,22 +81,30 @@ class OvertimeAccountServiceImplTest {
     @Test
     void ensureUpdateOvertimeAccount() {
 
+        final UserId userId = new UserId("uuid-1");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user_1 = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserByLocalId(userLocalId)).thenReturn(Optional.of(user_1));
+
         final OvertimeAccountEntity existingEntity = new OvertimeAccountEntity();
-        existingEntity.setUserId(42L);
+        existingEntity.setUserId(userLocalId.value());
         existingEntity.setAllowed(true);
         existingEntity.setMaxAllowedOvertime("PT1337H");
 
-        when(repository.findById(42L)).thenReturn(Optional.of(existingEntity));
+        when(repository.findById(userLocalId.value())).thenReturn(Optional.of(existingEntity));
         when(repository.save(any())).thenAnswer(returnsFirstArg());
 
-        sut.updateOvertimeAccount(new UserLocalId(42L), false, Duration.ofHours(10));
+        final OvertimeAccount actualUpdatedOvertimeAccount = sut.updateOvertimeAccount(userLocalId, false, Duration.ofHours(10));
+
+        assertThat(actualUpdatedOvertimeAccount.getUserIdComposite()).isEqualTo(userIdComposite);
 
         final ArgumentCaptor<OvertimeAccountEntity> captor = ArgumentCaptor.forClass(OvertimeAccountEntity.class);
         verify(repository).save(captor.capture());
 
         final OvertimeAccountEntity actualPersisted = captor.getValue();
         assertThat(actualPersisted).isNotNull();
-        assertThat(actualPersisted.getUserId()).isEqualTo(42L);
+        assertThat(actualPersisted.getUserId()).isEqualTo(1L);
         assertThat(actualPersisted.isAllowed()).isFalse();
         assertThat(actualPersisted.getMaxAllowedOvertime()).isEqualTo("PT10H");
     }
@@ -86,13 +112,21 @@ class OvertimeAccountServiceImplTest {
     @Test
     void ensureUpdateOvertimeAccountWithoutMaxAllowedOvertime() {
 
+        final UserId userId = new UserId("uuid-1");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user_1 = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserByLocalId(userLocalId)).thenReturn(Optional.of(user_1));
+
         final OvertimeAccountEntity existingEntity = new OvertimeAccountEntity();
         existingEntity.setMaxAllowedOvertime("PT1337H");
 
-        when(repository.findById(42L)).thenReturn(Optional.of(existingEntity));
+        when(repository.findById(userLocalId.value())).thenReturn(Optional.of(existingEntity));
         when(repository.save(any())).thenAnswer(returnsFirstArg());
 
-        sut.updateOvertimeAccount(new UserLocalId(42L), false, null);
+        final OvertimeAccount actualUpdatedOvertimeAccount = sut.updateOvertimeAccount(userLocalId, false, null);
+
+        assertThat(actualUpdatedOvertimeAccount.getUserIdComposite()).isEqualTo(userIdComposite);
 
         final ArgumentCaptor<OvertimeAccountEntity> captor = ArgumentCaptor.forClass(OvertimeAccountEntity.class);
         verify(repository).save(captor.capture());
@@ -104,17 +138,25 @@ class OvertimeAccountServiceImplTest {
     @Test
     void ensureUpdateOvertimeAccountWhenNothingExistsInDatabaseYet() {
 
-        when(repository.findById(42L)).thenReturn(Optional.empty());
+        final UserId userId = new UserId("uuid-1");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user_1 = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserByLocalId(userLocalId)).thenReturn(Optional.of(user_1));
+
+        when(repository.findById(userLocalId.value())).thenReturn(Optional.empty());
         when(repository.save(any())).thenAnswer(returnsFirstArg());
 
-        sut.updateOvertimeAccount(new UserLocalId(42L), false, Duration.ofHours(10));
+        final OvertimeAccount actualUpdatedOvertime = sut.updateOvertimeAccount(userLocalId, false, Duration.ofHours(10));
+
+        assertThat(actualUpdatedOvertime.getUserIdComposite()).isEqualTo(userIdComposite);
 
         final ArgumentCaptor<OvertimeAccountEntity> captor = ArgumentCaptor.forClass(OvertimeAccountEntity.class);
         verify(repository).save(captor.capture());
 
         final OvertimeAccountEntity actualPersisted = captor.getValue();
         assertThat(actualPersisted).isNotNull();
-        assertThat(actualPersisted.getUserId()).isEqualTo(42L);
+        assertThat(actualPersisted.getUserId()).isEqualTo(1L);
         assertThat(actualPersisted.isAllowed()).isFalse();
         assertThat(actualPersisted.getMaxAllowedOvertime()).isEqualTo("PT10H");
     }

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/UserManagementControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/UserManagementControllerTest.java
@@ -2,6 +2,7 @@ package de.focusshift.zeiterfassung.usermanagement;
 
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,8 +45,16 @@ class UserManagementControllerTest {
     @Test
     void ensureUsers() throws Exception {
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final UserId supermanId = new UserId("uuid-2");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         perform(
@@ -66,8 +75,16 @@ class UserManagementControllerTest {
     @Test
     void ensureUsersWithJavaScript() throws Exception {
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final UserId supermanId = new UserId("uuid-2");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         perform(
@@ -89,7 +106,10 @@ class UserManagementControllerTest {
     @Test
     void ensureUsersSearch() throws Exception {
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
         when(userManagementService.findAllUsers("bat")).thenReturn(List.of(batman));
 
         perform(
@@ -110,7 +130,10 @@ class UserManagementControllerTest {
     @Test
     void ensureUsersSearchWithJavaScript() throws Exception {
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
         when(userManagementService.findAllUsers("bat")).thenReturn(List.of(batman));
 
         perform(

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/UserManagementServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/UserManagementServiceImplTest.java
@@ -4,6 +4,7 @@ import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.tenancy.user.TenantUser;
 import de.focusshift.zeiterfassung.tenancy.user.TenantUserService;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,16 +44,17 @@ class UserManagementServiceImplTest {
     @Test
     void ensureFindUserById() {
 
-        final UserId id = new UserId("user-id");
-        final UserLocalId localId = new UserLocalId(42L);
+        final UserId userId = new UserId("user-id");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
         final EMailAddress email = new EMailAddress("mail@example.org");
 
-        final TenantUser tenantUser = new TenantUser(id.value(), localId.value(), "givenName", "familyName", email, Set.of());
-        final User user = new User(id, localId, "givenName", "familyName", email, Set.of());
+        final TenantUser tenantUser = new TenantUser(userId.value(), userLocalId.value(), "givenName", "familyName", email, Set.of());
+        final User user = new User(userIdComposite, "givenName", "familyName", email, Set.of());
 
-        when(tenantUserService.findById(new UserId("user-id"))).thenReturn(Optional.of(tenantUser));
+        when(tenantUserService.findById(userId)).thenReturn(Optional.of(tenantUser));
 
-        final Optional<User> actual = sut.findUserById(new UserId("user-id"));
+        final Optional<User> actual = sut.findUserById(userId);
 
         assertThat(actual)
             .isPresent()
@@ -71,16 +73,17 @@ class UserManagementServiceImplTest {
     @Test
     void ensureFindUserByLocalId() {
 
-        final UserId id = new UserId("user-id");
-        final UserLocalId localId = new UserLocalId(42L);
+        final UserId userId = new UserId("user-id");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
         final EMailAddress email = new EMailAddress("mail@example.org");
 
-        final TenantUser tenantUser = new TenantUser(id.value(), localId.value(), "givenName", "familyName", email, Set.of());
-        final User user = new User(id, localId, "givenName", "familyName", email, Set.of());
+        final TenantUser tenantUser = new TenantUser(userId.value(), userLocalId.value(), "givenName", "familyName", email, Set.of());
+        final User user = new User(userIdComposite, "givenName", "familyName", email, Set.of());
 
-        when(tenantUserService.findByLocalId(new UserLocalId(42L))).thenReturn(Optional.of(tenantUser));
+        when(tenantUserService.findByLocalId(userLocalId)).thenReturn(Optional.of(tenantUser));
 
-        final Optional<User> actual = sut.findUserByLocalId(new UserLocalId(42L));
+        final Optional<User> actual = sut.findUserByLocalId(userLocalId);
 
         assertThat(actual)
             .isPresent()
@@ -99,19 +102,21 @@ class UserManagementServiceImplTest {
     @Test
     void ensureFindAllUsersWithQuery() {
 
-        final UserId id = new UserId("user-id");
-        final UserLocalId localId = new UserLocalId(42L);
+        final UserId userId_1 = new UserId("user-id");
+        final UserLocalId userLocalId_1 = new UserLocalId(42L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
         final EMailAddress email = new EMailAddress("mail@example.org");
 
-        final TenantUser tenantUser = new TenantUser(id.value(), localId.value(), "givenName", "familyName", email, Set.of());
-        final User user = new User(id, localId, "givenName", "familyName", email, Set.of());
+        final TenantUser tenantUser = new TenantUser(userId_1.value(), userLocalId_1.value(), "givenName", "familyName", email, Set.of());
+        final User user = new User(userIdComposite_1, "givenName", "familyName", email, Set.of());
 
-        final UserId id2 = new UserId("user-id-2");
-        final UserLocalId localId2 = new UserLocalId(1337L);
+        final UserId userId_2 = new UserId("user-id-2");
+        final UserLocalId userLocalId_2 = new UserLocalId(1337L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
         final EMailAddress email2 = new EMailAddress("mail-2@example.org");
 
-        final TenantUser tenantUser2 = new TenantUser(id2.value(), localId2.value(), "givenName-2", "familyName-2", email2, Set.of());
-        final User user2 = new User(id2, localId2, "givenName-2", "familyName-2", email2, Set.of());
+        final TenantUser tenantUser2 = new TenantUser(userId_2.value(), userLocalId_2.value(), "givenName-2", "familyName-2", email2, Set.of());
+        final User user2 = new User(userIdComposite_2, "givenName-2", "familyName-2", email2, Set.of());
 
         when(tenantUserService.findAllUsers("batman")).thenReturn(List.of(tenantUser, tenantUser2));
 
@@ -133,23 +138,25 @@ class UserManagementServiceImplTest {
     @Test
     void ensureFindAllByIds() {
 
-        final UserId id = new UserId("user-id");
-        final UserLocalId localId = new UserLocalId(42L);
+        final UserId userId_1 = new UserId("user-id");
+        final UserLocalId userLocalId_1 = new UserLocalId(42L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
         final EMailAddress email = new EMailAddress("mail@example.org");
 
-        final TenantUser tenantUser = new TenantUser(id.value(), localId.value(), "givenName", "familyName", email, Set.of());
-        final User user = new User(id, localId, "givenName", "familyName", email, Set.of());
+        final TenantUser tenantUser = new TenantUser(userId_1.value(), userLocalId_1.value(), "givenName", "familyName", email, Set.of());
+        final User user = new User(userIdComposite_1, "givenName", "familyName", email, Set.of());
 
-        final UserId id2 = new UserId("user-id-2");
-        final UserLocalId localId2 = new UserLocalId(1337L);
+        final UserId userId_2 = new UserId("user-id-2");
+        final UserLocalId userLocalId_2 = new UserLocalId(1337L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
         final EMailAddress email2 = new EMailAddress("mail-2@example.org");
 
-        final TenantUser tenantUser2 = new TenantUser(id2.value(), localId2.value(), "givenName-2", "familyName-2", email2, Set.of());
-        final User user2 = new User(id2, localId2, "givenName-2", "familyName-2", email2, Set.of());
+        final TenantUser tenantUser2 = new TenantUser(userId_2.value(), userLocalId_2.value(), "givenName-2", "familyName-2", email2, Set.of());
+        final User user2 = new User(userIdComposite_2, "givenName-2", "familyName-2", email2, Set.of());
 
-        when(tenantUserService.findAllUsersById(List.of(id, id2))).thenReturn(List.of(tenantUser, tenantUser2));
+        when(tenantUserService.findAllUsersById(List.of(userId_1, userId_2))).thenReturn(List.of(tenantUser, tenantUser2));
 
-        final List<User> actual = sut.findAllUsersByIds(List.of(id, id2));
+        final List<User> actual = sut.findAllUsersByIds(List.of(userId_1, userId_2));
         assertThat(actual).containsExactly(user, user2);
     }
 
@@ -167,46 +174,48 @@ class UserManagementServiceImplTest {
     @Test
     void ensureFindAllByLocalIds() {
 
-        final UserId id = new UserId("user-id");
-        final UserLocalId localId = new UserLocalId(42L);
+        final UserId userId_1 = new UserId("user-id");
+        final UserLocalId userLocalId_1 = new UserLocalId(42L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
         final EMailAddress email = new EMailAddress("mail@example.org");
 
-        final TenantUser tenantUser = new TenantUser(id.value(), localId.value(), "givenName", "familyName", email, Set.of());
-        final User user = new User(id, localId, "givenName", "familyName", email, Set.of());
+        final TenantUser tenantUser = new TenantUser(userId_1.value(), userLocalId_1.value(), "givenName", "familyName", email, Set.of());
+        final User user = new User(userIdComposite_1, "givenName", "familyName", email, Set.of());
 
-        final UserId id2 = new UserId("user-id-2");
-        final UserLocalId localId2 = new UserLocalId(1337L);
+        final UserId userId_2 = new UserId("user-id-2");
+        final UserLocalId userLocalId_2 = new UserLocalId(1337L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
         final EMailAddress email2 = new EMailAddress("mail-2@example.org");
 
-        final TenantUser tenantUser2 = new TenantUser(id2.value(), localId2.value(), "givenName-2", "familyName-2", email2, Set.of());
-        final User user2 = new User(id2, localId2, "givenName-2", "familyName-2", email2, Set.of());
+        final TenantUser tenantUser2 = new TenantUser(userId_2.value(), userLocalId_2.value(), "givenName-2", "familyName-2", email2, Set.of());
+        final User user2 = new User(userIdComposite_2, "givenName-2", "familyName-2", email2, Set.of());
 
-        when(tenantUserService.findAllUsersByLocalId(List.of(localId, localId2))).thenReturn(List.of(tenantUser, tenantUser2));
+        when(tenantUserService.findAllUsersByLocalId(List.of(userLocalId_1, userLocalId_2))).thenReturn(List.of(tenantUser, tenantUser2));
 
-        final List<User> actual = sut.findAllUsersByLocalIds((List.of(localId, localId2)));
+        final List<User> actual = sut.findAllUsersByLocalIds((List.of(userLocalId_1, userLocalId_2)));
         assertThat(actual).containsExactly(user, user2);
     }
 
     @Test
     void ensureFindAllUserLocalIdsGroupedByUserId() {
 
-        final UserId id_1 = new UserId("user-id");
-        final UserLocalId localId_1 = new UserLocalId(42L);
+        final UserId userId_1 = new UserId("user-id");
+        final UserLocalId userLocalId_1 = new UserLocalId(42L);
         final EMailAddress email_1 = new EMailAddress("mail@example.org");
 
-        final UserId id_2 = new UserId("user-id-2");
-        final UserLocalId localId_2 = new UserLocalId(1337L);
+        final UserId userId_2 = new UserId("user-id-2");
+        final UserLocalId userLocalId_2 = new UserLocalId(1337L);
         final EMailAddress email_2 = new EMailAddress("mail-2@example.org");
 
-        final TenantUser tenantUser_1 = new TenantUser(id_1.value(), localId_1.value(), "givenName", "familyName", email_1, Set.of());
-        final TenantUser tenantUser_2 = new TenantUser(id_2.value(), localId_2.value(), "givenName-2", "familyName-2", email_2, Set.of());
+        final TenantUser tenantUser_1 = new TenantUser(userId_1.value(), userLocalId_1.value(), "givenName", "familyName", email_1, Set.of());
+        final TenantUser tenantUser_2 = new TenantUser(userId_2.value(), userLocalId_2.value(), "givenName-2", "familyName-2", email_2, Set.of());
 
         when(tenantUserService.findAllUsers()).thenReturn(List.of(tenantUser_1, tenantUser_2));
 
         final Map<UserId, UserLocalId> actual = sut.findAllUserLocalIdsGroupedByUserId();
         assertThat(actual).containsExactlyInAnyOrderEntriesOf(Map.of(
-            id_1, localId_1,
-            id_2, localId_2
+            userId_1, userLocalId_1,
+            userId_2, userLocalId_2
         ));
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/UserManagementServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/UserManagementServiceImplTest.java
@@ -12,7 +12,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -194,28 +193,5 @@ class UserManagementServiceImplTest {
 
         final List<User> actual = sut.findAllUsersByLocalIds((List.of(userLocalId_1, userLocalId_2)));
         assertThat(actual).containsExactly(user, user2);
-    }
-
-    @Test
-    void ensureFindAllUserLocalIdsGroupedByUserId() {
-
-        final UserId userId_1 = new UserId("user-id");
-        final UserLocalId userLocalId_1 = new UserLocalId(42L);
-        final EMailAddress email_1 = new EMailAddress("mail@example.org");
-
-        final UserId userId_2 = new UserId("user-id-2");
-        final UserLocalId userLocalId_2 = new UserLocalId(1337L);
-        final EMailAddress email_2 = new EMailAddress("mail-2@example.org");
-
-        final TenantUser tenantUser_1 = new TenantUser(userId_1.value(), userLocalId_1.value(), "givenName", "familyName", email_1, Set.of());
-        final TenantUser tenantUser_2 = new TenantUser(userId_2.value(), userLocalId_2.value(), "givenName-2", "familyName-2", email_2, Set.of());
-
-        when(tenantUserService.findAllUsers()).thenReturn(List.of(tenantUser_1, tenantUser_2));
-
-        final Map<UserId, UserLocalId> actual = sut.findAllUserLocalIdsGroupedByUserId();
-        assertThat(actual).containsExactlyInAnyOrderEntriesOf(Map.of(
-            userId_1, userLocalId_1,
-            userId_2, userLocalId_2
-        ));
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImplTest.java
@@ -307,8 +307,7 @@ class WorkTimeServiceImplTest {
         when(workingTimeRepository.findByUserId(42L)).thenReturn(Optional.of(entity));
         when(workingTimeRepository.save(any())).thenAnswer(returnsFirstArg());
 
-        final WorkingTime workingTime = WorkingTime.builder()
-            .userId(new UserLocalId(42L))
+        final WorkWeekUpdate workWeekUpdate = WorkWeekUpdate.builder()
             .monday(BigDecimal.valueOf(1))
             .tuesday(BigDecimal.valueOf(2))
             .wednesday(BigDecimal.valueOf(3))
@@ -318,9 +317,8 @@ class WorkTimeServiceImplTest {
             .sunday(BigDecimal.valueOf(7))
             .build();
 
-        final WorkingTime actual = sut.updateWorkingTime(workingTime);
+        final WorkingTime actual = sut.updateWorkingTime(new UserLocalId(42L), workWeekUpdate);
 
-        assertThat(actual).isNotSameAs(workingTime);
         assertThat(actual.getUserId()).isEqualTo(new UserLocalId(42L));
         assertThat(actual.getMonday()).hasValue(WorkDay.monday(Duration.ofHours(1)));
         assertThat(actual.getTuesday()).hasValue(WorkDay.tuesday(Duration.ofHours(2)));
@@ -350,8 +348,7 @@ class WorkTimeServiceImplTest {
         when(workingTimeRepository.findByUserId(42L)).thenReturn(Optional.empty());
         when(workingTimeRepository.save(any())).thenAnswer(returnsFirstArg());
 
-        final WorkingTime workingTime = WorkingTime.builder()
-            .userId(new UserLocalId(42L))
+        final WorkWeekUpdate workWeekUpdate = WorkWeekUpdate.builder()
             .monday(BigDecimal.valueOf(1))
             .tuesday(BigDecimal.valueOf(2))
             .wednesday(BigDecimal.valueOf(3))
@@ -361,9 +358,8 @@ class WorkTimeServiceImplTest {
             .sunday(BigDecimal.valueOf(7))
             .build();
 
-        final WorkingTime actual = sut.updateWorkingTime(workingTime);
+        final WorkingTime actual = sut.updateWorkingTime(new UserLocalId(42L), workWeekUpdate);
 
-        assertThat(actual).isNotSameAs(workingTime);
         assertThat(actual.getUserId()).isEqualTo(new UserLocalId(42L));
         assertThat(actual.getMonday()).hasValue(WorkDay.monday(Duration.ofHours(1)));
         assertThat(actual.getTuesday()).hasValue(WorkDay.tuesday(Duration.ofHours(2)));

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImplTest.java
@@ -1,5 +1,6 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
+import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.timeentry.PlannedWorkingHours;
 import de.focusshift.zeiterfassung.user.UserDateService;
 import de.focusshift.zeiterfassung.user.UserId;
@@ -19,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
@@ -49,6 +49,13 @@ class WorkTimeServiceImplTest {
     @Test
     void ensureWorkingTimeByUser() {
 
+        final UserId userId_1 = new UserId("uuid-1");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        when(userManagementService.findUserByLocalId(userLocalId_1)).thenReturn(Optional.of(user_1));
+
         final WorkingTimeEntity entity = new WorkingTimeEntity();
         entity.setUserId(42L);
         entity.setMonday("PT1H");
@@ -59,11 +66,11 @@ class WorkTimeServiceImplTest {
         entity.setSaturday("PT6H");
         entity.setSunday("PT7H");
 
-        when(workingTimeRepository.findByUserId(42L)).thenReturn(Optional.of(entity));
+        when(workingTimeRepository.findByUserId(userLocalId_1.value())).thenReturn(Optional.of(entity));
 
-        final WorkingTime actual = sut.getWorkingTimeByUser(new UserLocalId(42L));
+        final WorkingTime actual = sut.getWorkingTimeByUser(userLocalId_1);
 
-        assertThat(actual.getUserId()).isEqualTo(new UserLocalId(42L));
+        assertThat(actual.getUserIdComposite()).isEqualTo(userIdComposite_1);
         assertThat(actual.getMonday()).hasValue(WorkDay.monday(Duration.ofHours(1)));
         assertThat(actual.getTuesday()).hasValue(WorkDay.tuesday(Duration.ofHours(2)));
         assertThat(actual.getWednesday()).hasValue(WorkDay.wednesday(Duration.ofHours(3)));
@@ -76,11 +83,18 @@ class WorkTimeServiceImplTest {
     @Test
     void ensureWorkingTimeByUserReturnsDefault() {
 
-        when(workingTimeRepository.findByUserId(42L)).thenReturn(Optional.empty());
+        final UserId userId_1 = new UserId("uuid-1");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
-        final WorkingTime actual = sut.getWorkingTimeByUser(new UserLocalId(42L));
+        when(userManagementService.findUserByLocalId(userLocalId_1)).thenReturn(Optional.of(user_1));
 
-        assertThat(actual.getUserId()).isEqualTo(new UserLocalId(42L));
+        when(workingTimeRepository.findByUserId(userLocalId_1.value())).thenReturn(Optional.empty());
+
+        final WorkingTime actual = sut.getWorkingTimeByUser(userLocalId_1);
+
+        assertThat(actual.getUserIdComposite()).isEqualTo(userIdComposite_1);
         assertThat(actual.getMonday()).hasValue(WorkDay.monday(Duration.ofHours(8)));
         assertThat(actual.getTuesday()).hasValue(WorkDay.tuesday(Duration.ofHours(8)));
         assertThat(actual.getWednesday()).hasValue(WorkDay.wednesday(Duration.ofHours(8)));
@@ -115,11 +129,24 @@ class WorkTimeServiceImplTest {
 
         when(workingTimeRepository.findAllByUserIdIsIn(List.of(1L, 2L))).thenReturn(List.of(entity_1, entity_2));
 
-        final Map<UserLocalId, WorkingTime> actual = sut.getWorkingTimeByUsers(List.of(new UserLocalId(1L), new UserLocalId(2L)));
+        final UserId userId_1 = new UserId("uuid-1");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        final UserId userId_2 = new UserId("uuid-2");
+        final UserLocalId userLocalId_2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+        final User user_2 = new User(userIdComposite_2, "Clark", "Kent", new EMailAddress(""), Set.of());
+
+        when(userManagementService.findAllUsersByLocalIds(List.of(userLocalId_1, userLocalId_2)))
+            .thenReturn(List.of(user_1, user_2));
+
+        final Map<UserIdComposite, WorkingTime> actual = sut.getWorkingTimeByUsers(List.of(new UserLocalId(1L), new UserLocalId(2L)));
 
         assertThat(actual)
-            .containsEntry(new UserLocalId(1L), WorkingTime.builder()
-                .userId(new UserLocalId(1L))
+            .containsEntry(userIdComposite_1, WorkingTime.builder()
+                .userIdComposite(userIdComposite_1)
                 .monday(1)
                 .tuesday(2)
                 .wednesday(3)
@@ -129,8 +156,8 @@ class WorkTimeServiceImplTest {
                 .sunday(8)
                 .build()
             )
-            .containsEntry(new UserLocalId(2L), WorkingTime.builder()
-                .userId(new UserLocalId(2L))
+            .containsEntry(userIdComposite_2, WorkingTime.builder()
+                .userIdComposite(userIdComposite_2)
                 .monday(7)
                 .tuesday(6)
                 .wednesday(5)
@@ -147,11 +174,19 @@ class WorkTimeServiceImplTest {
 
         when(workingTimeRepository.findAllByUserIdIsIn(List.of(1L))).thenReturn(List.of());
 
-        final Map<UserLocalId, WorkingTime> actual = sut.getWorkingTimeByUsers(List.of(new UserLocalId(1L)));
+        final UserId userId_1 = new UserId("uuid-1");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        when(userManagementService.findAllUsersByLocalIds(List.of(userLocalId_1)))
+            .thenReturn(List.of(user_1));
+
+        final Map<UserIdComposite, WorkingTime> actual = sut.getWorkingTimeByUsers(List.of(new UserLocalId(1L)));
 
         assertThat(actual)
-            .containsEntry(new UserLocalId(1L), WorkingTime.builder()
-                .userId(new UserLocalId(1L))
+            .containsEntry(userIdComposite_1, WorkingTime.builder()
+                .userIdComposite(userIdComposite_1)
                 .monday(8)
                 .tuesday(8)
                 .wednesday(8)
@@ -186,21 +221,24 @@ class WorkTimeServiceImplTest {
         entity_2.setSaturday("PT2H");
         entity_2.setSunday("PT1H");
 
+        final UserId userId_1 = new UserId("uuid-1");
         final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        final UserId userId_2 = new UserId("uuid-2");
         final UserLocalId userLocalId_2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+        final User user_2 = new User(userIdComposite_2, "Clark", "Kent", new EMailAddress(""), Set.of());
 
-        when(userManagementService.findAllUsers()).thenReturn(List.of(
-            new User(new UserIdComposite(new UserId(UUID.randomUUID().toString()), userLocalId_1), "", "", null, Set.of()),
-            new User(new UserIdComposite(new UserId(UUID.randomUUID().toString()), userLocalId_2), "", "", null, Set.of())
-        ));
-
+        when(userManagementService.findAllUsers()).thenReturn(List.of(user_1, user_2));
         when(workingTimeRepository.findAllByUserIdIsIn(List.of(1L, 2L))).thenReturn(List.of(entity_1, entity_2));
 
-        final Map<UserLocalId, WorkingTime> actual = sut.getAllWorkingTimeByUsers();
+        final Map<UserIdComposite, WorkingTime> actual = sut.getAllWorkingTimeByUsers();
 
         assertThat(actual)
-            .containsEntry(userLocalId_1, WorkingTime.builder()
-                .userId(userLocalId_1)
+            .containsEntry(userIdComposite_1, WorkingTime.builder()
+                .userIdComposite(userIdComposite_1)
                 .monday(1)
                 .tuesday(2)
                 .wednesday(3)
@@ -210,8 +248,8 @@ class WorkTimeServiceImplTest {
                 .sunday(8)
                 .build()
             )
-            .containsEntry(userLocalId_2, WorkingTime.builder()
-                .userId(userLocalId_2)
+            .containsEntry(userIdComposite_2, WorkingTime.builder()
+                .userIdComposite(userIdComposite_2)
                 .monday(7)
                 .tuesday(6)
                 .wednesday(5)
@@ -226,18 +264,19 @@ class WorkTimeServiceImplTest {
     @Test
     void ensureGetAllWorkingTimeByUsersAddsDefaultWorkingTimeForUsersWithoutExplicitOne() {
 
-        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserId userId_1 = new UserId("uuid-1");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
-        when(userManagementService.findAllUsers())
-            .thenReturn(List.of(new User(new UserIdComposite(new UserId(UUID.randomUUID().toString()), userLocalId), "", "", null, Set.of())));
-
+        when(userManagementService.findAllUsers()).thenReturn(List.of(user_1));
         when(workingTimeRepository.findAllByUserIdIsIn(List.of(1L))).thenReturn(List.of());
 
-        final Map<UserLocalId, WorkingTime> actual = sut.getAllWorkingTimeByUsers();
+        final Map<UserIdComposite, WorkingTime> actual = sut.getAllWorkingTimeByUsers();
 
         assertThat(actual)
-            .containsEntry(userLocalId, WorkingTime.builder()
-                .userId(userLocalId)
+            .containsEntry(userIdComposite_1, WorkingTime.builder()
+                .userIdComposite(userIdComposite_1)
                 .monday(8)
                 .tuesday(8)
                 .wednesday(8)
@@ -252,8 +291,14 @@ class WorkTimeServiceImplTest {
     @Test
     void ensureGetWorkingHoursByUserAndYearWeek() {
 
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserByLocalId(userLocalId)).thenReturn(Optional.of(user));
+
         final WorkingTimeEntity entity = new WorkingTimeEntity();
-        entity.setUserId(42L);
+        entity.setUserId(userLocalId.value());
         entity.setMonday("PT1H");
         entity.setTuesday("PT2H");
         entity.setWednesday("PT3H");
@@ -262,12 +307,12 @@ class WorkTimeServiceImplTest {
         entity.setSaturday("PT6H");
         entity.setSunday("PT7H");
 
-        when(workingTimeRepository.findByUserId(42L)).thenReturn(Optional.of(entity));
+        when(workingTimeRepository.findByUserId(userLocalId.value())).thenReturn(Optional.of(entity));
 
         when(userDateService.firstDayOfWeek(Year.of(2023), 7))
             .thenReturn(LocalDate.of(2023, 2, 13));
 
-        final Map<LocalDate, PlannedWorkingHours> actual = sut.getWorkingHoursByUserAndYearWeek(new UserLocalId(42L), Year.of(2023), 7);
+        final Map<LocalDate, PlannedWorkingHours> actual = sut.getWorkingHoursByUserAndYearWeek(userLocalId, Year.of(2023), 7);
 
         assertThat(actual)
             .containsEntry(LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(1)))
@@ -282,12 +327,18 @@ class WorkTimeServiceImplTest {
     @Test
     void ensureGetWorkingHoursByUserAndYearWeekUsesDefault() {
 
-        when(workingTimeRepository.findByUserId(42L)).thenReturn(Optional.empty());
+        final UserId userId = new UserId("batman");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserByLocalId(userLocalId)).thenReturn(Optional.of(user));
+
+        when(workingTimeRepository.findByUserId(1L)).thenReturn(Optional.empty());
 
         when(userDateService.firstDayOfWeek(Year.of(2023), 7))
             .thenReturn(LocalDate.of(2023, 2, 13));
 
-        final Map<LocalDate, PlannedWorkingHours> actual = sut.getWorkingHoursByUserAndYearWeek(new UserLocalId(42L), Year.of(2023), 7);
+        final Map<LocalDate, PlannedWorkingHours> actual = sut.getWorkingHoursByUserAndYearWeek(userLocalId, Year.of(2023), 7);
 
         assertThat(actual)
             .containsEntry(LocalDate.of(2023, 2, 13), PlannedWorkingHours.EIGHT)
@@ -302,6 +353,12 @@ class WorkTimeServiceImplTest {
     @Test
     void ensureUpdateWorkingTime() {
 
+        final UserId userId_1 = new UserId("uuid-1");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        when(userManagementService.findUserByLocalId(userLocalId_1)).thenReturn(Optional.of(user_1));
+
         final WorkingTimeEntity entity = new WorkingTimeEntity();
         entity.setUserId(42L);
         entity.setMonday("PT24H");
@@ -312,7 +369,7 @@ class WorkTimeServiceImplTest {
         entity.setSaturday("PT24H");
         entity.setSunday("PT24H");
 
-        when(workingTimeRepository.findByUserId(42L)).thenReturn(Optional.of(entity));
+        when(workingTimeRepository.findByUserId(userLocalId_1.value())).thenReturn(Optional.of(entity));
         when(workingTimeRepository.save(any())).thenAnswer(returnsFirstArg());
 
         final WorkWeekUpdate workWeekUpdate = WorkWeekUpdate.builder()
@@ -325,9 +382,9 @@ class WorkTimeServiceImplTest {
             .sunday(BigDecimal.valueOf(7))
             .build();
 
-        final WorkingTime actual = sut.updateWorkingTime(new UserLocalId(42L), workWeekUpdate);
+        final WorkingTime actual = sut.updateWorkingTime(userLocalId_1, workWeekUpdate);
 
-        assertThat(actual.getUserId()).isEqualTo(new UserLocalId(42L));
+        assertThat(actual.getUserIdComposite()).isEqualTo(userIdComposite_1);
         assertThat(actual.getMonday()).hasValue(WorkDay.monday(Duration.ofHours(1)));
         assertThat(actual.getTuesday()).hasValue(WorkDay.tuesday(Duration.ofHours(2)));
         assertThat(actual.getWednesday()).hasValue(WorkDay.wednesday(Duration.ofHours(3)));
@@ -340,7 +397,7 @@ class WorkTimeServiceImplTest {
         verify(workingTimeRepository).save(captor.capture());
 
         final WorkingTimeEntity actualEntity = captor.getValue();
-        assertThat(actualEntity.getUserId()).isEqualTo(42L);
+        assertThat(actualEntity.getUserId()).isEqualTo(1L);
         assertThat(actualEntity.getMonday()).isEqualTo("PT1H");
         assertThat(actualEntity.getTuesday()).isEqualTo("PT2H");
         assertThat(actualEntity.getWednesday()).isEqualTo("PT3H");
@@ -353,7 +410,13 @@ class WorkTimeServiceImplTest {
     @Test
     void ensureUpdateWorkingTimeWithNewItem() {
 
-        when(workingTimeRepository.findByUserId(42L)).thenReturn(Optional.empty());
+        final UserId userId_1 = new UserId("uuid-1");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        when(userManagementService.findUserByLocalId(userLocalId_1)).thenReturn(Optional.of(user_1));
+        when(workingTimeRepository.findByUserId(userLocalId_1.value())).thenReturn(Optional.empty());
         when(workingTimeRepository.save(any())).thenAnswer(returnsFirstArg());
 
         final WorkWeekUpdate workWeekUpdate = WorkWeekUpdate.builder()
@@ -366,9 +429,9 @@ class WorkTimeServiceImplTest {
             .sunday(BigDecimal.valueOf(7))
             .build();
 
-        final WorkingTime actual = sut.updateWorkingTime(new UserLocalId(42L), workWeekUpdate);
+        final WorkingTime actual = sut.updateWorkingTime(userLocalId_1, workWeekUpdate);
 
-        assertThat(actual.getUserId()).isEqualTo(new UserLocalId(42L));
+        assertThat(actual.getUserIdComposite()).isEqualTo(userIdComposite_1);
         assertThat(actual.getMonday()).hasValue(WorkDay.monday(Duration.ofHours(1)));
         assertThat(actual.getTuesday()).hasValue(WorkDay.tuesday(Duration.ofHours(2)));
         assertThat(actual.getWednesday()).hasValue(WorkDay.wednesday(Duration.ofHours(3)));
@@ -381,7 +444,7 @@ class WorkTimeServiceImplTest {
         verify(workingTimeRepository).save(captor.capture());
 
         final WorkingTimeEntity actualEntity = captor.getValue();
-        assertThat(actualEntity.getUserId()).isEqualTo(42L);
+        assertThat(actualEntity.getUserId()).isEqualTo(1L);
         assertThat(actualEntity.getMonday()).isEqualTo("PT1H");
         assertThat(actualEntity.getTuesday()).isEqualTo("PT2H");
         assertThat(actualEntity.getWednesday()).isEqualTo("PT3H");

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImplTest.java
@@ -70,7 +70,7 @@ class WorkTimeServiceImplTest {
 
         final WorkingTime actual = sut.getWorkingTimeByUser(userLocalId_1);
 
-        assertThat(actual.getUserIdComposite()).isEqualTo(userIdComposite_1);
+        assertThat(actual.userIdComposite()).isEqualTo(userIdComposite_1);
         assertThat(actual.getMonday()).hasValue(WorkDay.monday(Duration.ofHours(1)));
         assertThat(actual.getTuesday()).hasValue(WorkDay.tuesday(Duration.ofHours(2)));
         assertThat(actual.getWednesday()).hasValue(WorkDay.wednesday(Duration.ofHours(3)));
@@ -94,7 +94,7 @@ class WorkTimeServiceImplTest {
 
         final WorkingTime actual = sut.getWorkingTimeByUser(userLocalId_1);
 
-        assertThat(actual.getUserIdComposite()).isEqualTo(userIdComposite_1);
+        assertThat(actual.userIdComposite()).isEqualTo(userIdComposite_1);
         assertThat(actual.getMonday()).hasValue(WorkDay.monday(Duration.ofHours(8)));
         assertThat(actual.getTuesday()).hasValue(WorkDay.tuesday(Duration.ofHours(8)));
         assertThat(actual.getWednesday()).hasValue(WorkDay.wednesday(Duration.ofHours(8)));
@@ -384,7 +384,7 @@ class WorkTimeServiceImplTest {
 
         final WorkingTime actual = sut.updateWorkingTime(userLocalId_1, workWeekUpdate);
 
-        assertThat(actual.getUserIdComposite()).isEqualTo(userIdComposite_1);
+        assertThat(actual.userIdComposite()).isEqualTo(userIdComposite_1);
         assertThat(actual.getMonday()).hasValue(WorkDay.monday(Duration.ofHours(1)));
         assertThat(actual.getTuesday()).hasValue(WorkDay.tuesday(Duration.ofHours(2)));
         assertThat(actual.getWednesday()).hasValue(WorkDay.wednesday(Duration.ofHours(3)));
@@ -431,7 +431,7 @@ class WorkTimeServiceImplTest {
 
         final WorkingTime actual = sut.updateWorkingTime(userLocalId_1, workWeekUpdate);
 
-        assertThat(actual.getUserIdComposite()).isEqualTo(userIdComposite_1);
+        assertThat(actual.userIdComposite()).isEqualTo(userIdComposite_1);
         assertThat(actual.getMonday()).hasValue(WorkDay.monday(Duration.ofHours(1)));
         assertThat(actual.getTuesday()).hasValue(WorkDay.tuesday(Duration.ofHours(2)));
         assertThat(actual.getWednesday()).hasValue(WorkDay.wednesday(Duration.ofHours(3)));

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkTimeServiceImplTest.java
@@ -2,6 +2,8 @@ package de.focusshift.zeiterfassung.usermanagement;
 
 import de.focusshift.zeiterfassung.timeentry.PlannedWorkingHours;
 import de.focusshift.zeiterfassung.user.UserDateService;
+import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
@@ -183,9 +186,12 @@ class WorkTimeServiceImplTest {
         entity_2.setSaturday("PT2H");
         entity_2.setSunday("PT1H");
 
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserLocalId userLocalId_2 = new UserLocalId(2L);
+
         when(userManagementService.findAllUsers()).thenReturn(List.of(
-            new User(null, new UserLocalId(1L), "", "", null, Set.of()),
-            new User(null, new UserLocalId(2L), "", "", null, Set.of())
+            new User(new UserIdComposite(new UserId(UUID.randomUUID().toString()), userLocalId_1), "", "", null, Set.of()),
+            new User(new UserIdComposite(new UserId(UUID.randomUUID().toString()), userLocalId_2), "", "", null, Set.of())
         ));
 
         when(workingTimeRepository.findAllByUserIdIsIn(List.of(1L, 2L))).thenReturn(List.of(entity_1, entity_2));
@@ -193,8 +199,8 @@ class WorkTimeServiceImplTest {
         final Map<UserLocalId, WorkingTime> actual = sut.getAllWorkingTimeByUsers();
 
         assertThat(actual)
-            .containsEntry(new UserLocalId(1L), WorkingTime.builder()
-                .userId(new UserLocalId(1L))
+            .containsEntry(userLocalId_1, WorkingTime.builder()
+                .userId(userLocalId_1)
                 .monday(1)
                 .tuesday(2)
                 .wednesday(3)
@@ -204,8 +210,8 @@ class WorkTimeServiceImplTest {
                 .sunday(8)
                 .build()
             )
-            .containsEntry(new UserLocalId(2L), WorkingTime.builder()
-                .userId(new UserLocalId(2L))
+            .containsEntry(userLocalId_2, WorkingTime.builder()
+                .userId(userLocalId_2)
                 .monday(7)
                 .tuesday(6)
                 .wednesday(5)
@@ -220,16 +226,18 @@ class WorkTimeServiceImplTest {
     @Test
     void ensureGetAllWorkingTimeByUsersAddsDefaultWorkingTimeForUsersWithoutExplicitOne() {
 
+        final UserLocalId userLocalId = new UserLocalId(1L);
+
         when(userManagementService.findAllUsers())
-            .thenReturn(List.of(new User(null, new UserLocalId(1L), "", "", null, Set.of())));
+            .thenReturn(List.of(new User(new UserIdComposite(new UserId(UUID.randomUUID().toString()), userLocalId), "", "", null, Set.of())));
 
         when(workingTimeRepository.findAllByUserIdIsIn(List.of(1L))).thenReturn(List.of());
 
         final Map<UserLocalId, WorkingTime> actual = sut.getAllWorkingTimeByUsers();
 
         assertThat(actual)
-            .containsEntry(new UserLocalId(1L), WorkingTime.builder()
-                .userId(new UserLocalId(1L))
+            .containsEntry(userLocalId, WorkingTime.builder()
+                .userId(userLocalId)
                 .monday(8)
                 .tuesday(8)
                 .wednesday(8)

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeCalendarServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeCalendarServiceImplTest.java
@@ -1,6 +1,8 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
 import de.focusshift.zeiterfassung.timeentry.PlannedWorkingHours;
+import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,9 +33,17 @@ class WorkingTimeCalendarServiceImplTest {
     @Test
     void ensureGetWorkingTimesForAll() {
 
+        final UserId userId_1 = new UserId("uuid-1");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+
+        final UserId userId_2 = new UserId("uuid-2");
+        final UserLocalId userLocalId_2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+
         when(workingTimeService.getAllWorkingTimeByUsers()).thenReturn(Map.of(
-                new UserLocalId(1L), WorkingTime.builder()
-                    .userId(new UserLocalId(1L))
+                userIdComposite_1, WorkingTime.builder()
+                    .userIdComposite(userIdComposite_1)
                     .monday(1)
                     .tuesday(2)
                     .wednesday(3)
@@ -42,8 +52,8 @@ class WorkingTimeCalendarServiceImplTest {
                     .saturday(6)
                     .sunday(7)
                     .build(),
-                new UserLocalId(2L), WorkingTime.builder()
-                    .userId(new UserLocalId(1L))
+            userIdComposite_2, WorkingTime.builder()
+                    .userIdComposite(userIdComposite_2)
                     .monday(7)
                     .tuesday(6)
                     .wednesday(5)
@@ -54,11 +64,11 @@ class WorkingTimeCalendarServiceImplTest {
                     .build()
         ));
 
-        final Map<UserLocalId, WorkingTimeCalendar> actual = sut.getWorkingTimes(LocalDate.of(2023, 2, 13), LocalDate.of(2023, 2, 20));
+        final Map<UserIdComposite, WorkingTimeCalendar> actual = sut.getWorkingTimes(LocalDate.of(2023, 2, 13), LocalDate.of(2023, 2, 20));
 
         assertThat(actual)
             .hasSize(2)
-            .containsEntry(new UserLocalId(1L), new WorkingTimeCalendar(Map.of(
+            .containsEntry(userIdComposite_1, new WorkingTimeCalendar(Map.of(
                 LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(1)),
                 LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(2)),
                 LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(3)),
@@ -67,7 +77,7 @@ class WorkingTimeCalendarServiceImplTest {
                 LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(6)),
                 LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(7))
             )))
-            .containsEntry(new UserLocalId(2L), new WorkingTimeCalendar(Map.of(
+            .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
                 LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(7)),
                 LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(6)),
                 LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(5)),
@@ -81,12 +91,17 @@ class WorkingTimeCalendarServiceImplTest {
     @Test
     void ensureGetWorkingTimesForUsers() {
 
-        final UserLocalId userId_2 = new UserLocalId(2L);
-        final UserLocalId userId_1 = new UserLocalId(1L);
+        final UserId userId_1 = new UserId("uuid-1");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
 
-        when(workingTimeService.getWorkingTimeByUsers(List.of(userId_1, userId_2))).thenReturn(Map.of(
-            userId_1, WorkingTime.builder()
-                .userId(userId_1)
+        final UserId userId_2 = new UserId("uuid-2");
+        final UserLocalId userLocalId_2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+
+        when(workingTimeService.getWorkingTimeByUsers(List.of(userLocalId_1, userLocalId_2))).thenReturn(Map.of(
+            userIdComposite_1, WorkingTime.builder()
+                .userIdComposite(userIdComposite_1)
                 .monday(1)
                 .tuesday(2)
                 .wednesday(3)
@@ -95,8 +110,8 @@ class WorkingTimeCalendarServiceImplTest {
                 .saturday(6)
                 .sunday(7)
                 .build(),
-            userId_2, WorkingTime.builder()
-                .userId(userId_1)
+            userIdComposite_2, WorkingTime.builder()
+                .userIdComposite(userIdComposite_2)
                 .monday(7)
                 .tuesday(6)
                 .wednesday(5)
@@ -107,15 +122,15 @@ class WorkingTimeCalendarServiceImplTest {
                 .build()
         ));
 
-        final Map<UserLocalId, WorkingTimeCalendar> actual = sut.getWorkingTimes(
+        final Map<UserIdComposite, WorkingTimeCalendar> actual = sut.getWorkingTimes(
             LocalDate.of(2023, 2, 13),
             LocalDate.of(2023, 2, 20),
-            List.of(userId_1, userId_2)
+            List.of(userLocalId_1, userLocalId_2)
         );
 
         assertThat(actual)
             .hasSize(2)
-            .containsEntry(userId_1, new WorkingTimeCalendar(Map.of(
+            .containsEntry(userIdComposite_1, new WorkingTimeCalendar(Map.of(
                 LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(1)),
                 LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(2)),
                 LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(3)),
@@ -124,7 +139,7 @@ class WorkingTimeCalendarServiceImplTest {
                 LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(6)),
                 LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(7))
             )))
-            .containsEntry(userId_2, new WorkingTimeCalendar(Map.of(
+            .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
                 LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(7)),
                 LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(6)),
                 LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(5)),

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeControllerTest.java
@@ -85,7 +85,7 @@ class WorkingTimeControllerTest {
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(supermanLocalId)
+            .userIdComposite(supermanIdComposite)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -96,7 +96,7 @@ class WorkingTimeControllerTest {
         when(workingTimeService.getWorkingTimeByUser(supermanLocalId)).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserId().value())
+            .userId(workingTime.getUserIdComposite().localId().value())
             .workday(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY))
             .workingTime(8.0)
             .build();
@@ -140,7 +140,7 @@ class WorkingTimeControllerTest {
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(new UserLocalId(42L))
+            .userIdComposite(supermanIdComposite)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -175,7 +175,7 @@ class WorkingTimeControllerTest {
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(supermanLocalId)
+            .userIdComposite(supermanIdComposite)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -186,7 +186,7 @@ class WorkingTimeControllerTest {
         when(workingTimeService.getWorkingTimeByUser(new UserLocalId(42L))).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserId().value())
+            .userId(workingTime.getUserIdComposite().localId().value())
             .workday(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY))
             .workingTime(8.0)
             .build();
@@ -221,7 +221,7 @@ class WorkingTimeControllerTest {
         when(userManagementService.findAllUsers("")).thenReturn(List.of(user));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(userLocalId)
+            .userIdComposite(userIdComposite)
             .monday(BigDecimal.valueOf(4))
             .wednesday(BigDecimal.valueOf(5))
             .saturday(BigDecimal.valueOf(6))
@@ -230,7 +230,7 @@ class WorkingTimeControllerTest {
         when(workingTimeService.getWorkingTimeByUser(new UserLocalId(1L))).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserId().value())
+            .userId(workingTime.getUserIdComposite().localId().value())
             .workday(List.of(MONDAY, WEDNESDAY, SATURDAY))
             .workingTimeMonday(4.0)
             .workingTimeWednesday(5.0)
@@ -263,7 +263,7 @@ class WorkingTimeControllerTest {
         when(userManagementService.findAllUsers("super")).thenReturn(List.of(user));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(new UserLocalId(42L))
+            .userIdComposite(userIdComposite)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -274,7 +274,7 @@ class WorkingTimeControllerTest {
         when(workingTimeService.getWorkingTimeByUser(new UserLocalId(42L))).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserId().value())
+            .userId(workingTime.getUserIdComposite().localId().value())
             .workday(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY))
             .workingTime(8.0)
             .build();
@@ -308,7 +308,7 @@ class WorkingTimeControllerTest {
         when(userManagementService.findAllUsers("super")).thenReturn(List.of(user));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(userLocalId)
+            .userIdComposite(userIdComposite)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -361,7 +361,7 @@ class WorkingTimeControllerTest {
         when(userManagementService.findUserByLocalId(new UserLocalId(42L))).thenReturn(Optional.of(superman));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(supermanLocalId)
+            .userIdComposite(supermanIdComposite)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -413,7 +413,7 @@ class WorkingTimeControllerTest {
         when(userManagementService.findUserByLocalId(supermanLocalId)).thenReturn(Optional.of(superman));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(supermanLocalId)
+            .userIdComposite(supermanIdComposite)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeControllerTest.java
@@ -96,7 +96,7 @@ class WorkingTimeControllerTest {
         when(workingTimeService.getWorkingTimeByUser(supermanLocalId)).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserIdComposite().localId().value())
+            .userId(workingTime.userIdComposite().localId().value())
             .workday(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY))
             .workingTime(8.0)
             .build();
@@ -186,7 +186,7 @@ class WorkingTimeControllerTest {
         when(workingTimeService.getWorkingTimeByUser(new UserLocalId(42L))).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserIdComposite().localId().value())
+            .userId(workingTime.userIdComposite().localId().value())
             .workday(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY))
             .workingTime(8.0)
             .build();
@@ -230,7 +230,7 @@ class WorkingTimeControllerTest {
         when(workingTimeService.getWorkingTimeByUser(new UserLocalId(1L))).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserIdComposite().localId().value())
+            .userId(workingTime.userIdComposite().localId().value())
             .workday(List.of(MONDAY, WEDNESDAY, SATURDAY))
             .workingTimeMonday(4.0)
             .workingTimeWednesday(5.0)
@@ -274,7 +274,7 @@ class WorkingTimeControllerTest {
         when(workingTimeService.getWorkingTimeByUser(new UserLocalId(42L))).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserIdComposite().localId().value())
+            .userId(workingTime.userIdComposite().localId().value())
             .workday(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY))
             .workingTime(8.0)
             .build();

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeControllerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -28,11 +27,9 @@ import java.util.Set;
 import static java.time.DayOfWeek.FRIDAY;
 import static java.time.DayOfWeek.MONDAY;
 import static java.time.DayOfWeek.SATURDAY;
-import static java.time.DayOfWeek.SUNDAY;
 import static java.time.DayOfWeek.THURSDAY;
 import static java.time.DayOfWeek.TUESDAY;
 import static java.time.DayOfWeek.WEDNESDAY;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -420,18 +417,17 @@ class WorkingTimeControllerTest {
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/users/42/working-time"));
 
-        final ArgumentCaptor<WorkingTime> captor = ArgumentCaptor.forClass(WorkingTime.class);
-        verify(workingTimeService).updateWorkingTime(captor.capture());
+        final WorkWeekUpdate expectedWorkWeekUpdate = WorkWeekUpdate.builder()
+            .monday(Duration.ofHours(0))
+            .tuesday(Duration.ofHours(1))
+            .wednesday(Duration.ofHours(2))
+            .thursday(Duration.ofHours(3))
+            .friday(Duration.ofHours(4))
+            .saturday(Duration.ofHours(5))
+            .sunday(Duration.ofHours(6))
+            .build();
 
-        final WorkingTime actual = captor.getValue();
-        assertThat(actual.getUserId()).isEqualTo(new UserLocalId(42L));
-        assertThat(actual.getMonday()).hasValue(new WorkDay(MONDAY, Duration.ofHours(0)));
-        assertThat(actual.getTuesday()).hasValue(new WorkDay(TUESDAY, Duration.ofHours(1)));
-        assertThat(actual.getWednesday()).hasValue(new WorkDay(WEDNESDAY, Duration.ofHours(2)));
-        assertThat(actual.getThursday()).hasValue(new WorkDay(THURSDAY, Duration.ofHours(3)));
-        assertThat(actual.getFriday()).hasValue(new WorkDay(FRIDAY, Duration.ofHours(4)));
-        assertThat(actual.getSaturday()).hasValue(new WorkDay(SATURDAY, Duration.ofHours(5)));
-        assertThat(actual.getSunday()).hasValue(new WorkDay(SUNDAY, Duration.ofHours(6)));
+        verify(workingTimeService).updateWorkingTime(new UserLocalId(42L), expectedWorkWeekUpdate);
     }
 
     @Test
@@ -453,18 +449,17 @@ class WorkingTimeControllerTest {
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/users/42/working-time"));
 
-        final ArgumentCaptor<WorkingTime> captor = ArgumentCaptor.forClass(WorkingTime.class);
-        verify(workingTimeService).updateWorkingTime(captor.capture());
+        final WorkWeekUpdate expectedWorkWeekUpdate = WorkWeekUpdate.builder()
+            .monday(Duration.ofHours(0))
+            .tuesday(Duration.ofHours(1))
+            .wednesday(Duration.ofHours(2))
+            .thursday(Duration.ofHours(3))
+            .friday(Duration.ofHours(4))
+            .saturday(Duration.ofHours(5))
+            .sunday(Duration.ofHours(6))
+            .build();
 
-        final WorkingTime actual = captor.getValue();
-        assertThat(actual.getUserId()).isEqualTo(new UserLocalId(42L));
-        assertThat(actual.getMonday()).hasValue(new WorkDay(MONDAY, Duration.ofHours(0)));
-        assertThat(actual.getTuesday()).hasValue(new WorkDay(TUESDAY, Duration.ofHours(1)));
-        assertThat(actual.getWednesday()).hasValue(new WorkDay(WEDNESDAY, Duration.ofHours(2)));
-        assertThat(actual.getThursday()).hasValue(new WorkDay(THURSDAY, Duration.ofHours(3)));
-        assertThat(actual.getFriday()).hasValue(new WorkDay(FRIDAY, Duration.ofHours(4)));
-        assertThat(actual.getSaturday()).hasValue(new WorkDay(SATURDAY, Duration.ofHours(5)));
-        assertThat(actual.getSunday()).hasValue(new WorkDay(SUNDAY, Duration.ofHours(6)));
+        verify(workingTimeService).updateWorkingTime(new UserLocalId(42L), expectedWorkWeekUpdate);
     }
 
     @Test

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeControllerTest.java
@@ -2,6 +2,7 @@ package de.focusshift.zeiterfassung.usermanagement;
 
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,12 +72,20 @@ class WorkingTimeControllerTest {
     @Test
     void ensureSimpleGet() throws Exception {
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final UserId supermanId = new UserId("uuid-2");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(new UserLocalId(42L))
+            .userId(supermanLocalId)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -84,7 +93,7 @@ class WorkingTimeControllerTest {
             .friday(EIGHT)
             .build();
 
-        when(workingTimeService.getWorkingTimeByUser(new UserLocalId(42L))).thenReturn(workingTime);
+        when(workingTimeService.getWorkingTimeByUser(supermanLocalId)).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
             .userId(workingTime.getUserId().value())
@@ -118,8 +127,16 @@ class WorkingTimeControllerTest {
     })
     void ensureSimpleGetAllowedToEditX(String authority, boolean editWorkingTime, boolean editOvertimeAccount) throws Exception {
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final UserId supermanId = new UserId("uuid-2");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         final WorkingTime workingTime = WorkingTime.builder()
@@ -131,7 +148,7 @@ class WorkingTimeControllerTest {
             .friday(EIGHT)
             .build();
 
-        when(workingTimeService.getWorkingTimeByUser(new UserLocalId(42L))).thenReturn(workingTime);
+        when(workingTimeService.getWorkingTimeByUser(supermanLocalId)).thenReturn(workingTime);
 
 
         perform(
@@ -145,12 +162,20 @@ class WorkingTimeControllerTest {
     @Test
     void ensureSimpleGetJavaScript() throws Exception {
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final UserId supermanId = new UserId("uuid-2");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(new UserLocalId(42L))
+            .userId(supermanLocalId)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -189,11 +214,14 @@ class WorkingTimeControllerTest {
     @Test
     void ensureSimpleGetForWorkingTimeWithSpecialWorkingDays() throws Exception {
 
-        final User alfred = new User(new UserId("uuid"), new UserLocalId(1L), "Alfred", "Pennyworth", new EMailAddress("alfred@example.org"), Set.of());
-        when(userManagementService.findAllUsers("")).thenReturn(List.of(alfred));
+        final UserId userId = new UserId("uuid");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Alfred", "Pennyworth", new EMailAddress("alfred@example.org"), Set.of());
+        when(userManagementService.findAllUsers("")).thenReturn(List.of(user));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(new UserLocalId(1L))
+            .userId(userLocalId)
             .monday(BigDecimal.valueOf(4))
             .wednesday(BigDecimal.valueOf(5))
             .saturday(BigDecimal.valueOf(6))
@@ -228,8 +256,11 @@ class WorkingTimeControllerTest {
     @Test
     void ensureSearch() throws Exception {
 
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
-        when(userManagementService.findAllUsers("super")).thenReturn(List.of(superman));
+        final UserId userId = new UserId("uuid-2");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        when(userManagementService.findAllUsers("super")).thenReturn(List.of(user));
 
         final WorkingTime workingTime = WorkingTime.builder()
             .userId(new UserLocalId(42L))
@@ -270,11 +301,14 @@ class WorkingTimeControllerTest {
     @Test
     void ensureSearchJavaScript() throws Exception {
 
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
-        when(userManagementService.findAllUsers("super")).thenReturn(List.of(superman));
+        final UserId userId = new UserId("uuid-2");
+        final UserLocalId userLocalId = new UserLocalId(42L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        when(userManagementService.findAllUsers("super")).thenReturn(List.of(user));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(new UserLocalId(42L))
+            .userId(userLocalId)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -285,7 +319,7 @@ class WorkingTimeControllerTest {
         when(workingTimeService.getWorkingTimeByUser(new UserLocalId(42L))).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserId().value())
+            .userId(userLocalId.value())
             .workday(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY))
             .workingTime(8.0)
             .build();
@@ -313,13 +347,21 @@ class WorkingTimeControllerTest {
     @Test
     void ensureSearchWithSelectedUserNotInQuery() throws Exception {
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final UserId supermanId = new UserId("uuid-2");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("bat")).thenReturn(List.of(batman));
         when(userManagementService.findUserByLocalId(new UserLocalId(42L))).thenReturn(Optional.of(superman));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(new UserLocalId(42L))
+            .userId(supermanLocalId)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -327,10 +369,10 @@ class WorkingTimeControllerTest {
             .friday(EIGHT)
             .build();
 
-        when(workingTimeService.getWorkingTimeByUser(new UserLocalId(42L))).thenReturn(workingTime);
+        when(workingTimeService.getWorkingTimeByUser(supermanLocalId)).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserId().value())
+            .userId(supermanLocalId.value())
             .workday(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY))
             .workingTime(8.0)
             .build();
@@ -357,13 +399,21 @@ class WorkingTimeControllerTest {
     @Test
     void ensureSearchWithSelectedUserNotInQueryJavaScript() throws Exception {
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final UserId supermanId = new UserId("uuid-2");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("bat")).thenReturn(List.of(batman));
-        when(userManagementService.findUserByLocalId(new UserLocalId(42L))).thenReturn(Optional.of(superman));
+        when(userManagementService.findUserByLocalId(supermanLocalId)).thenReturn(Optional.of(superman));
 
         final WorkingTime workingTime = WorkingTime.builder()
-            .userId(new UserLocalId(42L))
+            .userId(supermanLocalId)
             .monday(EIGHT)
             .tuesday(EIGHT)
             .wednesday(EIGHT)
@@ -374,7 +424,7 @@ class WorkingTimeControllerTest {
         when(workingTimeService.getWorkingTimeByUser(new UserLocalId(42L))).thenReturn(workingTime);
 
         final WorkingTimeDto expectedWorkingTimeDto = WorkingTimeDto.builder()
-            .userId(workingTime.getUserId().value())
+            .userId(supermanLocalId.value())
             .workday(List.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY))
             .workingTime(8.0)
             .build();
@@ -479,8 +529,16 @@ class WorkingTimeControllerTest {
             }
         ).when(workingTimeDtoValidator).validate(eq(expectedWorkingTimeDto), any(BindingResult.class));
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final UserId supermanId = new UserId("uuid-2");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         perform(
@@ -525,8 +583,16 @@ class WorkingTimeControllerTest {
             }
         ).when(workingTimeDtoValidator).validate(eq(expectedWorkingTimeDto), any(BindingResult.class));
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final UserId supermanId = new UserId("uuid-2");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         perform(
@@ -556,8 +622,16 @@ class WorkingTimeControllerTest {
             }
         ).when(workingTimeDtoValidator).validate(eq(expectedWorkingTimeDto), any(BindingResult.class));
 
-        final User batman = new User(new UserId("uuid"), new UserLocalId(1337L), "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
-        final User superman = new User(new UserId("uuid-2"), new UserLocalId(42L), "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
+        final UserId batmanId = new UserId("uuid");
+        final UserLocalId batmanLocalId = new UserLocalId(1337L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+
+        final UserId supermanId = new UserId("uuid-2");
+        final UserLocalId supermanLocalId = new UserLocalId(42L);
+        final UserIdComposite supermanIdComposite = new UserIdComposite(supermanId, supermanLocalId);
+
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+        final User superman = new User(supermanIdComposite, "Clark", "Kent", new EMailAddress("superman@example.org"), Set.of());
         when(userManagementService.findAllUsers("")).thenReturn(List.of(batman, superman));
 
         perform(

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeRepositoryIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeRepositoryIT.java
@@ -1,12 +1,19 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
 import de.focusshift.zeiterfassung.TestContainersBase;
+import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
+import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,6 +25,8 @@ class WorkingTimeRepositoryIT extends TestContainersBase {
 
     @Autowired
     private WorkingTimeService workingTimeService;
+    @MockBean
+    private UserManagementService userManagementService;
 
     @AfterEach
     void tearDown() {
@@ -27,8 +36,27 @@ class WorkingTimeRepositoryIT extends TestContainersBase {
     @Test
     void ensureFindAllByUserIdIsIn() {
 
+        final UserId userId_1 = new UserId("uuid-1");
+        final UserLocalId userLocalId_1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+        final User user_1 = new User(userIdComposite_1, "", "", new EMailAddress(""), Set.of());
+
+        final UserId userId_2 = new UserId("uuid-2");
+        final UserLocalId userLocalId_2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+        final User user_2 = new User(userIdComposite_2, "", "", new EMailAddress(""), Set.of());
+
+        final UserId userId_3 = new UserId("uuid-3");
+        final UserLocalId userLocalId_3 = new UserLocalId(3L);
+        final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
+        final User user_3 = new User(userIdComposite_3, "", "", new EMailAddress(""), Set.of());
+
+        Mockito.when(userManagementService.findUserByLocalId(userLocalId_1)).thenReturn(Optional.of(user_1));
+        Mockito.when(userManagementService.findUserByLocalId(userLocalId_2)).thenReturn(Optional.of(user_2));
+        Mockito.when(userManagementService.findUserByLocalId(userLocalId_3)).thenReturn(Optional.of(user_3));
+
         workingTimeService.updateWorkingTime(
-            new UserLocalId(1L),
+            userLocalId_1,
             WorkWeekUpdate.builder()
                 .monday(1)
                 .tuesday(2)
@@ -41,7 +69,7 @@ class WorkingTimeRepositoryIT extends TestContainersBase {
         );
 
         workingTimeService.updateWorkingTime(
-            new UserLocalId(2L),
+            userLocalId_2,
             WorkWeekUpdate.builder()
                 .monday(10)
                 .tuesday(10)
@@ -54,7 +82,7 @@ class WorkingTimeRepositoryIT extends TestContainersBase {
         );
 
         workingTimeService.updateWorkingTime(
-            new UserLocalId(3L),
+            userLocalId_3,
             WorkWeekUpdate.builder()
                 .monday(8)
                 .tuesday(8)

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeRepositoryIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/WorkingTimeRepositoryIT.java
@@ -28,8 +28,8 @@ class WorkingTimeRepositoryIT extends TestContainersBase {
     void ensureFindAllByUserIdIsIn() {
 
         workingTimeService.updateWorkingTime(
-            WorkingTime.builder()
-                .userId(new UserLocalId(1L))
+            new UserLocalId(1L),
+            WorkWeekUpdate.builder()
                 .monday(1)
                 .tuesday(2)
                 .wednesday(3)
@@ -41,8 +41,8 @@ class WorkingTimeRepositoryIT extends TestContainersBase {
         );
 
         workingTimeService.updateWorkingTime(
-            WorkingTime.builder()
-                .userId(new UserLocalId(2L))
+            new UserLocalId(2L),
+            WorkWeekUpdate.builder()
                 .monday(10)
                 .tuesday(10)
                 .wednesday(10)
@@ -54,8 +54,8 @@ class WorkingTimeRepositoryIT extends TestContainersBase {
         );
 
         workingTimeService.updateWorkingTime(
-            WorkingTime.builder()
-                .userId(new UserLocalId(3L))
+            new UserLocalId(3L),
+            WorkWeekUpdate.builder()
                 .monday(8)
                 .tuesday(8)
                 .wednesday(8)


### PR DESCRIPTION
`UserLocalId` -> short number to identify a user of a tenant / database id  
`UserId` -> authentication sub (uuid in most cases)

`UserLocalId` is used when there is interaction with the frontend like selecting multiple persons in the report view. or selecting a person in the userManagement view. (to have shorter and more readable URLs)

sometimes `UserId` is required, sometimes `UserLocalId`...  
`UserIdComposite` has been introduced to make this more usable / explicit in the code base. So we don't have to think about whether `UserLocalId` or `UserId` should be the key of a `Map` for instance. Just use `UserIdComposite` now. View Controllers are able to pass the `UserLocalId` value to html forms.

---

Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
