### PR TITLE
fix authentication session reloader with tenantid context

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/security/SecurityWebConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/SecurityWebConfiguration.java
@@ -1,5 +1,6 @@
 package de.focusshift.zeiterfassung.security;
 
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
@@ -44,7 +45,7 @@ public class SecurityWebConfiguration {
     }
 
     @Bean
-    SecurityFilterChain filterChain(HttpSecurity http, DelegatingSecurityContextRepository securityContextRepository) throws Exception {
+    SecurityFilterChain filterChain(HttpSecurity http, DelegatingSecurityContextRepository securityContextRepository, TenantContextHolder tenantContextHolder) throws Exception {
         //@formatter:off
         http
             .authorizeHttpRequests(authorizeHttpRequests ->
@@ -79,7 +80,7 @@ public class SecurityWebConfiguration {
         );
 
         http.securityContext(securityContext -> securityContext.securityContextRepository(securityContextRepository));
-        http.addFilterAfter(new ReloadAuthenticationAuthoritiesFilter(userManagementService, sessionService, securityContextRepository), BasicAuthenticationFilter.class);
+        http.addFilterAfter(new ReloadAuthenticationAuthoritiesFilter(userManagementService, sessionService, securityContextRepository, tenantContextHolder), BasicAuthenticationFilter.class);
 
         //@formatter:on
         return http.build();

--- a/src/test/java/de/focusshift/zeiterfassung/security/ReloadAuthenticationAuthoritiesFilterTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/security/ReloadAuthenticationAuthoritiesFilterTest.java
@@ -1,5 +1,6 @@
 package de.focusshift.zeiterfassung.security;
 
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.UserId;
 import de.focusshift.zeiterfassung.user.UserIdComposite;
@@ -29,6 +30,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,10 +46,12 @@ class ReloadAuthenticationAuthoritiesFilterTest {
     private SessionService sessionService;
     @Mock
     private DelegatingSecurityContextRepository securityContextRepository;
+    @Mock(answer = CALLS_REAL_METHODS)
+    private TenantContextHolder tenantContextHolder;
 
     @BeforeEach
     void setUp() {
-        sut = new ReloadAuthenticationAuthoritiesFilter(userManagementService, sessionService, securityContextRepository);
+        sut = new ReloadAuthenticationAuthoritiesFilter(userManagementService, sessionService, securityContextRepository, tenantContextHolder);
     }
 
     @Test


### PR DESCRIPTION
Updating user permissions is handled by `ReloadAuthenticationAuthoritiesFilter` on next request so the user has not to logout and login again. This action has to run with tenant context, too now since https://github.com/urlaubsverwaltung/zeiterfassung/pull/546

Here are some things you should have thought about:

**Multi-Tenancy**
- ~~[ ] Extended new entities with `AbstractTenantAwareEntity`?~~
- [x] New entity added to `TenantAwareDatabaseConfiguration`?
- [x] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
