### PR TITLE
Only use public holidays for public holiday calculations

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/publicholiday/PublicHolidaysServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/publicholiday/PublicHolidaysServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static de.focus_shift.jollyday.core.HolidayType.PUBLIC_HOLIDAY;
 import static java.util.stream.Collectors.groupingBy;
 
 @Service
@@ -49,7 +50,7 @@ class PublicHolidaysServiceImpl implements PublicHolidaysService {
         }
 
         final HolidayManager holidayManager = holidayManagers.get(federalState.getCountry());
-        return holidayManager.getHolidays(from, to, federalState.getCodes())
+        return holidayManager.getHolidays(from, to, PUBLIC_HOLIDAY, federalState.getCodes())
             .stream()
             .map(holiday -> new PublicHoliday(holiday.getDate(), holiday::getDescription))
             .collect(groupingBy(PublicHoliday::date));


### PR DESCRIPTION
...since Jollyday 0.31.0 there is a possibility to filter holidays. We only want holidays of the type public holidays other types would be "bank" holidays or maybe school holidays in the future. We do not want these types.

closes #829


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
