### PR TITLE
Do use MissingClaimAuthorityException in group claim mapper...

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/security/oidc/claimmapper/RolesFromGroupsClaimMapper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/oidc/claimmapper/RolesFromGroupsClaimMapper.java
@@ -2,7 +2,6 @@ package de.focusshift.zeiterfassung.security.oidc.claimmapper;
 
 import de.focusshift.zeiterfassung.security.oidc.claimmapper.RolesFromClaimMappersProperties.GroupClaimMapperProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 
@@ -45,13 +44,12 @@ public class RolesFromGroupsClaimMapper implements RolesFromClaimMapper {
 
         final GroupClaimMapperProperties groupClaim = properties.getGroupClaim();
 
+        final String neededResourceAccessRole = ZEITERFASSUNG_USER.name().toLowerCase();
         if (!claims.containsKey(groupClaim.getClaimName())) {
-            throw new AccessDeniedException(format("claim=%s is missing!", groupClaim.getClaimName()));
+            throw new MissingClaimAuthorityException(format("User has not required permission '%s' to access zeiterfassung! The claim '%s' is missing!", neededResourceAccessRole, groupClaim.getClaimName()));
         }
 
         final List<String> groups = extractRolesFromClaimName(claims, groupClaim.getClaimName());
-        final String neededResourceAccessRole = ZEITERFASSUNG_USER.name().toLowerCase();
-
         if (groups.stream().noneMatch(neededResourceAccessRole::equals)) {
             throw new MissingClaimAuthorityException(format("User has not required permission '%s' to access zeiterfassung!", neededResourceAccessRole));
         }

--- a/src/test/java/de/focusshift/zeiterfassung/security/oidc/claimmapper/RolesFromGroupsClaimMapperTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/security/oidc/claimmapper/RolesFromGroupsClaimMapperTest.java
@@ -3,7 +3,6 @@ package de.focusshift.zeiterfassung.security.oidc.claimmapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.util.List;
@@ -74,7 +73,7 @@ class RolesFromGroupsClaimMapperTest {
         );
 
         assertThatThrownBy(() -> sut.mapClaimToRoles(claims))
-            .isInstanceOf(AccessDeniedException.class)
-            .hasMessageContaining("claim=groups is missing");
+            .isInstanceOf(MissingClaimAuthorityException.class)
+            .hasMessageContaining("User has not required permission 'zeiterfassung_user' to access zeiterfassung! The claim 'groups' is missing!");
     }
 }


### PR DESCRIPTION
... if we use AccessDeniedException it will redirect on the login page again and will end in a loop


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
