### PR TITLE
add aggregated info of selected users to report view

### DIFF
--- a/src/main/css/reports.css
+++ b/src/main/css/reports.css
@@ -54,6 +54,10 @@
         @apply text-blue-100;
         @apply transition-colors;
       }
+      > * {
+        @apply bg-transparent;
+        @apply transition-colors;
+      }
       > *:first-child {
         @apply rounded-l-2xl;
       }
@@ -63,10 +67,8 @@
       th {
         @apply font-normal;
         @apply text-left;
-      }
-      td {
-        @apply bg-transparent;
-        @apply transition-colors;
+        @apply sticky;
+        @apply left-0;
       }
       &:hover {
         > * {

--- a/src/main/css/reports.css
+++ b/src/main/css/reports.css
@@ -28,6 +28,53 @@
   display: none;
 }
 
+.report-person-detail-table {
+  width: 100%;
+
+  th,
+  td {
+    @apply px-2;
+    @apply py-1;
+    &:last-of-type {
+      @apply pr-4;
+    }
+  }
+
+  thead {
+    th {
+      @apply font-medium;
+      @apply text-sm;
+    }
+  }
+
+  tbody {
+    tr {
+      .report-person-detail-table__avatar {
+        @apply text-blue-100;
+        @apply transition-colors;
+      }
+      td {
+        @apply bg-transparent;
+        @apply transition-colors;
+        &:first-of-type {
+          @apply rounded-l-2xl;
+        }
+        &:last-of-type {
+          @apply rounded-r-2xl;
+        }
+      }
+      &:hover {
+        td {
+          @apply bg-blue-50;
+        }
+        .report-person-detail-table__avatar {
+          @apply text-blue-200;
+        }
+      }
+    }
+  }
+}
+
 @screen xxs {
   .report-actions {
     grid-template-columns: auto;

--- a/src/main/css/reports.css
+++ b/src/main/css/reports.css
@@ -54,18 +54,22 @@
         @apply text-blue-100;
         @apply transition-colors;
       }
+      > *:first-child {
+        @apply rounded-l-2xl;
+      }
+      > *:last-child {
+        @apply rounded-r-2xl;
+      }
+      th {
+        @apply font-normal;
+        @apply text-left;
+      }
       td {
         @apply bg-transparent;
         @apply transition-colors;
-        &:first-of-type {
-          @apply rounded-l-2xl;
-        }
-        &:last-of-type {
-          @apply rounded-r-2xl;
-        }
       }
       &:hover {
-        td {
+        > * {
           @apply bg-blue-50;
         }
         .report-person-detail-table__avatar {

--- a/src/main/css/reports.css
+++ b/src/main/css/reports.css
@@ -30,6 +30,7 @@
 
 .report-person-detail-table {
   width: 100%;
+  @apply text-sm;
 
   th,
   td {

--- a/src/main/java/de/focusshift/zeiterfassung/report/DeltaWorkingHours.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/DeltaWorkingHours.java
@@ -1,0 +1,40 @@
+package de.focusshift.zeiterfassung.report;
+
+import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
+import de.focusshift.zeiterfassung.timeentry.WorkDuration;
+import de.focusshift.zeiterfassung.workingtime.ZeitDuration;
+
+import java.time.Duration;
+
+/**
+ * Describes the difference between {@linkplain WorkDuration} and {@linkplain ShouldWorkingHours}.
+ *
+ * <p>
+ * Example: {@code WorkDuration(7h) - ShouldWorkingHours(8h) = DeltaWorkingHours(-1h)}
+ *
+ * @param duration duration value of the delta
+ */
+record DeltaWorkingHours(Duration duration) implements ZeitDuration {
+
+    public static final DeltaWorkingHours ZERO = new DeltaWorkingHours(Duration.ZERO);
+    public static final DeltaWorkingHours EIGHT_POSITIVE = new DeltaWorkingHours(Duration.ofHours(8));
+    public static final DeltaWorkingHours EIGHT_NEGATIVE = new DeltaWorkingHours(Duration.ofHours(8).negated());
+
+    public boolean isNegative() {
+        return duration.isNegative();
+    }
+
+    /**
+     * Returns a {@linkplain DeltaWorkingHours} whose value is {@code (this + augend)}.
+     *
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param augend value to add, not null
+     * @return a {@linkplain DeltaWorkingHours} whose value is {@code (this + augend)}
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    public DeltaWorkingHours plus(DeltaWorkingHours augend) {
+        return new DeltaWorkingHours(duration().plus(augend.duration()));
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/report/HasWorkDurationByUser.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/HasWorkDurationByUser.java
@@ -1,0 +1,34 @@
+package de.focusshift.zeiterfassung.report;
+
+import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
+import de.focusshift.zeiterfassung.timeentry.WorkDuration;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
+import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
+
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+
+interface HasWorkDurationByUser {
+
+    Map<UserIdComposite, WorkDuration> workDurationByUser();
+
+    Map<UserIdComposite, ShouldWorkingHours> shouldWorkingHoursByUser();
+
+    Map<UserIdComposite, PlannedWorkingHours> plannedWorkingHoursByUser();
+
+    /**
+     * Returns the difference between {@linkplain ShouldWorkingHours} and the {@linkplain WorkDuration}of every user in this week.
+     *
+     * @return Map of delta duration for every user in this week
+     */
+    default Map<UserIdComposite, DeltaWorkingHours> deltaDurationByUser() {
+
+        final Map<UserIdComposite, WorkDuration> workedByUser = workDurationByUser();
+
+        return shouldWorkingHoursByUser().entrySet().stream().collect(toMap(
+            Map.Entry::getKey,
+            entry -> new DeltaWorkingHours(workedByUser.get(entry.getKey()).duration().minus(entry.getValue().duration()))
+        ));
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
@@ -26,7 +26,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toMap;
 
 @Component
 class ReportControllerHelper {
@@ -57,6 +59,7 @@ class ReportControllerHelper {
             model.addAttribute("users", selectableUserDtos);
             model.addAttribute("selectedUsers", selectableUserDtos.stream().filter(SelectableUserDto::selected).toList());
             model.addAttribute("selectedUserIds", selectedUserLocalIds.stream().map(UserLocalId::value).toList());
+            model.addAttribute("selectedUsersById", selectableUserDtos.stream().collect(toMap(SelectableUserDto::id, identity())));
             model.addAttribute("allUsersSelected", allUsersSelected);
             model.addAttribute("userReportFilterUrl", userReportFilterUrl);
         }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
@@ -9,8 +9,6 @@ import de.focusshift.zeiterfassung.user.UserId;
 import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
-import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
-import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.Model;

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
@@ -50,16 +50,18 @@ class ReportControllerHelper {
     void addUserFilterModelAttributes(Model model, boolean allUsersSelected, List<UserLocalId> selectedUserLocalIds, String userReportFilterUrl) {
 
         final List<User> permittedUsers = reportPermissionService.findAllPermittedUsersForCurrentUser();
-        if (permittedUsers.size() > 1) {
-            final List<SelectableUserDto> selectableUserDtos = permittedUsers
-                .stream()
-                .map(user -> userToSelectableUserDto(user, selectedUserLocalIds.contains(user.userLocalId())))
-                .toList();
 
-            model.addAttribute("users", selectableUserDtos);
+        final List<SelectableUserDto> selectableUserDtos = permittedUsers
+            .stream()
+            .map(user -> userToSelectableUserDto(user, selectedUserLocalIds.contains(user.userLocalId())))
+            .toList();
+
+        model.addAttribute("users", selectableUserDtos);
+        model.addAttribute("usersById", selectableUserDtos.stream().collect(toMap(SelectableUserDto::id, identity())));
+
+        if (permittedUsers.size() > 1) {
             model.addAttribute("selectedUsers", selectableUserDtos.stream().filter(SelectableUserDto::selected).toList());
             model.addAttribute("selectedUserIds", selectedUserLocalIds.stream().map(UserLocalId::value).toList());
-            model.addAttribute("selectedUsersById", selectableUserDtos.stream().collect(toMap(SelectableUserDto::id, identity())));
             model.addAttribute("allUsersSelected", allUsersSelected);
             model.addAttribute("userReportFilterUrl", userReportFilterUrl);
         }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
@@ -77,20 +77,24 @@ class ReportControllerHelper {
         final Map<UserIdComposite, PlannedWorkingHours> plannedByUser = report.plannedWorkingHoursByUser();
         final Map<UserIdComposite, DeltaWorkingHours> deltaByUser = report.deltaDurationByUser();
 
-        final List<ReportSelectedUserDurationAggregationDto> dtos = plannedByUser.keySet().stream()
-            .map(userIdComposite -> {
-                final DeltaWorkingHours delta = deltaByUser.get(userIdComposite);
-                return new ReportSelectedUserDurationAggregationDto(
-                    userIdComposite.localId().value(),
-                    durationToTimeString(delta.durationInMinutes()),
-                    delta.isNegative(),
-                    durationToTimeString(workedByUser.get(userIdComposite).durationInMinutes()),
-                    durationToTimeString(shouldByUser.get(userIdComposite).durationInMinutes())
-                );
-            })
-            .toList();
+        final boolean showAggregatedInformation = report.deltaDurationByUser().size() > 1;
 
-        model.addAttribute("selectedUserDurationAggregation", dtos);
+        if (showAggregatedInformation) {
+            final List<ReportSelectedUserDurationAggregationDto> dtos = plannedByUser.keySet().stream()
+                .map(userIdComposite -> {
+                    final DeltaWorkingHours delta = deltaByUser.get(userIdComposite);
+                    return new ReportSelectedUserDurationAggregationDto(
+                        userIdComposite.localId().value(),
+                        durationToTimeString(delta.durationInMinutes()),
+                        delta.isNegative(),
+                        durationToTimeString(workedByUser.get(userIdComposite).durationInMinutes()),
+                        durationToTimeString(shouldByUser.get(userIdComposite).durationInMinutes())
+                    );
+                })
+                .toList();
+
+            model.addAttribute("selectedUserDurationAggregation", dtos);
+        }
     }
 
     private static SelectableUserDto userToSelectableUserDto(User user, boolean selected) {

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
@@ -16,6 +16,17 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
 
+/**
+ * Report information for a certain date and users.
+ *
+ * <p>
+ * All byUser Maps contains values for the same keys. (Please ensure this on constructing this object.)
+ *
+ * @param date
+ * @param workingTimeCalendarByUser
+ * @param reportDayEntriesByUser
+ * @param detailDayAbsencesByUser
+ */
 record ReportDay(
     LocalDate date,
     Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser,

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
@@ -32,7 +32,7 @@ record ReportDay(
     Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser,
     Map<UserIdComposite, List<ReportDayEntry>> reportDayEntriesByUser,
     Map<UserIdComposite, List<ReportDayAbsence>> detailDayAbsencesByUser
-) {
+) implements HasWorkDurationByUser {
 
     public List<ReportDayEntry> reportDayEntries() {
         return reportDayEntriesByUser.values().stream().flatMap(Collection::stream).toList();

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
@@ -3,17 +3,18 @@ package de.focusshift.zeiterfassung.report;
 import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
 import de.focusshift.zeiterfassung.timeentry.WorkDuration;
 import de.focusshift.zeiterfassung.user.UserIdComposite;
-import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
 
 record ReportDay(
     LocalDate date,
@@ -33,6 +34,13 @@ record ReportDay(
             .reduce(PlannedWorkingHours.ZERO, PlannedWorkingHours::plus);
     }
 
+    public Map<UserIdComposite, PlannedWorkingHours> plannedWorkingHoursByUser() {
+        return workingTimeCalendarByUser.entrySet().stream().collect(toMap(
+            Map.Entry::getKey,
+            entry -> entry.getValue().plannedWorkingHours(date).orElse(PlannedWorkingHours.ZERO)
+        ));
+    }
+
     public ShouldWorkingHours shouldWorkingHours() {
         return workingTimeCalendarByUser.values().stream()
             .map(calendar -> calendar.shouldWorkingHours(date))
@@ -40,10 +48,12 @@ record ReportDay(
             .reduce(ShouldWorkingHours.ZERO, ShouldWorkingHours::plus);
     }
 
-    public PlannedWorkingHours plannedWorkingHoursByUser(UserLocalId userLocalId) {
-        return findValueByFirstKeyMatch(workingTimeCalendarByUser, userIdComposite -> userLocalId.equals(userIdComposite.localId()))
-            .flatMap(calendar -> calendar.plannedWorkingHours(date))
-            .orElse(PlannedWorkingHours.ZERO);
+    public Map<UserIdComposite, ShouldWorkingHours> shouldWorkingHoursByUser() {
+        return workingTimeCalendarByUser.entrySet().stream()
+            .collect(toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().shouldWorkingHours(date).orElse(ShouldWorkingHours.ZERO))
+            );
     }
 
     public WorkDuration workDuration() {
@@ -55,26 +65,27 @@ record ReportDay(
         return calculateWorkDurationFrom(allReportDayEntries);
     }
 
-    public WorkDuration workDurationByUser(UserLocalId userLocalId) {
-        return workDurationByUserPredicate(userIdComposite -> userLocalId.equals(userIdComposite.localId()));
-    }
+    public Map<UserIdComposite, WorkDuration> workDurationByUser() {
 
-    private WorkDuration workDurationByUserPredicate(Predicate<UserIdComposite> predicate) {
-        final List<ReportDayEntry> reportDayEntries = findValueByFirstKeyMatch(reportDayEntriesByUser, predicate).orElse(List.of());
-        return calculateWorkDurationFrom(reportDayEntries.stream());
+        final HashMap<UserIdComposite, WorkDuration> workDurationByUser = new HashMap<>();
+
+        for (Map.Entry<UserIdComposite, List<ReportDayEntry>> entry : reportDayEntriesByUser.entrySet()) {
+            final UserIdComposite id = entry.getKey();
+            final List<ReportDayEntry> reportDayEntries = entry.getValue();
+
+            final WorkDuration workDuration = reportDayEntries.stream()
+                .map(ReportDayEntry::workDuration)
+                .reduce(WorkDuration.ZERO, WorkDuration::plus);
+
+            workDurationByUser.put(id, workDuration);
+        }
+
+        return workDurationByUser;
     }
 
     private WorkDuration calculateWorkDurationFrom(Stream<ReportDayEntry> reportDayEntries) {
         return reportDayEntries
             .map(ReportDayEntry::workDuration)
             .reduce(WorkDuration.ZERO, WorkDuration::plus);
-    }
-
-    private <K, T> Optional<T> findValueByFirstKeyMatch(Map<K, T> map, Predicate<K> predicate) {
-        return map.entrySet()
-            .stream()
-            .filter(entry -> predicate.test(entry.getKey()))
-            .findFirst()
-            .map(Map.Entry::getValue);
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
@@ -23,9 +23,9 @@ import static java.util.stream.Collectors.toMap;
  * All byUser Maps contains values for the same keys. (Please ensure this on constructing this object.)
  *
  * @param date
- * @param workingTimeCalendarByUser
- * @param reportDayEntriesByUser
- * @param detailDayAbsencesByUser
+ * @param workingTimeCalendarByUser {@linkplain WorkingTimeCalendar} for all relevant users
+ * @param reportDayEntriesByUser {@linkplain ReportDayEntry entries} for all relevant users
+ * @param detailDayAbsencesByUser {@linkplain ReportDayAbsence absences} for all relevant users
  */
 record ReportDay(
     LocalDate date,

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportDayEntry.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportDayEntry.java
@@ -6,6 +6,15 @@ import de.focusshift.zeiterfassung.usermanagement.User;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 
+/**
+ * Provides {@linkplain de.focusshift.zeiterfassung.timeentry.TimeEntry} information for reports.
+ *
+ * @param user user the entry belongs to
+ * @param comment comment of the day entry, never {@code null}
+ * @param start start timestamp fo the entry
+ * @param end end timestamp of the entry
+ * @param isBreak whether the entry is a break or not
+ */
 record ReportDayEntry(
     User user,
     String comment,

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportFunctions.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportFunctions.java
@@ -1,0 +1,89 @@
+package de.focusshift.zeiterfassung.report;
+
+import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
+import de.focusshift.zeiterfassung.timeentry.WorkDuration;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
+import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.function.Predicate.not;
+
+/**
+ * Functions used by Report domain objects to calculate stuff regarding durations.
+ */
+class ReportFunctions {
+
+    private ReportFunctions() {
+    }
+
+    static <T> PlannedWorkingHours summarizePlannedWorkingHours(List<T> elements, Function<T, PlannedWorkingHours> supplier) {
+        return elements.stream().map(supplier).reduce(PlannedWorkingHours.ZERO, PlannedWorkingHours::plus);
+    }
+
+    static Map<UserIdComposite, PlannedWorkingHours> summarizePlannedWorkingHoursByUser(List<? extends HasWorkDurationByUser> elements) {
+        final HashMap<UserIdComposite, PlannedWorkingHours> plannedWorkingHoursByUser = new HashMap<>();
+
+        for (HasWorkDurationByUser element : elements) {
+            element.plannedWorkingHoursByUser().forEach((userIdComposite, plannedWorkingHours) -> {
+                final PlannedWorkingHours hours = plannedWorkingHoursByUser.getOrDefault(userIdComposite, PlannedWorkingHours.ZERO);
+                plannedWorkingHoursByUser.put(userIdComposite, hours.plus(plannedWorkingHours));
+            });
+        }
+
+        return plannedWorkingHoursByUser;
+    }
+
+    static <T> ShouldWorkingHours summarizeShouldWorkingHours(List<T> elements, Function<T, ShouldWorkingHours> supplier) {
+        return elements.stream().map(supplier).reduce(ShouldWorkingHours.ZERO, ShouldWorkingHours::plus);
+    }
+
+    static Map<UserIdComposite, ShouldWorkingHours> summarizeShouldWorkingHoursByUser(List<? extends HasWorkDurationByUser> elements) {
+        final HashMap<UserIdComposite, ShouldWorkingHours> shouldWorkingHoursByUser = new HashMap<>();
+
+        for (HasWorkDurationByUser element : elements) {
+            element.shouldWorkingHoursByUser().forEach((userIdComposite, shouldWorkingHours) -> {
+                final ShouldWorkingHours hours = shouldWorkingHoursByUser.getOrDefault(userIdComposite, ShouldWorkingHours.ZERO);
+                shouldWorkingHoursByUser.put(userIdComposite, hours.plus(shouldWorkingHours));
+            });
+        }
+
+        return shouldWorkingHoursByUser;
+    }
+
+    static <T> WorkDuration calculateAverageDayWorkDuration(List<T> elements, Function<T, WorkDuration> supplier) {
+
+        final double averageMinutes = elements.stream()
+            .map(supplier)
+            .filter(not(WorkDuration.ZERO::equals))
+            .map(WorkDuration::durationInMinutes)
+            .mapToLong(Duration::toMinutes)
+            .average()
+            .orElse(0.0);// o.O
+
+        final Duration duration = Duration.ofMinutes(Math.round(averageMinutes));
+
+        return new WorkDuration(duration);
+    }
+
+    static <T> WorkDuration summarizeWorkDuration(List<T> elements, Function<T, WorkDuration> supplier) {
+        return elements.stream().map(supplier).reduce(WorkDuration.ZERO, WorkDuration::plus);
+    }
+
+    static Map<UserIdComposite, WorkDuration> summarizeWorkDurationByUser(List<? extends HasWorkDurationByUser> elements) {
+        final HashMap<UserIdComposite, WorkDuration> byUser = new HashMap<>();
+
+        for (HasWorkDurationByUser element : elements) {
+            element.workDurationByUser().forEach((userIdComposite, dayDuration) -> {
+                final WorkDuration summedDuration = byUser.getOrDefault(userIdComposite, WorkDuration.ZERO);
+                byUser.put(userIdComposite, summedDuration.plus(dayDuration));
+            });
+        }
+
+        return byUser;
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportMonth.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportMonth.java
@@ -6,89 +6,45 @@ import de.focusshift.zeiterfassung.timeentry.WorkDuration;
 import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
 
-import java.time.Duration;
 import java.time.YearMonth;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.function.Predicate.not;
+import static de.focusshift.zeiterfassung.report.ReportFunctions.calculateAverageDayWorkDuration;
+import static de.focusshift.zeiterfassung.report.ReportFunctions.summarizePlannedWorkingHours;
+import static de.focusshift.zeiterfassung.report.ReportFunctions.summarizePlannedWorkingHoursByUser;
+import static de.focusshift.zeiterfassung.report.ReportFunctions.summarizeShouldWorkingHours;
+import static de.focusshift.zeiterfassung.report.ReportFunctions.summarizeShouldWorkingHoursByUser;
+import static de.focusshift.zeiterfassung.report.ReportFunctions.summarizeWorkDuration;
+import static de.focusshift.zeiterfassung.report.ReportFunctions.summarizeWorkDurationByUser;
 
 record ReportMonth(YearMonth yearMonth, List<ReportWeek> weeks) implements HasWorkDurationByUser, HasWorkedHoursRatio {
 
     public PlannedWorkingHours plannedWorkingHours() {
-        return weeks.stream()
-            .map(ReportWeek::plannedWorkingHours)
-            .reduce(PlannedWorkingHours.ZERO, PlannedWorkingHours::plus);
+        return summarizePlannedWorkingHours(weeks, ReportWeek::plannedWorkingHours);
     }
 
     public Map<UserIdComposite, PlannedWorkingHours> plannedWorkingHoursByUser() {
-        final HashMap<UserIdComposite, PlannedWorkingHours> plannedWorkingHoursByUser = new HashMap<>();
-
-        for (ReportWeek week : weeks) {
-            week.plannedWorkingHoursByUser().forEach((userIdComposite, plannedWorkingHours) -> {
-                final PlannedWorkingHours hours = plannedWorkingHoursByUser.getOrDefault(userIdComposite, PlannedWorkingHours.ZERO);
-                plannedWorkingHoursByUser.put(userIdComposite, hours.plus(plannedWorkingHours));
-            });
-        }
-
-        return plannedWorkingHoursByUser;
+        return summarizePlannedWorkingHoursByUser(weeks);
     }
 
     public ShouldWorkingHours shouldWorkingHours() {
-        return weeks.stream()
-            .map(ReportWeek::shouldWorkingHours)
-            .reduce(ShouldWorkingHours.ZERO, ShouldWorkingHours::plus);
+        return summarizeShouldWorkingHours(weeks, ReportWeek::shouldWorkingHours);
     }
 
     public Map<UserIdComposite, ShouldWorkingHours> shouldWorkingHoursByUser() {
-        final HashMap<UserIdComposite, ShouldWorkingHours> shouldWorkingHoursByUser = new HashMap<>();
-
-        for (ReportWeek week : weeks) {
-            week.shouldWorkingHoursByUser().forEach((userIdComposite, shouldWorkingHours) -> {
-                final ShouldWorkingHours hours = shouldWorkingHoursByUser.getOrDefault(userIdComposite, ShouldWorkingHours.ZERO);
-                shouldWorkingHoursByUser.put(userIdComposite, hours.plus(shouldWorkingHours));
-            });
-        }
-
-        return shouldWorkingHoursByUser;
+        return summarizeShouldWorkingHoursByUser(weeks);
     }
 
     public WorkDuration averageDayWorkDuration() {
-
-        final double averageMinutes = weeks.stream()
-            .map(ReportWeek::reportDays)
-            .flatMap(Collection::stream)
-            .map(ReportDay::workDuration)
-            .filter(not(WorkDuration.ZERO::equals))
-            .map(WorkDuration::durationInMinutes)
-            .mapToLong(Duration::toMinutes)
-            .average()
-            .orElse(0.0);// o.O
-
-        final Duration duration = Duration.ofMinutes(Math.round(averageMinutes));
-
-        return new WorkDuration(duration);
+        return calculateAverageDayWorkDuration(weeks, ReportWeek::averageDayWorkDuration);
     }
 
     public WorkDuration workDuration() {
-        return weeks
-            .stream()
-            .map(ReportWeek::workDuration)
-            .reduce(WorkDuration.ZERO, WorkDuration::plus);
+        return summarizeWorkDuration(weeks, ReportWeek::workDuration);
     }
 
     public Map<UserIdComposite, WorkDuration> workDurationByUser() {
-        final HashMap<UserIdComposite, WorkDuration> byUser = new HashMap<>();
-
-        for (ReportWeek week : weeks) {
-            week.workDurationByUser().forEach((userIdComposite, dayDuration) -> {
-                final WorkDuration summedDuration = byUser.getOrDefault(userIdComposite, WorkDuration.ZERO);
-                byUser.put(userIdComposite, summedDuration.plus(dayDuration));
-            });
-        }
-
-        return byUser;
+        return summarizeWorkDurationByUser(weeks);
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportMonth.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportMonth.java
@@ -3,12 +3,15 @@ package de.focusshift.zeiterfassung.report;
 import de.focusshift.zeiterfassung.timeentry.HasWorkedHoursRatio;
 import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
 import de.focusshift.zeiterfassung.timeentry.WorkDuration;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
 
 import java.time.Duration;
 import java.time.YearMonth;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.function.Predicate.not;
 
@@ -20,10 +23,36 @@ record ReportMonth(YearMonth yearMonth, List<ReportWeek> weeks) implements HasWo
             .reduce(PlannedWorkingHours.ZERO, PlannedWorkingHours::plus);
     }
 
+    public Map<UserIdComposite, PlannedWorkingHours> plannedWorkingHoursByUser() {
+        final HashMap<UserIdComposite, PlannedWorkingHours> plannedWorkingHoursByUser = new HashMap<>();
+
+        for (ReportWeek week : weeks) {
+            week.plannedWorkingHoursByUser().forEach((userIdComposite, plannedWorkingHours) -> {
+                final PlannedWorkingHours hours = plannedWorkingHoursByUser.getOrDefault(userIdComposite, PlannedWorkingHours.ZERO);
+                plannedWorkingHoursByUser.put(userIdComposite, hours.plus(plannedWorkingHours));
+            });
+        }
+
+        return plannedWorkingHoursByUser;
+    }
+
     public ShouldWorkingHours shouldWorkingHours() {
         return weeks.stream()
             .map(ReportWeek::shouldWorkingHours)
             .reduce(ShouldWorkingHours.ZERO, ShouldWorkingHours::plus);
+    }
+
+    public Map<UserIdComposite, ShouldWorkingHours> shouldWorkingHoursByUser() {
+        final HashMap<UserIdComposite, ShouldWorkingHours> shouldWorkingHoursByUser = new HashMap<>();
+
+        for (ReportWeek week : weeks) {
+            week.shouldWorkingHoursByUser().forEach((userIdComposite, shouldWorkingHours) -> {
+                final ShouldWorkingHours hours = shouldWorkingHoursByUser.getOrDefault(userIdComposite, ShouldWorkingHours.ZERO);
+                shouldWorkingHoursByUser.put(userIdComposite, hours.plus(shouldWorkingHours));
+            });
+        }
+
+        return shouldWorkingHoursByUser;
     }
 
     public WorkDuration averageDayWorkDuration() {
@@ -48,5 +77,18 @@ record ReportMonth(YearMonth yearMonth, List<ReportWeek> weeks) implements HasWo
             .stream()
             .map(ReportWeek::workDuration)
             .reduce(WorkDuration.ZERO, WorkDuration::plus);
+    }
+
+    public Map<UserIdComposite, WorkDuration> workDurationByUser() {
+        final HashMap<UserIdComposite, WorkDuration> byUser = new HashMap<>();
+
+        for (ReportWeek week : weeks) {
+            week.workDurationByUser().forEach((userIdComposite, dayDuration) -> {
+                final WorkDuration summedDuration = byUser.getOrDefault(userIdComposite, WorkDuration.ZERO);
+                byUser.put(userIdComposite, summedDuration.plus(dayDuration));
+            });
+        }
+
+        return byUser;
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportMonth.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportMonth.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 import static java.util.function.Predicate.not;
 
-record ReportMonth(YearMonth yearMonth, List<ReportWeek> weeks) implements HasWorkedHoursRatio {
+record ReportMonth(YearMonth yearMonth, List<ReportWeek> weeks) implements HasWorkDurationByUser, HasWorkedHoursRatio {
 
     public PlannedWorkingHours plannedWorkingHours() {
         return weeks.stream()

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
@@ -5,9 +5,7 @@ import de.focusshift.zeiterfassung.timeclock.HasTimeClock;
 import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
 import de.focusshift.zeiterfassung.timeentry.WorkDuration;
 import de.focusshift.zeiterfassung.user.DateFormatter;
-import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
-import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +28,6 @@ import java.time.Duration;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.invoke.MethodHandles.lookup;
@@ -117,7 +114,7 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad {
         model.addAttribute("userReportCsvDownloadUrl", csvDownloadUrl);
 
         helper.addUserFilterModelAttributes(model, allUsersSelected, userLocalIds, String.format("/report/year/%d/month/%d", year, month));
-        model.addAttribute("selectedUserDurationAggregation", toReportSelectedUserDurationAggregationDto(reportMonth));
+        helper.addSelectedUserDurationAggregationModelAttributes(model, reportMonth);
 
         return "reports/user-report";
     }
@@ -162,20 +159,6 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad {
         final double weekRatio = reportMonth.workedHoursRatio().multiply(BigDecimal.valueOf(100), new MathContext(2)).doubleValue();
 
         return new GraphMonthDto(yearMonth, graphWeekDtos, maxHoursWorked, workedWorkingHoursString, shouldWorkingHoursString, deltaHours, deltaDuration.isNegative(), weekRatio);
-    }
-
-    private List<ReportSelectedUserDurationAggregationDto> toReportSelectedUserDurationAggregationDto(ReportMonth reportMonth) {
-
-        final Map<UserIdComposite, WorkDuration> workedByUser = reportMonth.workDurationByUser();
-        final Map<UserIdComposite, ShouldWorkingHours> shouldByUser = reportMonth.shouldWorkingHoursByUser();
-        final Map<UserIdComposite, PlannedWorkingHours> plannedByUser = reportMonth.plannedWorkingHoursByUser();
-
-        return plannedByUser.keySet().stream().map(userIdComposite -> new ReportSelectedUserDurationAggregationDto(
-            userIdComposite.localId().value(),
-            durationToTimeString(Duration.ZERO), // TODO
-            durationToTimeString(workedByUser.get(userIdComposite).duration()),
-            durationToTimeString(shouldByUser.get(userIdComposite).duration())
-        )).toList();
     }
 
     private DetailMonthDto toDetailMonthDto(ReportMonth reportMonth, Locale locale) {

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
@@ -164,7 +164,7 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad {
         return new GraphMonthDto(yearMonth, graphWeekDtos, maxHoursWorked, workedWorkingHoursString, shouldWorkingHoursString, deltaHours, deltaDuration.isNegative(), weekRatio);
     }
 
-    record ReportSelectedUserDurationAggregationDto(Long userId, String delta, String worked, String should, String planned) {}
+    record ReportSelectedUserDurationAggregationDto(Long userId, String delta, String worked, String should) {}
 
     private List<ReportSelectedUserDurationAggregationDto> toReportSelectedUserDurationAggregationDto(ReportMonth reportMonth) {
 
@@ -176,8 +176,7 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad {
             userIdComposite.localId().value(),
             durationToTimeString(Duration.ZERO), // TODO
             durationToTimeString(workedByUser.get(userIdComposite).duration()),
-            durationToTimeString(shouldByUser.get(userIdComposite).duration()),
-            durationToTimeString(plannedByUser.get(userIdComposite).duration())
+            durationToTimeString(shouldByUser.get(userIdComposite).duration())
         )).toList();
     }
 

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
@@ -164,8 +164,6 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad {
         return new GraphMonthDto(yearMonth, graphWeekDtos, maxHoursWorked, workedWorkingHoursString, shouldWorkingHoursString, deltaHours, deltaDuration.isNegative(), weekRatio);
     }
 
-    record ReportSelectedUserDurationAggregationDto(Long userId, String delta, String worked, String should) {}
-
     private List<ReportSelectedUserDurationAggregationDto> toReportSelectedUserDurationAggregationDto(ReportMonth reportMonth) {
 
         final Map<UserIdComposite, WorkDuration> workedByUser = reportMonth.workDurationByUser();

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
@@ -5,6 +5,7 @@ import de.focusshift.zeiterfassung.timeclock.HasTimeClock;
 import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
 import de.focusshift.zeiterfassung.timeentry.WorkDuration;
 import de.focusshift.zeiterfassung.user.DateFormatter;
+import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -43,12 +44,14 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad {
     private final DateFormatter dateFormatter;
     private final ReportControllerHelper helper;
     private final Clock clock;
+    private final ReportPermissionService reportPermissionService;
 
-    ReportMonthController(ReportService reportService, DateFormatter dateFormatter, ReportControllerHelper helper, Clock clock) {
+    ReportMonthController(ReportService reportService, ReportPermissionService reportPermissionService, DateFormatter dateFormatter, ReportControllerHelper helper, Clock clock) {
         this.reportService = reportService;
         this.dateFormatter = dateFormatter;
         this.helper = helper;
         this.clock = clock;
+        this.reportPermissionService = reportPermissionService;
     }
 
     @GetMapping("/report/month")
@@ -113,8 +116,10 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad {
         model.addAttribute("userReportNextSectionUrl", nextSectionUrl);
         model.addAttribute("userReportCsvDownloadUrl", csvDownloadUrl);
 
-        helper.addUserFilterModelAttributes(model, allUsersSelected, userLocalIds, String.format("/report/year/%d/month/%d", year, month));
-        helper.addSelectedUserDurationAggregationModelAttributes(model, reportMonth);
+        final List<User> users = reportPermissionService.findAllPermittedUsersForCurrentUser();
+
+        helper.addUserFilterModelAttributes(model, allUsersSelected, users, userLocalIds, String.format("/report/year/%d/month/%d", year, month));
+        helper.addSelectedUserDurationAggregationModelAttributes(model, allUsersSelected, users, userLocalIds, reportMonth);
 
         return "reports/user-report";
     }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
@@ -5,7 +5,9 @@ import de.focusshift.zeiterfassung.timeclock.HasTimeClock;
 import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
 import de.focusshift.zeiterfassung.timeentry.WorkDuration;
 import de.focusshift.zeiterfassung.user.DateFormatter;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +30,7 @@ import java.time.Duration;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.invoke.MethodHandles.lookup;
@@ -114,6 +117,7 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad {
         model.addAttribute("userReportCsvDownloadUrl", csvDownloadUrl);
 
         helper.addUserFilterModelAttributes(model, allUsersSelected, userLocalIds, String.format("/report/year/%d/month/%d", year, month));
+        model.addAttribute("selectedUserDurationAggregation", toReportSelectedUserDurationAggregationDto(reportMonth));
 
         return "reports/user-report";
     }
@@ -158,6 +162,23 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad {
         final double weekRatio = reportMonth.workedHoursRatio().multiply(BigDecimal.valueOf(100), new MathContext(2)).doubleValue();
 
         return new GraphMonthDto(yearMonth, graphWeekDtos, maxHoursWorked, workedWorkingHoursString, shouldWorkingHoursString, deltaHours, deltaDuration.isNegative(), weekRatio);
+    }
+
+    record ReportSelectedUserDurationAggregationDto(Long userId, String delta, String worked, String should, String planned) {}
+
+    private List<ReportSelectedUserDurationAggregationDto> toReportSelectedUserDurationAggregationDto(ReportMonth reportMonth) {
+
+        final Map<UserIdComposite, WorkDuration> workedByUser = reportMonth.workDurationByUser();
+        final Map<UserIdComposite, ShouldWorkingHours> shouldByUser = reportMonth.shouldWorkingHoursByUser();
+        final Map<UserIdComposite, PlannedWorkingHours> plannedByUser = reportMonth.plannedWorkingHoursByUser();
+
+        return plannedByUser.keySet().stream().map(userIdComposite -> new ReportSelectedUserDurationAggregationDto(
+            userIdComposite.localId().value(),
+            durationToTimeString(Duration.ZERO), // TODO
+            durationToTimeString(workedByUser.get(userIdComposite).duration()),
+            durationToTimeString(shouldByUser.get(userIdComposite).duration()),
+            durationToTimeString(plannedByUser.get(userIdComposite).duration())
+        )).toList();
     }
 
     private DetailMonthDto toDetailMonthDto(ReportMonth reportMonth, Locale locale) {

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportSelectedUserDurationAggregationDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportSelectedUserDurationAggregationDto.java
@@ -1,4 +1,4 @@
 package de.focusshift.zeiterfassung.report;
 
-record ReportSelectedUserDurationAggregationDto(Long userId, String delta, boolean deltaNegative, String worked, String should) {
+record ReportSelectedUserDurationAggregationDto(Long userId, String fullName, String delta, boolean deltaNegative, String worked, String should) {
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportSelectedUserDurationAggregationDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportSelectedUserDurationAggregationDto.java
@@ -1,0 +1,4 @@
+package de.focusshift.zeiterfassung.report;
+
+record ReportSelectedUserDurationAggregationDto(Long userId, String delta, String worked, String should) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportSelectedUserDurationAggregationDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportSelectedUserDurationAggregationDto.java
@@ -1,4 +1,4 @@
 package de.focusshift.zeiterfassung.report;
 
-record ReportSelectedUserDurationAggregationDto(Long userId, String delta, String worked, String should) {
+record ReportSelectedUserDurationAggregationDto(Long userId, String delta, boolean deltaNegative, String worked, String should) {
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportServiceRaw.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportServiceRaw.java
@@ -175,7 +175,7 @@ class ReportServiceRaw {
         }
 
         final Function<LocalDate, Map<UserIdComposite, List<ReportDayEntry>>> resolveReportDayEntries =
-            (LocalDate date) -> reportEntriesByDate.getOrDefault(date, Map.of());
+            (LocalDate date) -> reportEntriesByDate.getOrDefault(date, new HashMap<>());
 
         final List<ReportDay> reportDays = IntStream.rangeClosed(0, 6)
             .mapToObj(daysToAdd ->
@@ -230,7 +230,7 @@ class ReportServiceRaw {
         final Map<UserIdComposite, List<ReportDayAbsence>> reportDayAbsencesByUser = new HashMap<>();
 
         // to avoid NullPointer exceptions Maps must contain values for every user that has planned working hours at this day
-        // todoo: workingTimeCalendar map contains ALL users, we may want to handle only relevant users some time
+        // todo: workingTimeCalendar map contains ALL users, we may want to handle only relevant users some time
         for (Map.Entry<UserIdComposite, WorkingTimeCalendar> entry : workingTimeCalendars.entrySet()) {
             final UserIdComposite userIdComposite = entry.getKey();
             final WorkingTimeCalendar workingTimeCalendar = entry.getValue();

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportWeek.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportWeek.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 import static java.util.function.Predicate.not;
 
-record ReportWeek(LocalDate firstDateOfWeek, List<ReportDay> reportDays) implements HasWorkedHoursRatio {
+record ReportWeek(LocalDate firstDateOfWeek, List<ReportDay> reportDays) implements HasWorkDurationByUser, HasWorkedHoursRatio {
 
     public PlannedWorkingHours plannedWorkingHours() {
         return reportDays.stream()

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportWeekController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportWeekController.java
@@ -2,7 +2,11 @@ package de.focusshift.zeiterfassung.report;
 
 import de.focus_shift.launchpad.api.HasLaunchpad;
 import de.focusshift.zeiterfassung.timeclock.HasTimeClock;
+import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
+import de.focusshift.zeiterfassung.timeentry.WorkDuration;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,9 +24,11 @@ import org.threeten.extra.YearWeek;
 
 import java.time.Clock;
 import java.time.DateTimeException;
+import java.time.Duration;
 import java.time.Year;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -107,6 +113,7 @@ class ReportWeekController implements HasTimeClock, HasLaunchpad {
         model.addAttribute("userReportCsvDownloadUrl", csvDownloadUrl);
 
         helper.addUserFilterModelAttributes(model, allUsersSelected, userLocalIds, format("/report/year/%d/week/%d", year, week));
+        model.addAttribute("selectedUserDurationAggregation", toReportSelectedUserDurationAggregationDto(reportWeek));
 
         return "reports/user-report";
     }
@@ -126,6 +133,22 @@ class ReportWeekController implements HasTimeClock, HasLaunchpad {
         return reportWeek;
     }
 
+    record ReportSelectedUserDurationAggregationDto(Long userId, String delta, String worked, String should) {}
+
+    private List<ReportSelectedUserDurationAggregationDto> toReportSelectedUserDurationAggregationDto(ReportWeek reportWeek) {
+
+        final Map<UserIdComposite, WorkDuration> workedByUser = reportWeek.workDurationByUser();
+        final Map<UserIdComposite, ShouldWorkingHours> shouldByUser = reportWeek.shouldWorkingHoursByUser();
+        final Map<UserIdComposite, PlannedWorkingHours> plannedByUser = reportWeek.plannedWorkingHoursByUser();
+
+        return plannedByUser.keySet().stream().map(userIdComposite -> new ReportSelectedUserDurationAggregationDto(
+            userIdComposite.localId().value(),
+            durationToTimeString(Duration.ZERO), // TODO
+            durationToTimeString(workedByUser.get(userIdComposite).duration()),
+            durationToTimeString(shouldByUser.get(userIdComposite).duration())
+        )).toList();
+    }
+
     private static Optional<YearWeek> yearWeek(int year, int week) {
         try {
             return Optional.of(YearWeek.of(Year.of(year), week));
@@ -133,5 +156,11 @@ class ReportWeekController implements HasTimeClock, HasLaunchpad {
             LOG.error("could not create YearWeek with year={} week={}", year, week, exception);
             return Optional.empty();
         }
+    }
+
+    private static String durationToTimeString(Duration duration) {
+        // use positive values to format duration string
+        // negative value is handled in template
+        return String.format("%02d:%02d", Math.abs(duration.toHours()), Math.abs(duration.toMinutesPart()));
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportWeekController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportWeekController.java
@@ -133,8 +133,6 @@ class ReportWeekController implements HasTimeClock, HasLaunchpad {
         return reportWeek;
     }
 
-    record ReportSelectedUserDurationAggregationDto(Long userId, String delta, String worked, String should) {}
-
     private List<ReportSelectedUserDurationAggregationDto> toReportSelectedUserDurationAggregationDto(ReportWeek reportWeek) {
 
         final Map<UserIdComposite, WorkDuration> workedByUser = reportWeek.workDurationByUser();

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportWeekController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportWeekController.java
@@ -35,6 +35,8 @@ class ReportWeekController implements HasTimeClock, HasLaunchpad {
 
     private static final Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());
 
+    private static final String REPORT_YEAR_WEEK_URL_TEMPLATE = "/report/year/%d/week/%d";
+
     private final ReportService reportService;
     private final ReportPermissionService reportPermissionService;
     private final ReportControllerHelper helper;
@@ -91,17 +93,17 @@ class ReportWeekController implements HasTimeClock, HasLaunchpad {
 
         final int previousYear = reportYearWeek.minusWeeks(1).getYear();
         final int previousWeek = reportYearWeek.minusWeeks(1).getWeek();
-        final String previousSectionUrl = helper.createUrl(format("/report/year/%d/week/%d", previousYear, previousWeek), allUsersSelected, selectedUserLocalIds);
+        final String previousSectionUrl = helper.createUrl(format(REPORT_YEAR_WEEK_URL_TEMPLATE, previousYear, previousWeek), allUsersSelected, selectedUserLocalIds);
 
         final String todaySectionUrl = helper.createUrl("/report/week", allUsersSelected, selectedUserLocalIds);
 
         final int nextYear = reportYearWeek.plusWeeks(1).getYear();
         final int nextWeek = reportYearWeek.plusWeeks(1).getWeek();
-        final String nextSectionUrl = helper.createUrl(format("/report/year/%d/week/%d", nextYear, nextWeek), allUsersSelected, selectedUserLocalIds);
+        final String nextSectionUrl = helper.createUrl(format(REPORT_YEAR_WEEK_URL_TEMPLATE, nextYear, nextWeek), allUsersSelected, selectedUserLocalIds);
 
         final int selectedYear = reportYearWeek.getYear();
         final int selectedWeek = reportYearWeek.getWeek();
-        final String selectedYearWeekUrl = helper.createUrl(format("/report/year/%d/week/%d", selectedYear, selectedWeek), allUsersSelected, selectedUserLocalIds);
+        final String selectedYearWeekUrl = helper.createUrl(format(REPORT_YEAR_WEEK_URL_TEMPLATE, selectedYear, selectedWeek), allUsersSelected, selectedUserLocalIds);
         final String csvDownloadUrl = selectedYearWeekUrl.contains("?") ? selectedYearWeekUrl + "&csv" : selectedYearWeekUrl + "?csv";
 
         model.addAttribute("userReportPreviousSectionUrl", previousSectionUrl);
@@ -111,7 +113,7 @@ class ReportWeekController implements HasTimeClock, HasLaunchpad {
 
         final List<User> users = reportPermissionService.findAllPermittedUsersForCurrentUser();
 
-        helper.addUserFilterModelAttributes(model, allUsersSelected, users, selectedUserLocalIds, format("/report/year/%d/week/%d", year, week));
+        helper.addUserFilterModelAttributes(model, allUsersSelected, users, selectedUserLocalIds, format(REPORT_YEAR_WEEK_URL_TEMPLATE, year, week));
         helper.addSelectedUserDurationAggregationModelAttributes(model, allUsersSelected, users, selectedUserLocalIds, reportWeek);
 
         return "reports/user-report";

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntry.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntry.java
@@ -6,6 +6,16 @@ import de.focusshift.zeiterfassung.workingtime.ZeitDuration;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 
+/**
+ * Describes one time entry of a user.
+ *
+ * @param id id of this time entry
+ * @param userIdComposite id composite of the corresponding user
+ * @param comment comment of the time entry, never {@code null}
+ * @param start start timestamp
+ * @param end end timestamp, never {@code null} ({@linkplain de.focusshift.zeiterfassung.timeclock.TimeClock} is something with start but without end)
+ * @param isBreak whether time entry is a break or not
+ */
 public record TimeEntry(
     TimeEntryId id,
     UserIdComposite userIdComposite,

--- a/src/main/javascript/components/avatar/avatar.ts
+++ b/src/main/javascript/components/avatar/avatar.ts
@@ -39,7 +39,7 @@ export class Avatar extends HTMLImageElement {
 
     const parent = this.parentElement;
     parent.replaceChild(t.content, this);
-    parent.querySelector("svg").classList.add(...clazzes);
+    parent.querySelector("svg").classList.add(...clazzes, "cursor-default");
   }
 
   private addTooltip(altText: string) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -325,7 +325,6 @@ report.aggregated.table.head.user=Person
 report.aggregated.table.head.delta=Abweichung
 report.aggregated.table.head.worked=Geleistet
 report.aggregated.table.head.should=Soll
-report.aggregated.table.head.planned=Geplant
 
 report.detail.summary.planned-working-hours=Geplante Arbeitszeit:
 report.detail.summary.hours-worked=Geleistete Arbeitszeit:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -321,6 +321,12 @@ report.csv.header.break=Pause
 
 report.time.pagination.navigation.aria-label=Bericht Seiten-Nummerierung
 
+report.aggregated.table.head.user=Person
+report.aggregated.table.head.delta=Abweichung
+report.aggregated.table.head.worked=Geleistet
+report.aggregated.table.head.should=Soll
+report.aggregated.table.head.planned=Geplant
+
 report.detail.summary.planned-working-hours=Geplante Arbeitszeit:
 report.detail.summary.hours-worked=Geleistete Arbeitszeit:
 report.detail.summary.hoursDelta.negative=Noch zu leistende Arbeitszeit:

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -324,7 +324,7 @@ report.time.pagination.navigation.aria-label=Bericht Seiten-Nummerierung
 report.aggregated.table.head.user=Person
 report.aggregated.table.head.delta=Abweichung
 report.aggregated.table.head.worked=Geleistet
-report.aggregated.table.head.should=Soll
+report.aggregated.table.head.should=Geplant
 
 report.detail.summary.planned-working-hours=Geplante Arbeitszeit:
 report.detail.summary.hours-worked=Geleistete Arbeitszeit:

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -321,6 +321,12 @@ report.csv.header.break=Break
 
 report.time.pagination.navigation.aria-label=Bericht Seiten-Nummerierung
 
+report.aggregated.table.head.user=Person
+report.aggregated.table.head.delta=Difference
+report.aggregated.table.head.worked=Worked
+report.aggregated.table.head.should=Should
+report.aggregated.table.head.planned=Planned
+
 report.detail.summary.planned-working-hours=Planned Working Hours:
 report.detail.summary.hours-worked=Hours Worked:
 report.detail.summary.hoursDelta.negative=Hours Remaining to Work:

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -325,7 +325,6 @@ report.aggregated.table.head.user=Person
 report.aggregated.table.head.delta=Difference
 report.aggregated.table.head.worked=Worked
 report.aggregated.table.head.should=Should
-report.aggregated.table.head.planned=Planned
 
 report.detail.summary.planned-working-hours=Planned Working Hours:
 report.detail.summary.hours-worked=Hours Worked:

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -67,7 +67,7 @@
                 <table class="report-person-detail-table">
                   <thead>
                     <tr>
-                      <th>
+                      <th scope="col">
                         <span
                           class="sr-only"
                           th:text="#{report.aggregated.table.head.user}"
@@ -75,18 +75,21 @@
                         >
                       </th>
                       <th
+                        scope="col"
                         class="text-right"
                         th:text="#{report.aggregated.table.head.delta}"
                       >
                         Abweichung
                       </th>
                       <th
+                        scope="col"
                         class="text-right"
                         th:text="#{report.aggregated.table.head.worked}"
                       >
                         Geleistet
                       </th>
                       <th
+                        scope="col"
                         class="text-right"
                         th:text="#{report.aggregated.table.head.should}"
                       >
@@ -99,7 +102,7 @@
                       th:each="userDurationAggregation : ${selectedUserDurationAggregation}"
                       th:with="user=${usersById.get(userDurationAggregation.userId)}"
                     >
-                      <th>
+                      <th scope="row">
                         <div class="flex items-center gap-2">
                           <span class="report-person-detail-table__avatar">
                             <img

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -60,7 +60,10 @@
               >
                 <div th:replace="~{__${chartFragment}__}"></div>
               </div>
-              <div class="xs:px-4 w-full overflow-x-auto">
+              <div
+                th:if="${selectedUserDurationAggregation != null}"
+                class="xs:px-4 w-full overflow-x-auto"
+              >
                 <table class="report-person-detail-table">
                   <thead>
                     <tr>

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -60,7 +60,7 @@
               >
                 <div th:replace="~{__${chartFragment}__}"></div>
               </div>
-              <div class="px-4">
+              <div class="px-4 w-full overflow-x-auto">
                 <table class="report-person-detail-table">
                   <thead>
                     <tr>

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -108,11 +108,17 @@
                           <span th:text="${user.fullName}"> Bruce Wayne </span>
                         </div>
                       </td>
-                      <td
-                        class="text-right tabular-nums"
-                        th:text="${{userDurationAggregation.delta}}"
-                      >
-                        -
+                      <td class="text-right tabular-nums">
+                        <span th:if="${userDurationAggregation.deltaNegative}"
+                          >-</span
+                        >
+                        <span
+                          th:if="${not userDurationAggregation.deltaNegative}"
+                          >+</span
+                        >
+                        <span th:text="${{userDurationAggregation.delta}}"
+                          >00:00</span
+                        >
                       </td>
                       <td
                         class="text-right tabular-nums"

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -96,7 +96,7 @@
                       th:each="userDurationAggregation : ${selectedUserDurationAggregation}"
                       th:with="user=${usersById.get(userDurationAggregation.userId)}"
                     >
-                      <td>
+                      <th>
                         <div class="flex items-center gap-2">
                           <span class="report-person-detail-table__avatar">
                             <img
@@ -107,7 +107,7 @@
                           </span>
                           <span th:text="${user.fullName}"> Bruce Wayne </span>
                         </div>
-                      </td>
+                      </th>
                       <td class="text-right tabular-nums">
                         <span th:if="${userDurationAggregation.deltaNegative}"
                           >-</span

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -68,10 +68,14 @@
                       <th class="text-right">Abweichung</th>
                       <th class="text-right">Geleistet</th>
                       <th class="text-right">Soll</th>
+                      <th class="text-right">Geplant</th>
                     </tr>
                   </thead>
                   <tbody>
-                    <tr th:each="user : ${selectedUsers}">
+                    <tr
+                      th:each="userDurationAggregation : ${selectedUserDurationAggregation}"
+                      th:with="user=${selectedUsersById.get(userDurationAggregation.userId)}"
+                    >
                       <td>
                         <div class="flex items-center gap-2">
                           <span class="report-person-detail-table__avatar">
@@ -84,9 +88,30 @@
                           <span th:text="${user.fullName}"> Bruce Wayne </span>
                         </div>
                       </td>
-                      <td class="text-right tabular-nums">-</td>
-                      <td class="text-right tabular-nums">-</td>
-                      <td class="text-right tabular-nums">-</td>
+                      <td
+                        class="text-right tabular-nums"
+                        th:text="${{userDurationAggregation.delta}}"
+                      >
+                        -
+                      </td>
+                      <td
+                        class="text-right tabular-nums"
+                        th:text="${{userDurationAggregation.worked}}"
+                      >
+                        -
+                      </td>
+                      <td
+                        class="text-right tabular-nums"
+                        th:text="${{userDurationAggregation.should}}"
+                      >
+                        -
+                      </td>
+                      <td
+                        class="text-right tabular-nums"
+                        th:text="${{userDurationAggregation.planned}}"
+                      >
+                        -
+                      </td>
                     </tr>
                   </tbody>
                 </table>

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -60,6 +60,37 @@
               >
                 <div th:replace="~{__${chartFragment}__}"></div>
               </div>
+              <div class="px-4">
+                <table class="report-person-detail-table">
+                  <thead>
+                    <tr>
+                      <th><span class="sr-only">Person</span></th>
+                      <th class="text-right">Abweichung</th>
+                      <th class="text-right">Geleistet</th>
+                      <th class="text-right">Soll</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr th:each="user : ${selectedUsers}">
+                      <td>
+                        <div class="flex items-center gap-2">
+                          <span class="report-person-detail-table__avatar">
+                            <img
+                              alt=""
+                              src=""
+                              th:replace="~{fragments/avatar::avatar(${user.fullName},38,38)}"
+                            />
+                          </span>
+                          <span th:text="${user.fullName}"> Bruce Wayne </span>
+                        </div>
+                      </td>
+                      <td class="text-right tabular-nums">-</td>
+                      <td class="text-right tabular-nums">-</td>
+                      <td class="text-right tabular-nums">-</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
             <div class="">
               <div class="p-4 bg-white border border-gray-100 rounded-3xl">

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -64,11 +64,37 @@
                 <table class="report-person-detail-table">
                   <thead>
                     <tr>
-                      <th><span class="sr-only">Person</span></th>
-                      <th class="text-right">Abweichung</th>
-                      <th class="text-right">Geleistet</th>
-                      <th class="text-right">Soll</th>
-                      <th class="text-right">Geplant</th>
+                      <th>
+                        <span
+                          class="sr-only"
+                          th:text="#{report.aggregated.table.head.user}"
+                          >Person</span
+                        >
+                      </th>
+                      <th
+                        class="text-right"
+                        th:text="#{report.aggregated.table.head.delta}"
+                      >
+                        Abweichung
+                      </th>
+                      <th
+                        class="text-right"
+                        th:text="#{report.aggregated.table.head.worked}"
+                      >
+                        Geleistet
+                      </th>
+                      <th
+                        class="text-right"
+                        th:text="#{report.aggregated.table.head.should}"
+                      >
+                        Soll
+                      </th>
+                      <th
+                        class="text-right"
+                        th:text="#{report.aggregated.table.head.planned}"
+                      >
+                        Geplant
+                      </th>
                     </tr>
                   </thead>
                   <tbody>

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -100,7 +100,7 @@
                   <tbody>
                     <tr
                       th:each="userDurationAggregation : ${selectedUserDurationAggregation}"
-                      th:with="user=${selectedUsersById.get(userDurationAggregation.userId)}"
+                      th:with="user=${usersById.get(userDurationAggregation.userId)}"
                     >
                       <td>
                         <div class="flex items-center gap-2">

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -90,7 +90,7 @@
                         class="text-right"
                         th:text="#{report.aggregated.table.head.should}"
                       >
-                        Soll
+                        Geplant
                       </th>
                     </tr>
                   </thead>

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -60,7 +60,7 @@
               >
                 <div th:replace="~{__${chartFragment}__}"></div>
               </div>
-              <div class="px-4 w-full overflow-x-auto">
+              <div class="xs:px-4 w-full overflow-x-auto">
                 <table class="report-person-detail-table">
                   <thead>
                     <tr>

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -108,7 +108,7 @@
                             <img
                               alt=""
                               src=""
-                              th:replace="~{fragments/avatar::avatar(${user.fullName},38,38)}"
+                              th:replace="~{fragments/avatar::avatar(fullName=${user.fullName},width='38px',height='38px',tooltip=false)}"
                             />
                           </span>
                           <span th:text="${user.fullName}"> Bruce Wayne </span>

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -89,12 +89,6 @@
                       >
                         Soll
                       </th>
-                      <th
-                        class="text-right"
-                        th:text="#{report.aggregated.table.head.planned}"
-                      >
-                        Geplant
-                      </th>
                     </tr>
                   </thead>
                   <tbody>
@@ -129,12 +123,6 @@
                       <td
                         class="text-right tabular-nums"
                         th:text="${{userDurationAggregation.should}}"
-                      >
-                        -
-                      </td>
-                      <td
-                        class="text-right tabular-nums"
-                        th:text="${{userDurationAggregation.planned}}"
                       >
                         -
                       </td>

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
@@ -75,29 +75,6 @@ class ReportDayTest {
     }
 
     @Test
-    void plannedWorkingHoursByUser() {
-        final UserId batmanId = new UserId("uuid");
-        final UserLocalId batmanLocalId = new UserLocalId(1L);
-        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
-
-        final UserId robinId = new UserId("uuid2");
-        final UserLocalId robinLocalId = new UserLocalId(2L);
-        final UserIdComposite robinIdComposite = new UserIdComposite(robinId, robinLocalId);
-
-        LocalDate reportDate = LocalDate.of(2024, 11, 13);
-        ReportDay reportDay = new ReportDay(
-                reportDate,
-                Map.of(
-                        batmanIdComposite, new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of()),
-                        robinIdComposite, new WorkingTimeCalendar(Map.of(reportDate, new PlannedWorkingHours(Duration.ofHours(4))), Map.of())
-                ),
-                Map.of(),
-                Map.of());
-
-        assertThat(reportDay.plannedWorkingHoursByUser(robinLocalId).duration()).isEqualTo(Duration.ofHours(4));
-    }
-
-    @Test
     void ensureToRemoveBreaks() {
 
         final UserId batmanId = new UserId("uuid");

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
@@ -43,12 +43,13 @@ class ReportDayTest {
         final ZonedDateTime to = dateTime(2024, 11, 13, 2, 0);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, true);
 
-        LocalDate reportDate = LocalDate.of(2024, 11, 13);
-        ReportDay reportDay = new ReportDay(reportDate, Map.of(), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
+        final LocalDate reportDate = LocalDate.of(2024, 11, 13);
+        final ReportDay sut = new ReportDay(reportDate, Map.of(), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
 
-        List<ReportDayEntry> reportDayEntries = reportDay.reportDayEntries();
-
-        assertThat(reportDayEntries).hasSize(1).containsExactly(reportDayEntry);
+        final List<ReportDayEntry> reportDayEntries = sut.reportDayEntries();
+        assertThat(reportDayEntries)
+            .hasSize(1)
+            .containsExactly(reportDayEntry);
     }
 
     @Test
@@ -61,17 +62,18 @@ class ReportDayTest {
         final UserLocalId robinLocalId = new UserLocalId(1337L);
         final UserIdComposite robinIdComposite = new UserIdComposite(robinId, robinLocalId);
 
-        LocalDate reportDate = LocalDate.of(2024, 11, 13);
-        ReportDay reportDay = new ReportDay(
-                reportDate,
-                Map.of(
-                        batmanIdComposite, new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of()),
-                        robinIdComposite, new WorkingTimeCalendar(Map.of(reportDate, new PlannedWorkingHours(Duration.ofHours(4))), Map.of())
-                ),
-                Map.of(),
-                Map.of());
+        final LocalDate reportDate = LocalDate.of(2024, 11, 13);
 
-        assertThat(reportDay.plannedWorkingHours().duration()).isEqualTo(Duration.ofHours(12));
+        final ReportDay sut = new ReportDay(
+            reportDate,
+            Map.of(
+                batmanIdComposite, new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of()),
+                robinIdComposite, new WorkingTimeCalendar(Map.of(reportDate, new PlannedWorkingHours(Duration.ofHours(4))), Map.of())
+            ),
+            Map.of(),
+            Map.of());
+
+        assertThat(sut.plannedWorkingHours().duration()).isEqualTo(Duration.ofHours(12));
     }
 
     @Test
@@ -86,11 +88,11 @@ class ReportDayTest {
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, true);
 
-        LocalDate reportDate = LocalDate.of(2021, 1, 4);
-        WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of());
-        final ReportDay reportDay = new ReportDay(reportDate, Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
+        final LocalDate reportDate = LocalDate.of(2021, 1, 4);
+        final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of());
 
-        assertThat(reportDay.workDuration().duration()).isEqualTo(Duration.ZERO);
+        final ReportDay sut = new ReportDay(reportDate, Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
+        assertThat(sut.workDuration().duration()).isEqualTo(Duration.ZERO);
     }
 
     @Test
@@ -103,13 +105,13 @@ class ReportDayTest {
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        Absence absence = new Absence(batmanId, from, to, FULL, locale -> "foo", RED, HOLIDAY);
+        final Absence absence = new Absence(batmanId, from, to, FULL, locale -> "foo", RED, HOLIDAY);
 
-        LocalDate reportDate = LocalDate.of(2021, 1, 4);
-        WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of(reportDate, List.of(absence)));
-        final ReportDay reportDay = new ReportDay(reportDate, Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence))));
+        final LocalDate reportDate = LocalDate.of(2021, 1, 4);
+        final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of(reportDate, List.of(absence)));
 
-        assertThat(reportDay.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ZERO));
+        final ReportDay sut = new ReportDay(reportDate, Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence))));
+        assertThat(sut.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ZERO));
     }
 
     @ParameterizedTest
@@ -123,13 +125,13 @@ class ReportDayTest {
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        Absence absence = new Absence(batmanId, from, to, dayLength, locale -> "foo", RED, HOLIDAY);
+        final Absence absence = new Absence(batmanId, from, to, dayLength, locale -> "foo", RED, HOLIDAY);
 
-        LocalDate reportDate = LocalDate.of(2021, 1, 4);
-        WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of(reportDate, List.of(absence)));
-        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence))));
+        final LocalDate reportDate = LocalDate.of(2021, 1, 4);
+        final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of(reportDate, List.of(absence)));
 
-        assertThat(reportDay.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ofHours(4)));
+        final ReportDay sut = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence))));
+        assertThat(sut.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ofHours(4)));
     }
 
     @Test
@@ -142,27 +144,27 @@ class ReportDayTest {
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        Absence absence = new Absence(batmanId, from, to, FULL, locale -> "foo", RED, HOLIDAY);
+        final Absence absence = new Absence(batmanId, from, to, FULL, locale -> "foo", RED, HOLIDAY);
 
         final UserId robinId = new UserId("uuid2");
         final UserLocalId robinLocalId = new UserLocalId(1337L);
         final UserIdComposite robinIdComposite = new UserIdComposite(robinId, robinLocalId);
 
-        Map<UserIdComposite, List<ReportDayEntry>> entriesByUser = Map.of(batmanIdComposite, List.of(), robinIdComposite, List.of());
-        Map<UserIdComposite, List<ReportDayAbsence>> absencesByUser = Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence)), robinIdComposite, List.of());
+        final Map<UserIdComposite, List<ReportDayEntry>> entriesByUser = Map.of(batmanIdComposite, List.of(), robinIdComposite, List.of());
+        final Map<UserIdComposite, List<ReportDayAbsence>> absencesByUser = Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence)), robinIdComposite, List.of());
 
-        LocalDate reportDate = LocalDate.of(2021, 1, 4);
-        Map<UserIdComposite, WorkingTimeCalendar> plannedWorkingHoursByUser = Map.of(
-                batmanIdComposite, new WorkingTimeCalendar(
-                        Map.of(reportDate, PlannedWorkingHours.EIGHT),
-                        Map.of(reportDate, List.of(absence))),
-                robinIdComposite, new WorkingTimeCalendar(
-                        Map.of(reportDate, new PlannedWorkingHours(Duration.ofHours(4))),
-                        Map.of(reportDate, List.of()))
+        final LocalDate reportDate = LocalDate.of(2021, 1, 4);
+        final Map<UserIdComposite, WorkingTimeCalendar> plannedWorkingHoursByUser = Map.of(
+            batmanIdComposite, new WorkingTimeCalendar(
+                Map.of(reportDate, PlannedWorkingHours.EIGHT),
+                Map.of(reportDate, List.of(absence))),
+            robinIdComposite, new WorkingTimeCalendar(
+                Map.of(reportDate, new PlannedWorkingHours(Duration.ofHours(4))),
+                Map.of(reportDate, List.of()))
         );
-        final ReportDay reportDay = new ReportDay(reportDate, plannedWorkingHoursByUser, entriesByUser, absencesByUser);
 
-        assertThat(reportDay.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ofHours(4L)));
+        final ReportDay sut = new ReportDay(reportDate, plannedWorkingHoursByUser, entriesByUser, absencesByUser);
+        assertThat(sut.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ofHours(4L)));
     }
 
     @ParameterizedTest
@@ -176,26 +178,26 @@ class ReportDayTest {
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        Absence absence = new Absence(batmanId, from, to, dayLength, locale -> "foo", RED, HOLIDAY);
+        final Absence absence = new Absence(batmanId, from, to, dayLength, locale -> "foo", RED, HOLIDAY);
 
         final UserId robinId = new UserId("uuid2");
         final UserLocalId robinLocalId = new UserLocalId(1337L);
         final UserIdComposite robinIdComposite = new UserIdComposite(robinId, robinLocalId);
 
-        Map<UserIdComposite, List<ReportDayEntry>> entriesByUser = Map.of(batmanIdComposite, List.of(), robinIdComposite, List.of());
-        Map<UserIdComposite, List<ReportDayAbsence>> absencesByUser = Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence)), robinIdComposite, List.of());
-        LocalDate reportDate = LocalDate.of(2021, 1, 4);
-        Map<UserIdComposite, WorkingTimeCalendar> plannedWorkingHoursByUser = Map.of(
-                batmanIdComposite, new WorkingTimeCalendar(
-                        Map.of(reportDate, PlannedWorkingHours.EIGHT),
-                        Map.of(reportDate, List.of(absence))),
-                robinIdComposite, new WorkingTimeCalendar(
-                        Map.of(reportDate, new PlannedWorkingHours(Duration.ofHours(4))),
-                        Map.of(reportDate, List.of()))
+        final Map<UserIdComposite, List<ReportDayEntry>> entriesByUser = Map.of(batmanIdComposite, List.of(), robinIdComposite, List.of());
+        final Map<UserIdComposite, List<ReportDayAbsence>> absencesByUser = Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence)), robinIdComposite, List.of());
+        final LocalDate reportDate = LocalDate.of(2021, 1, 4);
+        final Map<UserIdComposite, WorkingTimeCalendar> plannedWorkingHoursByUser = Map.of(
+            batmanIdComposite, new WorkingTimeCalendar(
+                Map.of(reportDate, PlannedWorkingHours.EIGHT),
+                Map.of(reportDate, List.of(absence))),
+            robinIdComposite, new WorkingTimeCalendar(
+                Map.of(reportDate, new PlannedWorkingHours(Duration.ofHours(4))),
+                Map.of(reportDate, List.of()))
         );
-        final ReportDay reportDay = new ReportDay(reportDate, plannedWorkingHoursByUser, entriesByUser, absencesByUser);
 
-        assertThat(reportDay.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ofHours(8L)));
+        final ReportDay sut = new ReportDay(reportDate, plannedWorkingHoursByUser, entriesByUser, absencesByUser);
+        assertThat(sut.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ofHours(8L)));
     }
 
     private static ZonedDateTime dateTime(int year, int month, int dayOfMonth, int hour, int minute) {

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
@@ -77,6 +77,34 @@ class ReportDayTest {
     }
 
     @Test
+    void ensurePlannedWorkingHoursByUser() {
+
+        final UserIdComposite batmanIdComposite = new UserIdComposite(new UserId("uuid"), new UserLocalId(1L));
+        final UserIdComposite robinIdComposite = new UserIdComposite(new UserId("uuid2"), new UserLocalId(2L));
+        final UserIdComposite jokerIdComposite = new UserIdComposite(new UserId("uuid3"), new UserLocalId(3L));
+
+        final LocalDate reportDate = LocalDate.of(2024, 11, 13);
+
+        final ReportDay sut = new ReportDay(
+            reportDate,
+            Map.of(
+                batmanIdComposite, new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of()),
+                robinIdComposite, new WorkingTimeCalendar(Map.of(reportDate, new PlannedWorkingHours(Duration.ofHours(4))), Map.of()),
+                // enforce empty optional value while calculating planned working hours
+                // which then use the fallback value of ZERO
+                jokerIdComposite, new WorkingTimeCalendar(Map.of(reportDate.plusDays(1), PlannedWorkingHours.EIGHT), Map.of())
+            ),
+            Map.of(),
+            Map.of());
+
+        assertThat(sut.plannedWorkingHoursByUser()).isEqualTo(Map.of(
+            batmanIdComposite, PlannedWorkingHours.EIGHT,
+            robinIdComposite, new PlannedWorkingHours(Duration.ofHours(4)),
+            jokerIdComposite, PlannedWorkingHours.ZERO)
+        );
+    }
+
+    @Test
     void ensureToRemoveBreaks() {
 
         final UserId batmanId = new UserId("uuid");

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
@@ -51,7 +51,6 @@ class ReportMonthControllerTest {
     private ReportService reportService;
     @Mock
     private ReportPermissionService reportPermissionService;
-
     @Mock
     private MessageSource messageSource;
 
@@ -61,8 +60,8 @@ class ReportMonthControllerTest {
     void setUp() {
         final DateFormatterImpl dateFormatter = new DateFormatterImpl();
         final DateRangeFormatter dateRangeFormatter = new DateRangeFormatter(dateFormatter, messageSource);
-        final ReportControllerHelper helper = new ReportControllerHelper(reportPermissionService, dateFormatter, dateRangeFormatter);
-        sut = new ReportMonthController(reportService, dateFormatter, helper, clock);
+        final ReportControllerHelper helper = new ReportControllerHelper(dateFormatter, dateRangeFormatter);
+        sut = new ReportMonthController(reportService, reportPermissionService, dateFormatter, helper, clock);
     }
 
     @Test
@@ -367,9 +366,9 @@ class ReportMonthControllerTest {
         perform(get("/report/year/2022/month/1").with(oidcLogin().userInfoToken(userInfo -> userInfo.subject("batman"))))
             .andExpect(model().attribute("users", List.of(
                 new SelectableUserDto(1L, "Bruce Wayne", false),
-                new SelectableUserDto(2L, "Jack Napier", false),
-                new SelectableUserDto(3L, "Dick Grayson", false)
-            )))
+                new SelectableUserDto(3L, "Dick Grayson", false),
+                new SelectableUserDto(2L, "Jack Napier", false))
+            ))
             .andExpect(model().attribute("selectedUserIds", List.of()))
             .andExpect(model().attribute("allUsersSelected", false))
             .andExpect(model().attribute("userReportFilterUrl", "/report/year/2022/month/1"));
@@ -405,9 +404,9 @@ class ReportMonthControllerTest {
                 .param("everyone", "")
         )
             .andExpect(model().attribute("users", List.of(
-                new SelectableUserDto(1L, "Bruce Wayne", false),
-                new SelectableUserDto(2L, "Jack Napier", false),
-                new SelectableUserDto(3L, "Dick Grayson", false)
+                    new SelectableUserDto(1L, "Bruce Wayne", false),
+                    new SelectableUserDto(3L, "Dick Grayson", false),
+                    new SelectableUserDto(2L, "Jack Napier", false)
             )))
             .andExpect(model().attribute("selectedUserIds", List.of()))
             .andExpect(model().attribute("allUsersSelected", true))
@@ -445,8 +444,8 @@ class ReportMonthControllerTest {
         )
             .andExpect(model().attribute("users", List.of(
                 new SelectableUserDto(1L, "Bruce Wayne", false),
-                new SelectableUserDto(2L, "Jack Napier", true),
-                new SelectableUserDto(3L, "Dick Grayson", true)
+                new SelectableUserDto(3L, "Dick Grayson", true),
+                new SelectableUserDto(2L, "Jack Napier", true)
             )))
             .andExpect(model().attribute("selectedUserIds", List.of(2L, 3L)))
             .andExpect(model().attribute("allUsersSelected", false))

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
@@ -58,7 +58,6 @@ class ReportWeekControllerTest {
     private ReportService reportService;
     @Mock
     private ReportPermissionService reportPermissionService;
-
     @Mock
     private MessageSource messageSource;
 
@@ -68,8 +67,8 @@ class ReportWeekControllerTest {
     void setUp() {
         final DateFormatterImpl dateFormatter = new DateFormatterImpl();
         final DateRangeFormatter dateRangeFormatter = new DateRangeFormatter(dateFormatter, messageSource);
-        final ReportControllerHelper helper = new ReportControllerHelper(reportPermissionService, dateFormatter, dateRangeFormatter);
-        sut = new ReportWeekController(reportService, helper, clock);
+        final ReportControllerHelper helper = new ReportControllerHelper(dateFormatter, dateRangeFormatter);
+        sut = new ReportWeekController(reportService, reportPermissionService, helper, clock);
     }
 
     @Test
@@ -349,8 +348,8 @@ class ReportWeekControllerTest {
         perform(get("/report/year/2022/week/1").with(oidcLogin().userInfoToken(userInfo -> userInfo.subject("batman"))))
             .andExpect(model().attribute("users", List.of(
                 new SelectableUserDto(1L, "Bruce Wayne", false),
-                new SelectableUserDto(2L, "Jack Napier", false),
-                new SelectableUserDto(3L, "Dick Grayson", false)
+                new SelectableUserDto(3L, "Dick Grayson", false),
+                new SelectableUserDto(2L, "Jack Napier", false)
             )))
             .andExpect(model().attribute("selectedUserIds", List.of()))
             .andExpect(model().attribute("allUsersSelected", false))
@@ -388,8 +387,8 @@ class ReportWeekControllerTest {
         )
             .andExpect(model().attribute("users", List.of(
                 new SelectableUserDto(1L, "Bruce Wayne", false),
-                new SelectableUserDto(2L, "Jack Napier", false),
-                new SelectableUserDto(3L, "Dick Grayson", false)
+                new SelectableUserDto(3L, "Dick Grayson", false),
+                new SelectableUserDto(2L, "Jack Napier", false)
             )))
             .andExpect(model().attribute("selectedUserIds", List.of()))
             .andExpect(model().attribute("allUsersSelected", true))
@@ -427,8 +426,8 @@ class ReportWeekControllerTest {
         )
             .andExpect(model().attribute("users", List.of(
                 new SelectableUserDto(1L, "Bruce Wayne", false),
-                new SelectableUserDto(2L, "Jack Napier", true),
-                new SelectableUserDto(3L, "Dick Grayson", true)
+                new SelectableUserDto(3L, "Dick Grayson", true),
+                new SelectableUserDto(2L, "Jack Napier", true)
             )))
             .andExpect(model().attribute("selectedUserIds", List.of(2L, 3L)))
             .andExpect(model().attribute("allUsersSelected", false))


### PR DESCRIPTION
closes #878

TODOs:
- [x] Ausblenden wenn die Ansicht nur für mich ist
- [x] Umsetzung der Wochen-Ansicht
- [x] angezeigte Zahlen auf Korrektheit verifizieren
  - aktuell wird mehr SOLL als GEPLANT angezeigt
  - SOLL (should): geplante Arbeitszeit abzüglich Abwesenheiten
  - GEPLANT (planned): geplante Arbeitszeit. z. B. in einer Woche 40h bei 5 Tagen a 8h.
- ~~[ ] wenn im Graphen ein Tag ausgewählt wird, wie soll sich die Tabelle verhalten?~~ (#911)
  - ~~Information nur für den Tag anzeigen?~~
  - ~~Zusätzlich die Information für diesen Tag anzeigen?~~

Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
