### PR TITLE
Replace spring session jdbc with own in-memory map implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <!-- SESSION -->
     <dependency>
       <groupId>org.springframework.session</groupId>
-      <artifactId>spring-session-jdbc</artifactId>
+      <artifactId>spring-session-core</artifactId>
     </dependency>
 
     <!-- Web -->

--- a/src/main/java/de/focusshift/zeiterfassung/security/IndexNameMapSessionRepository.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/IndexNameMapSessionRepository.java
@@ -1,0 +1,74 @@
+package de.focusshift.zeiterfassung.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.MapSession;
+import org.springframework.session.Session;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.stream.Collectors.toMap;
+
+class IndexNameMapSessionRepository implements FindByIndexNameSessionRepository<Session> {
+
+    // <SessionId, Session>
+    private final ConcurrentHashMap<String, Session> sessions = new ConcurrentHashMap<>();
+    // <AttributeName, <SessionId, AttributeValue>>
+    private final ConcurrentHashMap<String, ConcurrentHashMap<String, String>> indexMap = new ConcurrentHashMap<>();
+
+    @Override
+    public Session findById(String id) {
+        return sessions.get(id);
+    }
+
+    @Override
+    public Session createSession() {
+        return new MapSession();
+    }
+
+    @Override
+    public void save(final Session session) {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof final OAuth2AuthenticationToken token) {
+            final OAuth2User oAuth2User = token.getPrincipal();
+            if (oAuth2User instanceof final OidcUser oidcUser) {
+                session.setAttribute(PRINCIPAL_NAME_INDEX_NAME, oidcUser.getSubject());
+            }
+        }
+
+        sessions.put(session.getId(), session);
+        for (final String attributeName : session.getAttributeNames()) {
+            indexMap.computeIfAbsent(attributeName, k -> new ConcurrentHashMap<>())
+                .put(session.getId(), session.getAttribute(attributeName).toString());
+        }
+    }
+
+    @Override
+    public void deleteById(final String id) {
+        final Session session = sessions.remove(id);
+        if (session != null) {
+            for (final String attributeName : session.getAttributeNames()) {
+                final ConcurrentHashMap<String, String> index = indexMap.get(attributeName);
+                if (index != null) {
+                    index.remove(id);
+                }
+            }
+        }
+    }
+
+    @Override
+    public Map<String, Session> findByIndexNameAndIndexValue(final String indexName, final String indexValue) {
+        final ConcurrentHashMap<String, String> index = indexMap.get(indexName);
+        if (index != null) {
+            return index.entrySet().stream()
+                    .filter(entry -> entry.getValue().equals(indexValue))
+                    .collect(toMap(Map.Entry::getKey, entry -> sessions.get(entry.getKey())));
+        }
+        return Map.of();
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/security/SessionConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/SessionConfiguration.java
@@ -1,0 +1,17 @@
+package de.focusshift.zeiterfassung.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
+
+@Configuration
+@EnableSpringHttpSession
+class SessionConfiguration {
+
+    @Bean
+    FindByIndexNameSessionRepository<Session> sessionRepository() {
+        return new IndexNameMapSessionRepository();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,9 +21,6 @@ spring:
     hibernate:
       ddl-auto: none
     open-in-view: false
-  session:
-    jdbc:
-      initialize-schema: always
   liquibase:
     change-log: classpath:/db/changelog/db.changelog-main.xml
   mail:

--- a/src/test/java/de/focusshift/zeiterfassung/security/IndexNameMapSessionRepositoryTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/security/IndexNameMapSessionRepositoryTest.java
@@ -1,0 +1,110 @@
+package de.focusshift.zeiterfassung.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.session.MapSession;
+import org.springframework.session.Session;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.session.FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME;
+
+class IndexNameMapSessionRepositoryTest {
+
+    private IndexNameMapSessionRepository sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new IndexNameMapSessionRepository();
+    }
+
+    @Test
+    void createSession() {
+        assertThat(sut.createSession()).isInstanceOf(MapSession.class);
+    }
+
+    @Test
+    void saveAndFindById() {
+
+        final MapSession session = new MapSession("id");
+
+        sut.save(session);
+
+        assertThat(sut.findById("id")).isEqualTo(session);
+    }
+
+    @Test
+    void saveAndFindByIndexNameAndIndexValue() {
+
+        final SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(prepareOAuth2Authentication("user1"));
+        final MapSession session1 = new MapSession("id1");
+        final MapSession session2 = new MapSession("id2");
+        sut.save(session1);
+        sut.save(session2);
+
+        context.setAuthentication(prepareOAuth2Authentication("user2"));
+        final MapSession session3 = new MapSession("id3");
+        sut.save(session3);
+
+        final Map<String, Session> byIndexNameAndIndexValue = sut.findByIndexNameAndIndexValue(PRINCIPAL_NAME_INDEX_NAME, "user1");
+        assertThat(byIndexNameAndIndexValue)
+                .containsExactlyInAnyOrderEntriesOf(Map.of("id1", session1, "id2", session2))
+                .doesNotContain(entry("id3", session3));
+
+        assertThat(sut.findByIndexNameAndIndexValue("unknown-index-name", "unknown-index-value")).isEmpty();
+    }
+
+    @Test
+    void ensureToNotFindValuesByFindByIndexNameAndIndexValueIfIndexNameIsInWrongSensitivity() {
+
+        final SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(prepareOAuth2Authentication("user1"));
+        final MapSession session1 = new MapSession("id1");
+        session1.setAttribute("SomeAttributeName", "CamelCaseValue");
+        sut.save(session1);
+
+        assertThat(sut.findByIndexNameAndIndexValue("SomeAttributeName", "camelcasevalue")).isEmpty();
+    }
+
+    @Test
+    void deleteById() {
+
+        final SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(prepareOAuth2Authentication("user"));
+        final MapSession session = new MapSession("id");
+
+        sut.save(session);
+
+        assertThat(sut.findById("id")).isEqualTo(session);
+        assertThat(sut.findByIndexNameAndIndexValue(PRINCIPAL_NAME_INDEX_NAME, "user")).containsExactlyInAnyOrderEntriesOf(Map.of("id", session));
+
+        sut.deleteById(session.getId());
+
+        assertThat(sut.findById("id")).isNull();
+        assertThat(sut.findByIndexNameAndIndexValue(PRINCIPAL_NAME_INDEX_NAME, "user")).isEmpty();
+    }
+
+    private OAuth2AuthenticationToken prepareOAuth2Authentication(String subject) {
+
+        final DefaultOidcUser oidcUser = new DefaultOidcUser(
+                List.of(),
+                OidcIdToken.withTokenValue("token-value").subject(subject).build()
+        );
+
+        final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+        when(authentication.getPrincipal()).thenReturn(oidcUser);
+
+        return authentication;
+    }
+}


### PR DESCRIPTION
related to #691


Here are some things you should have thought about:

**Multi-Tenancy**
- ~~[ ] Extended new entities with `AbstractTenantAwareEntity`?~~
- ~~[ ] New entity added to `TenantAwareDatabaseConfiguration`?~~
- [x] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
