### PR TITLE
Remove deprecated `zeiterfassung.tenant.registration.rabbitmq.routing…

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/tenancy/registration/messaging/OidcClientRegistrationRabbitmqConfigurationProperties.java
+++ b/src/main/java/de/focusshift/zeiterfassung/tenancy/registration/messaging/OidcClientRegistrationRabbitmqConfigurationProperties.java
@@ -58,11 +58,6 @@ class OidcClientRegistrationRabbitmqConfigurationProperties {
         return routingKeyDeletedTemplate;
     }
 
-    @Deprecated
-    public void setRoutingKeyDeletedTwo(String routingKeyDeletedTemplate) {
-        this.routingKeyDeletedTemplate = routingKeyDeletedTemplate;
-    }
-
     public void setRoutingKeyDeletedTemplate(String routingKeyDeletedTemplate) {
         this.routingKeyDeletedTemplate = routingKeyDeletedTemplate;
     }

--- a/src/test/java/de/focusshift/zeiterfassung/tenancy/registration/messaging/OidcClientRegistrationRabbitmqConfigurationPropertiesTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/tenancy/registration/messaging/OidcClientRegistrationRabbitmqConfigurationPropertiesTest.java
@@ -50,17 +50,6 @@ class OidcClientRegistrationRabbitmqConfigurationPropertiesTest {
     @ParameterizedTest
     @ValueSource(strings = {""})
     @NullSource
-    void ensureRoutingKeyDeletedTwoCannotBeEmptyOrNull(String routingKeyDeletedTwo) {
-        final OidcClientRegistrationRabbitmqConfigurationProperties sut = new OidcClientRegistrationRabbitmqConfigurationProperties();
-        sut.setRoutingKeyDeletedTwo(routingKeyDeletedTwo);
-        final Set<ConstraintViolation<OidcClientRegistrationRabbitmqConfigurationProperties>> violations = validator.validate(sut);
-
-        assertThat(violations.size()).isOne();
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {""})
-    @NullSource
     void ensureRoutingKeyDeletedTemplateCannotBeEmptyOrNull(String routingKeyDeletedTemplate) {
         final OidcClientRegistrationRabbitmqConfigurationProperties sut = new OidcClientRegistrationRabbitmqConfigurationProperties();
         sut.setRoutingKeyDeletedTemplate(routingKeyDeletedTemplate);


### PR DESCRIPTION
…-key-deleted-two`

closes #472 

Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
