### PR TITLE
use custom gen_random_uuid function

### DIFF
--- a/src/main/resources/db/changelog/changelog-2.0.0-prepare-multiple-working-times-per-user.xml
+++ b/src/main/resources/db/changelog/changelog-2.0.0-prepare-multiple-working-times-per-user.xml
@@ -4,6 +4,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
 
   <changeSet author="seber" id="prepare-multiple-working-times-per-user--add-uuid">
+    <validCheckSum>9:0a68e4e4c90146101d28e6a5bea3b241</validCheckSum>
     <preConditions>
       <tableExists tableName="working_time"/>
       <not>
@@ -11,7 +12,7 @@
       </not>
     </preConditions>
     <addColumn tableName="working_time">
-      <column name="uuid" type="UUID" defaultValueComputed="gen_random_uuid()">
+      <column name="uuid" type="UUID" defaultValueComputed="uuid_in(overlay(overlay(md5(random()::text || ':' || clock_timestamp()::text) placing '4' from 13) placing to_hex(floor(random()*(11-8+1) + 8)::int)::text from 17)::cstring)">
         <!-- nullable and unique constraint not required. will be the primary key in next step -->
       </column>
     </addColumn>


### PR DESCRIPTION
`gen_random_uuid` is not supported by older Postgres Versions. This feature has been introduced with [Postgres 13](https://www.postgresql.org/docs/current/functions-uuid.html).

So, if you are using Postgres 13 or newer, you are fine.
If your are migrating from `zeiterfassung-1.x` to `zeiterfassung-2.0.1`, you are fine.

Otherwise read on to see an example on how to migrate:

---

Fixed:
* use custom uuid generation instead of newer postgres `gen_random_uuid`

**Dump using pg_dump**

Create a dump from `zeiterfassung-2.0.0`, e.g.:

```bash
docker exec -i pg_container_name /bin/bash -c "PGPASSWORD=pg_password pg_dump --username pg_username database_name" > /desired/path/on/your/machine/dump.sql
```

**patch dump**

search for `gen_random_uuid()` in the dump file and replace it with the custom uuid generator:

```diff
CREATE TABLE public.working_time (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    id uuid DEFAULT uuid_in(overlay(overlay(md5(random()::text || ':' || clock_timestamp()::text) placing '4' from 13) placing to_hex(floor(random()*(11-8+1) + 8)::int)::text from 17)::cstring) NOT NULL,
);
```

**Restore using psql**

```bash
docker exec -i pg_container_name /bin/bash -c "PGPASSWORD=pg_password psql --username pg_username database_name" < /path/on/your/machine/dump.sql
```

That's it. Have fun!