### PR TITLE
Fix duration for timeentry which ends next day

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/report/DetailDayEntryDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/DetailDayEntryDto.java
@@ -16,6 +16,11 @@ record DetailDayEntryDto(
 ) {
 
     public Duration getDuration() {
-        return Duration.between(start, end);
+        Duration duration = Duration.between(start, end);
+        // this is the case if timeentry ends on next day
+        if (end.isBefore(start)) {
+            return duration.plus(Duration.ofDays(1));
+        }
+        return duration;
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/report/DetailDayEntryDtoTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/DetailDayEntryDtoTest.java
@@ -1,0 +1,24 @@
+package de.focusshift.zeiterfassung.report;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DetailDayEntryDtoTest {
+
+    @Test
+    void durationSameDay() {
+        DetailDayEntryDto detailDayEntryDto = new DetailDayEntryDto(null, null, false, LocalTime.of(0, 0), LocalTime.of(1, 0));
+        assertThat(detailDayEntryDto.getDuration()).isEqualTo(Duration.ofHours(1L));
+    }
+
+    @Test
+    void durationWithEndNextDay() {
+        DetailDayEntryDto detailDayEntryDto = new DetailDayEntryDto(null, null, false, LocalTime.of(23, 0), LocalTime.of(1, 0));
+        assertThat(detailDayEntryDto.getDuration()).isEqualTo(Duration.ofHours(2L));
+    }
+}


### PR DESCRIPTION
fixes #908


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] ~~Extended new entities with `AbstractTenantAwareEntity`?~~
- [ ] ~~New entity added to `TenantAwareDatabaseConfiguration`?~~
- [x] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
