### PR TITLE
fix report planned vs should workingtime

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/absence/DayLength.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/DayLength.java
@@ -22,4 +22,12 @@ public enum DayLength {
     public double plus(DayLength dayLength) {
         return this.value + dayLength.value;
     }
+
+    public boolean isFull() {
+        return this.value == FULL.value;
+    }
+
+    public boolean isHalf() {
+        return !isFull();
+    }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportControllerHelper.java
@@ -106,7 +106,7 @@ class ReportControllerHelper {
         final String dayOfWeekFull = dateFormatter.formatDayOfWeekFull(reportDay.date().getDayOfWeek());
         final String dateString = dateFormatter.formatDate(reportDay.date());
         final double hoursWorked = reportDay.workDuration().hoursDoubleValue();
-        final double hoursWorkedShould = reportDay.plannedWorkingHours().hoursDoubleValue();
+        final double hoursWorkedShould = reportDay.shouldWorkingHours().hoursDoubleValue();
 
         return new GraphDayDto(differentMonth, dayOfWeekNarrow, dayOfWeekFull, dateString, hoursWorked, hoursWorkedShould);
     }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportServiceRaw.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportServiceRaw.java
@@ -1,7 +1,6 @@
 package de.focusshift.zeiterfassung.report;
 
 import de.focusshift.zeiterfassung.absence.Absence;
-import de.focusshift.zeiterfassung.absence.AbsenceService;
 import de.focusshift.zeiterfassung.timeentry.TimeEntry;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryService;
 import de.focusshift.zeiterfassung.user.UserDateService;
@@ -10,7 +9,6 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
-import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendarService;
 import org.slf4j.Logger;
@@ -28,12 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.time.temporal.ChronoUnit.MONTHS;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
 
@@ -49,17 +47,14 @@ class ReportServiceRaw {
     private final UserManagementService userManagementService;
     private final UserDateService userDateService;
     private final WorkingTimeCalendarService workingTimeCalendarService;
-    private final AbsenceService absenceService;
 
     ReportServiceRaw(TimeEntryService timeEntryService, UserManagementService userManagementService,
-                     UserDateService userDateService, WorkingTimeCalendarService workingTimeCalendarService, AbsenceService absenceService) {
+                     UserDateService userDateService, WorkingTimeCalendarService workingTimeCalendarService) {
 
         this.timeEntryService = timeEntryService;
         this.userManagementService = userManagementService;
         this.userDateService = userDateService;
         this.workingTimeCalendarService = workingTimeCalendarService;
-
-        this.absenceService = absenceService;
     }
 
     ReportWeek getReportWeek(Year year, int week, UserId userId) {
@@ -69,21 +64,18 @@ class ReportServiceRaw {
 
         return createReportWeek(year, week,
             period -> Map.of(user.userIdComposite(), timeEntryService.getEntries(period.from(), period.toExclusive(), userId)),
-            period -> Map.of(user.userIdComposite(), absenceService.getAbsencesByUserId(userId, period.from(), period.toExclusive())),
             period -> workingTimeCalendarService.getWorkingTimeCalendarForUsers(period.from(), period.toExclusive(), List.of(user.userLocalId())));
     }
 
     ReportWeek getReportWeek(Year year, int week, List<UserLocalId> userLocalIds) {
         return createReportWeek(year, week,
             period -> timeEntryService.getEntriesByUserLocalIds(period.from(), period.toExclusive(), userLocalIds),
-            period -> absenceService.getAbsencesByUserIds(userLocalIds, period.from(), period.toExclusive()),
             period -> workingTimeCalendarService.getWorkingTimeCalendarForUsers(period.from(), period.toExclusive(), userLocalIds));
     }
 
     ReportWeek getReportWeekForAllUsers(Year year, int week) {
         return createReportWeek(year, week,
             period -> timeEntryService.getEntriesForAllUsers(period.from(), period.toExclusive()),
-            period -> absenceService.getAbsencesForAllUsers(period.from(), period.toExclusive()),
             period -> workingTimeCalendarService.getWorkingTimeCalendarForAllUsers(period.from(), period.toExclusive()));
     }
 
@@ -94,60 +86,39 @@ class ReportServiceRaw {
 
         return createReportMonth(yearMonth,
             period -> timeEntryService.getEntriesByUserLocalIds(period.from(), period.toExclusive(), List.of(user.userLocalId())),
-            period -> Map.of(user.userIdComposite(), absenceService.getAbsencesByUserId(userId, period.from(), period.toExclusive())),
             period -> workingTimeCalendarService.getWorkingTimeCalendarForUsers(period.from(), period.toExclusive(), List.of(user.userLocalId())));
     }
 
     ReportMonth getReportMonth(YearMonth yearMonth, List<UserLocalId> userLocalIds) {
         return createReportMonth(yearMonth,
             period -> timeEntryService.getEntriesByUserLocalIds(period.from(), period.toExclusive(), userLocalIds),
-            period -> absenceService.getAbsencesByUserIds(userLocalIds, period.from(), period.toExclusive()),
             period -> workingTimeCalendarService.getWorkingTimeCalendarForUsers(period.from(), period.toExclusive(), userLocalIds));
     }
 
     ReportMonth getReportMonthForAllUsers(YearMonth yearMonth) {
         return createReportMonth(yearMonth,
             period -> timeEntryService.getEntriesForAllUsers(period.from(), period.toExclusive()),
-            period -> absenceService.getAbsencesForAllUsers(period.from(), period.toExclusive()),
             period -> workingTimeCalendarService.getWorkingTimeCalendarForAllUsers(period.from(), period.toExclusive()));
     }
 
     private ReportWeek createReportWeek(Year year, int week,
                                         Function<Period, Map<UserIdComposite, List<TimeEntry>>> timeEntriesProvider,
-                                        Function<Period, Map<UserIdComposite, List<Absence>>> absenceProvider,
                                         Function<Period, Map<UserIdComposite, WorkingTimeCalendar>> workingTimeCalendarProvider) {
 
         final LocalDate firstDateOfWeek = userDateService.firstDayOfWeek(year, week);
-
         final Period period = new Period(firstDateOfWeek, firstDateOfWeek.plusWeeks(1));
 
         final Map<UserIdComposite, List<TimeEntry>> timeEntries = timeEntriesProvider.apply(period);
-        final Map<UserIdComposite, List<Absence>> absenceEntries = absenceProvider.apply(period);
-
-        final Map<UserId, User> userById = userByIdFor(timeEntries, absenceEntries);
-
         final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendars = workingTimeCalendarProvider.apply(period);
-        final Function<LocalDate, Map<UserIdComposite, PlannedWorkingHours>> plannedWorkingTimeByDate = plannedWorkingTimeForDate(workingTimeCalendars);
 
-        return reportWeek(firstDateOfWeek, timeEntries, userById, plannedWorkingTimeByDate, absenceEntries);
-    }
+        final Map<UserIdComposite, User> userById = userByIdFor(timeEntries, workingTimeCalendars);
 
-    private Function<LocalDate, Map<UserIdComposite, List<ReportDayAbsence>>> getLocalDateMapFunction(Map<UserIdComposite, List<Absence>> absenceEntries, Map<UserId, User> userById) {
-        return date -> absenceEntries.entrySet().stream()
-            .collect(
-                toMap(
-                    Map.Entry::getKey,
-                    entry -> entry.getValue()
-                        .stream()
-                        .filter(isInAbsencePeriod(date))
-                        .map(absence -> new ReportDayAbsence(userById.get(absence.userId()), absence))
-                        .toList())
-            );
+
+        return reportWeek(firstDateOfWeek, timeEntries, workingTimeCalendars, userById);
     }
 
     private ReportMonth createReportMonth(YearMonth yearMonth,
                                           Function<Period, Map<UserIdComposite, List<TimeEntry>>> timeEntriesProvider,
-                                          Function<Period, Map<UserIdComposite, List<Absence>>> absenceProvider,
                                           Function<Period, Map<UserIdComposite, WorkingTimeCalendar>> workingTimeCalendarProvider) {
 
         final LocalDate firstOfMonth = LocalDate.of(yearMonth.getYear(), yearMonth.getMonthValue(), 1);
@@ -155,63 +126,35 @@ class ReportServiceRaw {
         final Period period = new Period(firstOfMonth, firstOfMonth.plusMonths(1));
 
         final Map<UserIdComposite, List<TimeEntry>> timeEntries = timeEntriesProvider.apply(period);
-        final Map<UserIdComposite, List<Absence>> absenceEntries = absenceProvider.apply(period);
-
-        final Map<UserId, User> userById = userByIdFor(timeEntries, absenceEntries);
-
         final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendars = workingTimeCalendarProvider.apply(period);
-        final Function<LocalDate, Map<UserIdComposite, PlannedWorkingHours>> plannedWorkingTimeForDate = plannedWorkingTimeForDate(workingTimeCalendars);
+        final Map<UserIdComposite, User> userById = userByIdFor(timeEntries, workingTimeCalendars);
 
         final List<ReportWeek> weeks = getStartOfWeekDatesForMonth(yearMonth)
             .stream()
-            .map(startOfWeekDate ->
-                reportWeek(
-                    startOfWeekDate,
-                    timeEntries,
-                    userById,
-                    plannedWorkingTimeForDate,
-                    absenceEntries
-                )
-            )
+            .map(startOfWeekDate -> reportWeek(startOfWeekDate, timeEntries, workingTimeCalendars, userById))
             .toList();
 
         return new ReportMonth(yearMonth, weeks);
     }
 
-    private Function<LocalDate, Map<UserIdComposite, PlannedWorkingHours>> plannedWorkingTimeForDate(Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendars) {
-        return date ->
-            workingTimeCalendars.entrySet()
-                .stream()
-                .collect(
-                    toMap(
-                        Map.Entry::getKey,
-                        entry -> entry.getValue().plannedWorkingHours(date).orElse(PlannedWorkingHours.ZERO)
-                    )
-                );
-    }
+    private Map<UserIdComposite, User> userByIdFor(Map<UserIdComposite, List<TimeEntry>> timeEntries, Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarEntries) {
 
-    private Predicate<Absence> isInAbsencePeriod(LocalDate date) {
-        return absence -> (absence.startDate().toLocalDate().isBefore(date) || absence.startDate().toLocalDate().equals(date)) &&
-            (absence.endDate().toLocalDate().isAfter(date) || absence.endDate().toLocalDate().equals(date));
-    }
+        final Stream<UserIdComposite> timeEntriesUserIds = timeEntries.values().stream().flatMap(Collection::stream).map(TimeEntry::userIdComposite);
+        final Stream<UserIdComposite> workingTimeCalenderUserIds = workingTimeCalendarEntries.keySet().stream();
 
-    private Map<UserId, User> userByIdFor(Map<UserIdComposite, List<TimeEntry>> timeEntries, Map<UserIdComposite, List<Absence>> absenceEntries) {
-        final List<UserId> timeEntriesUserIds = timeEntries.values().stream().flatMap(Collection::stream).map(TimeEntry::userIdComposite).map(UserIdComposite::id).distinct().toList();
-        final List<UserId> absencesUserIds = absenceEntries.values().stream().flatMap(Collection::stream).map(Absence::userId).distinct().toList();
-        final List<UserId> allUserIds = Stream.concat(timeEntriesUserIds.stream(), absencesUserIds.stream()).distinct().toList();
+        final List<UserId> allUserIds = Stream.concat(timeEntriesUserIds, workingTimeCalenderUserIds).map(UserIdComposite::id).distinct().toList();
+
         return userManagementService.findAllUsersByIds(allUserIds)
-            .stream()
-            .collect(toMap(User::userId, Function.identity()));
+            .stream().collect(toMap(User::userIdComposite, identity()));
     }
 
     private ReportWeek reportWeek(final LocalDate startOfWeekDate,
-                                  final Map<UserIdComposite, List<TimeEntry>> timeEntriesByUserLocalId,
-                                  final Map<UserId, User> userById,
-                                  final Function<LocalDate, Map<UserIdComposite, PlannedWorkingHours>> plannedWorkingHoursProvider,
-                                  final Map<UserIdComposite, List<Absence>> absenceEntries) {
+                                  final Map<UserIdComposite, List<TimeEntry>> timeEntriesByUserId,
+                                  final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendars,
+                                  final Map<UserIdComposite, User> userById) {
 
         final Map<LocalDate, Map<UserIdComposite, List<ReportDayEntry>>> reportEntriesByDate = new HashMap<>();
-        for (Map.Entry<UserIdComposite, List<TimeEntry>> entry : timeEntriesByUserLocalId.entrySet()) {
+        for (Map.Entry<UserIdComposite, List<TimeEntry>> entry : timeEntriesByUserId.entrySet()) {
 
             final UserIdComposite userIdComposite = entry.getKey();
 
@@ -234,15 +177,12 @@ class ReportServiceRaw {
         final Function<LocalDate, Map<UserIdComposite, List<ReportDayEntry>>> resolveReportDayEntries =
             (LocalDate date) -> reportEntriesByDate.getOrDefault(date, Map.of());
 
-        final Function<LocalDate, Map<UserIdComposite, List<ReportDayAbsence>>> absencesProvider =
-            getLocalDateMapFunction(absenceEntries, userById);
-
         final List<ReportDay> reportDays = IntStream.rangeClosed(0, 6)
             .mapToObj(daysToAdd ->
                 toReportDay(
                     startOfWeekDate.plusDays(daysToAdd),
-                    plannedWorkingHoursProvider,
-                    absencesProvider,
+                    userById,
+                    workingTimeCalendars,
                     resolveReportDayEntries
                 ))
             .toList();
@@ -264,13 +204,13 @@ class ReportServiceRaw {
         return startOfWeekDates;
     }
 
-    private static Optional<ReportDayEntry> timeEntryToReportDayEntry(TimeEntry timeEntry, Function<UserId, User> userProvider) {
+    private static Optional<ReportDayEntry> timeEntryToReportDayEntry(TimeEntry timeEntry, Function<UserIdComposite, User> userProvider) {
 
         final String comment = timeEntry.comment();
         final ZonedDateTime startDateTime = timeEntry.start();
         final ZonedDateTime endDateTime = timeEntry.end();
 
-        final UserId userId = timeEntry.userIdComposite().id();
+        final UserIdComposite userId = timeEntry.userIdComposite();
         final User user = userProvider.apply(userId);
         if (user == null) {
             LOG.info("could not find user with id={} for timeEntry={} while generating report.", userId, timeEntry.id());
@@ -282,11 +222,23 @@ class ReportServiceRaw {
     }
 
     private static ReportDay toReportDay(LocalDate date,
-                                         Function<LocalDate, Map<UserIdComposite, PlannedWorkingHours>> plannedWorkingHoursProvider,
-                                         Function<LocalDate, Map<UserIdComposite, List<ReportDayAbsence>>> absences,
-                                         Function<LocalDate, Map<UserIdComposite, List<ReportDayEntry>>> resolveReportDayEntries) {
+                                         Map<UserIdComposite, User> userById,
+                                         Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendars,
+                                         Function<LocalDate, Map<UserIdComposite, List<ReportDayEntry>>> reportDayEntriesForDate) {
 
-        return new ReportDay(date, plannedWorkingHoursProvider.apply(date), resolveReportDayEntries.apply(date), absences.apply(date));
+        final Map<UserIdComposite, List<ReportDayAbsence>> absencesByUser = workingTimeCalendars.entrySet().stream().collect(
+            toMap(
+                Map.Entry::getKey,
+                entry -> {
+                    final List<Absence> absencesAtDate = entry.getValue().absence(date).orElse(List.of());
+                    return absencesAtDate.stream()
+                        .map(absence -> new ReportDayAbsence(userById.get(entry.getKey()), absence))
+                        .toList();
+                }
+            )
+        );
+
+        return new ReportDay(date, workingTimeCalendars, reportDayEntriesForDate.apply(date), absencesByUser);
     }
 
     private static boolean isPreviousMonth(LocalDate possiblePreviousMonthDate, YearMonth yearMonth) {

--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendar.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendar.java
@@ -1,19 +1,29 @@
 package de.focusshift.zeiterfassung.workingtime;
 
+import de.focusshift.zeiterfassung.absence.Absence;
+import de.focusshift.zeiterfassung.absence.DayLength;
+import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
 import de.focusshift.zeiterfassung.usermanagement.User;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import static java.lang.Math.min;
+
 /**
- * Provides information about the {@link PlannedWorkingHours} on a given {@link LocalDate} including publicHolidays.
+ * Provides information about {@link PlannedWorkingHours} / {@link ShouldWorkingHours} on a given {@link LocalDate}.
+ * (including publicHolidays and {@linkplain Absence absences})
+ *
+ * <p>
  * For instance:
+ *
  * <ul>
  *     <li>2022-12-26 - 0h (publicHoliday, monday)</li>
  *     <li>2022-12-27 - 8h (tuesday)</li>
- *     <li>2022-12-28 - 8h (wednesday)</li>
+ *     <li>2022-12-28 - 4h (wednesday, absent on noon)</li>
  *     <li>2022-12-29 - 8h (thursday)</li>
  *     <li>2022-12-30 - 4h (friday)</li>
  * </ul>
@@ -23,13 +33,69 @@ import java.util.Optional;
 public final class WorkingTimeCalendar {
 
     private final Map<LocalDate, PlannedWorkingHours> plannedWorkingHoursByDate;
+    private final Map<LocalDate, List<Absence>> absencesByDate;
 
-    public WorkingTimeCalendar(Map<LocalDate, PlannedWorkingHours> plannedWorkingHoursByDate) {
+    public WorkingTimeCalendar(Map<LocalDate, PlannedWorkingHours> plannedWorkingHoursByDate, Map<LocalDate, List<Absence>> absencesByDate) {
         this.plannedWorkingHoursByDate = plannedWorkingHoursByDate;
+        this.absencesByDate = absencesByDate;
     }
 
+    /**
+     * Returns the {@link PlannedWorkingHours} for the given date or empty when the date is unknown in this calendar.
+     *
+     * @param date date to get the {@link PlannedWorkingHours} for
+     * @return the {@link PlannedWorkingHours} for the given date or empty when the date is unknown in this calendar.
+     */
     public Optional<PlannedWorkingHours> plannedWorkingHours(LocalDate date) {
         return Optional.ofNullable(plannedWorkingHoursByDate.get(date));
+    }
+
+    /**
+     * Returns the {@link ShouldWorkingHours} for the given date or empty when the date is unknown in this calendar.
+     *
+     * @param date date to get the {@link ShouldWorkingHours} for
+     * @return the {@link ShouldWorkingHours} for the given date or empty when the date is unknown in this calendar.
+     */
+    public Optional<ShouldWorkingHours> shouldWorkingHours(LocalDate date) {
+
+        final PlannedWorkingHours plannedWorkingHours = plannedWorkingHoursByDate.get(date);
+        if (plannedWorkingHours == null) {
+            return Optional.empty();
+        }
+
+        final List<Absence> absences = absencesByDate.getOrDefault(date, List.of());
+
+        // one of:
+        // - 0.0 (no absences)
+        // - 0.5 (one half-day-absence)
+        // - 1.0 (two half-day-absences or one full-day-absence)
+        final double absenceValue = min(absences.stream().map(Absence::dayLength).map(DayLength::getValue).reduce(Double::sum).orElse(0d), 1);
+        if (absenceValue == 0) {
+            // no absence -> should == planned
+            return Optional.of(new ShouldWorkingHours(plannedWorkingHours.duration()));
+        } else if (absenceValue == 0.5) {
+            // half day absence -> should == planned / 2
+            return Optional.of(new ShouldWorkingHours(plannedWorkingHours.duration().dividedBy(2)));
+        } else {
+            // full day absence -> should == ZERO
+            return Optional.of(ShouldWorkingHours.ZERO);
+        }
+    }
+
+    /**
+     * Returns list of absences for the given date. Can have length of:
+     *
+     * <ul>
+     *     <li>{@code zero}: no absences</li>
+     *     <li>{@code one}: one full- or one half-day-absence</li>
+     *     <li>{@code two}: two half-day-absences</li>
+     * </ul>
+     *
+     * @param date date to get the {@link Absence}s for
+     * @return list of absences for the given date
+     */
+    public Optional<List<Absence>> absence(LocalDate date) {
+        return Optional.ofNullable(absencesByDate.get(date));
     }
 
     /**
@@ -48,18 +114,19 @@ public final class WorkingTimeCalendar {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         WorkingTimeCalendar that = (WorkingTimeCalendar) o;
-        return plannedWorkingHoursByDate.equals(that.plannedWorkingHoursByDate);
+        return Objects.equals(plannedWorkingHoursByDate, that.plannedWorkingHoursByDate) && Objects.equals(absencesByDate, that.absencesByDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(plannedWorkingHoursByDate);
+        return Objects.hash(plannedWorkingHoursByDate, absencesByDate);
     }
 
     @Override
     public String toString() {
         return "WorkingTimeCalendar{" +
             "plannedWorkingHoursByDate=" + plannedWorkingHoursByDate +
+            ", absencesByDate=" + absencesByDate +
             '}';
     }
 

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
@@ -137,19 +137,19 @@ class ReportCsvServiceTest {
         );
 
         // day one
-        final ZonedDateTime d1_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
-        final ZonedDateTime d1_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 11, 0), ZONE_ID_BERLIN);
-        final ReportDayEntry d1_1_ReportDayEntry = new ReportDayEntry(batman, "hard work", d1_1_From, d1_1_To, false);
-        final ZonedDateTime d1_2_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
-        final ZonedDateTime d1_2_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
-        final ReportDayEntry d1_2_ReportDayEntry = new ReportDayEntry(batman, "hard work", d1_2_From, d1_2_To, false);
-        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
+        final ZonedDateTime dayOneFirstFrom = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
+        final ZonedDateTime dayOneFirstTo = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 11, 0), ZONE_ID_BERLIN);
+        final ReportDayEntry dayOneFirstReportDayEntry = new ReportDayEntry(batman, "hard work", dayOneFirstFrom, dayOneFirstTo, false);
+        final ZonedDateTime dayOneSecondFrom = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
+        final ZonedDateTime dayOneSecondTo = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
+        final ReportDayEntry dayOneSecondReportDayEntry = new ReportDayEntry(batman, "hard work", dayOneSecondFrom, dayOneSecondTo, false);
+        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayOneFirstReportDayEntry, dayOneSecondReportDayEntry)), Map.of());
 
         // day two
-        final ZonedDateTime d2_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
-        final ZonedDateTime d2_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
-        final ReportDayEntry d2_1_ReportDayEntry = new ReportDayEntry(batman, "hard work", d2_1_From, d2_1_To, false);
-        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(d2_1_ReportDayEntry)), Map.of());
+        final ZonedDateTime dayTwoFrom = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
+        final ZonedDateTime dayTwoTo = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
+        final ReportDayEntry dayTwoReportDayEntry = new ReportDayEntry(batman, "hard work", dayTwoFrom, dayTwoTo, false);
+        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayTwoReportDayEntry)), Map.of());
 
 
         when(reportService.getReportWeek(Year.of(2021), 1, batmanId))
@@ -251,22 +251,22 @@ class ReportCsvServiceTest {
         );
 
         // week one, day one
-        final ZonedDateTime d1_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
-        final ZonedDateTime d1_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 11, 0), ZONE_ID_BERLIN);
-        final ReportDayEntry d1_1_ReportDayEntry = new ReportDayEntry(batman, "hard work", d1_1_From, d1_1_To, false);
-        final ZonedDateTime d1_2_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
-        final ZonedDateTime d1_2_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
-        final ReportDayEntry d1_2_ReportDayEntry = new ReportDayEntry(batman, "hard work", d1_2_From, d1_2_To, false);
-        final ReportDay w1_reportDay = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
+        final ZonedDateTime dayOneFirstFrom = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
+        final ZonedDateTime dayOneFirstTo = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 11, 0), ZONE_ID_BERLIN);
+        final ReportDayEntry dayOneFirstReportDayEntry = new ReportDayEntry(batman, "hard work", dayOneFirstFrom, dayOneFirstTo, false);
+        final ZonedDateTime dayOneSecondFrom = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
+        final ZonedDateTime dayOneSecondTo = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
+        final ReportDayEntry dayOneSecondReportDayEntry = new ReportDayEntry(batman, "hard work", dayOneSecondFrom, dayOneSecondTo, false);
+        final ReportDay weekOneReportDay = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayOneFirstReportDayEntry, dayOneSecondReportDayEntry)), Map.of());
 
         // week two, day one
-        final ZonedDateTime d2_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
-        final ZonedDateTime d2_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
-        final ReportDayEntry d2_1_ReportDayEntry = new ReportDayEntry(batman, "hard work", d2_1_From, d2_1_To, false);
-        final ReportDay w2_reportDay = new ReportDay(LocalDate.of(2021, 1, 5), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(d2_1_ReportDayEntry)), Map.of());
+        final ZonedDateTime dayTwoFrom = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
+        final ZonedDateTime dayTwoTo = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
+        final ReportDayEntry dayTwoReportDayEntry = new ReportDayEntry(batman, "hard work", dayTwoFrom, dayTwoTo, false);
+        final ReportDay weekTwoReportDay = new ReportDay(LocalDate.of(2021, 1, 5), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayTwoReportDayEntry)), Map.of());
 
-        final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(w1_reportDay));
-        final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of(w2_reportDay));
+        final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(weekOneReportDay));
+        final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of(weekTwoReportDay));
         final ReportWeek thirdWeek = new ReportWeek(LocalDate.of(2021, 1, 11), List.of());
         final ReportWeek fourthWeek = new ReportWeek(LocalDate.of(2021, 1, 18), List.of());
         final ReportWeek fifthWeek = new ReportWeek(LocalDate.of(2021, 1, 25), List.of());

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
@@ -7,6 +7,7 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
+import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -89,10 +90,17 @@ class ReportCsvServiceTest {
         final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
         final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
+        final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser = Map.of(
+            batmanIdComposite, new WorkingTimeCalendar(
+                Map.of(LocalDate.of(2021, 1, 4), PlannedWorkingHours.EIGHT),
+                Map.of()
+            )
+        );
+
         final ZonedDateTime from = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
         final ZonedDateTime to = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 30), ZONE_ID_BERLIN);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, false);
-        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
 
         when(reportService.getReportWeek(Year.of(2021), 1, batmanId))
             .thenReturn(new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDay)));
@@ -118,6 +126,16 @@ class ReportCsvServiceTest {
         final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
         final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
+        final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser = Map.of(
+            batmanIdComposite, new WorkingTimeCalendar(
+                Map.of(
+                    LocalDate.of(2021, 1, 4), PlannedWorkingHours.EIGHT,
+                    LocalDate.of(2021, 1, 5), PlannedWorkingHours.EIGHT
+                ),
+                Map.of()
+            )
+        );
+
         // day one
         final ZonedDateTime d1_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d1_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 11, 0), ZONE_ID_BERLIN);
@@ -125,13 +143,13 @@ class ReportCsvServiceTest {
         final ZonedDateTime d1_2_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d1_2_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d1_2_ReportDayEntry = new ReportDayEntry(batman, "hard work", d1_2_From, d1_2_To, false);
-        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
+        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
 
         // day two
         final ZonedDateTime d2_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d2_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d2_1_ReportDayEntry = new ReportDayEntry(batman, "hard work", d2_1_From, d2_1_To, false);
-        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(d2_1_ReportDayEntry)), Map.of());
+        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(d2_1_ReportDayEntry)), Map.of());
 
 
         when(reportService.getReportWeek(Year.of(2021), 1, batmanId))
@@ -180,10 +198,17 @@ class ReportCsvServiceTest {
         final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
         final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
+        final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser = Map.of(
+            batmanIdComposite, new WorkingTimeCalendar(
+                Map.of(LocalDate.of(2021, 1, 4), PlannedWorkingHours.EIGHT),
+                Map.of()
+            )
+        );
+
         final ZonedDateTime from = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
         final ZonedDateTime to = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 30), ZONE_ID_BERLIN);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(batman, "hard work", from, to, false);
-        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
 
         final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDay));
         final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of());
@@ -215,6 +240,16 @@ class ReportCsvServiceTest {
         final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
         final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
+        final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser = Map.of(
+            batmanIdComposite, new WorkingTimeCalendar(
+                Map.of(
+                    LocalDate.of(2021, 1, 4), PlannedWorkingHours.EIGHT,
+                    LocalDate.of(2021, 1, 5), PlannedWorkingHours.EIGHT
+                ),
+                Map.of()
+            )
+        );
+
         // week one, day one
         final ZonedDateTime d1_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d1_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 11, 0), ZONE_ID_BERLIN);
@@ -222,13 +257,13 @@ class ReportCsvServiceTest {
         final ZonedDateTime d1_2_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d1_2_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d1_2_ReportDayEntry = new ReportDayEntry(batman, "hard work", d1_2_From, d1_2_To, false);
-        final ReportDay w1_reportDay = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
+        final ReportDay w1_reportDay = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(d1_1_ReportDayEntry, d1_2_ReportDayEntry)), Map.of());
 
         // week two, day one
         final ZonedDateTime d2_1_From = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
         final ZonedDateTime d2_1_To = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
         final ReportDayEntry d2_1_ReportDayEntry = new ReportDayEntry(batman, "hard work", d2_1_From, d2_1_To, false);
-        final ReportDay w2_reportDay = new ReportDay(LocalDate.of(2021, 1, 5), Map.of(batmanIdComposite, PlannedWorkingHours.EIGHT), Map.of(batmanIdComposite, List.of(d2_1_ReportDayEntry)), Map.of());
+        final ReportDay w2_reportDay = new ReportDay(LocalDate.of(2021, 1, 5), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(d2_1_ReportDayEntry)), Map.of());
 
         final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(w1_reportDay));
         final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of(w2_reportDay));

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
@@ -8,6 +8,7 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
+import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -465,23 +466,23 @@ class ReportMonthControllerTest {
             eightHoursDay(firstDateOfWeek.plusDays(4), user),
             new ReportDay(
                 firstDateOfWeek.plusDays(5),
-                Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO),
+                Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(firstDateOfWeek.plusDays(5), PlannedWorkingHours.ZERO), Map.of(firstDateOfWeek.plusDays(5), List.of()))),
                 Map.of(user.userIdComposite(), List.of()),
                 Map.of(user.userIdComposite(), List.of())
             ),
             new ReportDay(
                 firstDateOfWeek.plusDays(6),
-                Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO),
+                Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(firstDateOfWeek.plusDays(6), PlannedWorkingHours.ZERO), Map.of(firstDateOfWeek.plusDays(6), List.of()))),
                 Map.of(user.userIdComposite(), List.of()),
                 Map.of(user.userIdComposite(), List.of())
-            )
-        ));
+            ))
+        );
     }
 
     private ReportDay eightHoursDay(LocalDate date, User user) {
         return new ReportDay(
             date,
-            Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT),
+            Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(date, PlannedWorkingHours.EIGHT), Map.of(date, List.of()))),
             Map.of(user.userIdComposite(), List.of(reportDayEntry(user, date))),
             Map.of(user.userIdComposite(), List.of())
         );
@@ -490,7 +491,7 @@ class ReportMonthControllerTest {
     private ReportDay zeroHoursDay(LocalDate date, User user) {
         return new ReportDay(
             date,
-            Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO),
+            Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(date, PlannedWorkingHours.ZERO), Map.of(date, List.of()))),
             Map.of(user.userIdComposite(), List.of()),
             Map.of(user.userIdComposite(), List.of())
         );

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthTest.java
@@ -7,6 +7,7 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
+import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -57,22 +58,37 @@ class ReportMonthTest {
         final LocalDate saturday = firstDateOfWeek.plusDays(5);
         final LocalDate sunday = firstDateOfWeek.plusDays(6);
 
+        final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser = Map.of(
+            user.userIdComposite(), new WorkingTimeCalendar(
+                Map.of(
+                    firstDateOfWeek, PlannedWorkingHours.ZERO,
+                    tuesday, PlannedWorkingHours.EIGHT,
+                    wednesday, PlannedWorkingHours.EIGHT,
+                    thursday, PlannedWorkingHours.EIGHT,
+                    friday, PlannedWorkingHours.EIGHT,
+                    saturday, PlannedWorkingHours.EIGHT,
+                    sunday, PlannedWorkingHours.EIGHT
+                ),
+                Map.of()
+            )
+        );
+
         return new ReportWeek(firstDateOfWeek, List.of(
             // january
-            new ReportDay(firstDateOfWeek, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(tuesday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(firstDateOfWeek, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(tuesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
             // february
-            new ReportDay(wednesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(wednesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(thursday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(friday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of()), Map.of())
+            new ReportDay(saturday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
     }
 
@@ -85,24 +101,39 @@ class ReportMonthTest {
         final LocalDate saturday = firstDateOfWeek.plusDays(5);
         final LocalDate sunday = firstDateOfWeek.plusDays(6);
 
+        final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser = Map.of(
+            user.userIdComposite(), new WorkingTimeCalendar(
+                Map.of(
+                    firstDateOfWeek, PlannedWorkingHours.EIGHT,
+                    tuesday, PlannedWorkingHours.EIGHT,
+                    wednesday, PlannedWorkingHours.EIGHT,
+                    thursday, PlannedWorkingHours.EIGHT,
+                    friday, PlannedWorkingHours.EIGHT,
+                    saturday, PlannedWorkingHours.ZERO,
+                    sunday, PlannedWorkingHours.ZERO
+                ),
+                Map.of()
+            )
+        );
+
         return new ReportWeek(firstDateOfWeek, List.of(
-            new ReportDay(firstDateOfWeek, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(firstDateOfWeek, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(firstDateOfWeek, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(firstDateOfWeek, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(tuesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(tuesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(tuesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(wednesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(wednesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(thursday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(friday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of())
+            new ReportDay(saturday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
     }
 
@@ -115,20 +146,35 @@ class ReportMonthTest {
         final LocalDate saturday = firstDateOfWeek.plusDays(5);
         final LocalDate sunday = firstDateOfWeek.plusDays(6);
 
+        final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser = Map.of(
+            user.userIdComposite(), new WorkingTimeCalendar(
+                Map.of(
+                    firstDateOfWeek, PlannedWorkingHours.EIGHT,
+                    tuesday, PlannedWorkingHours.EIGHT,
+                    wednesday, PlannedWorkingHours.ZERO,
+                    thursday, PlannedWorkingHours.ZERO,
+                    friday, PlannedWorkingHours.ZERO,
+                    saturday, PlannedWorkingHours.ZERO,
+                    sunday, PlannedWorkingHours.ZERO
+                ),
+                Map.of()
+            )
+        );
+
         return new ReportWeek(firstDateOfWeek, List.of(
             // february
-            new ReportDay(firstDateOfWeek, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(firstDateOfWeek, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(tuesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
             // march
-            new ReportDay(wednesday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(thursday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(friday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(saturday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of())
+            new ReportDay(wednesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(thursday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(friday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(saturday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
@@ -11,6 +11,8 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
+import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
+import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendarService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +34,7 @@ import java.util.Set;
 
 import static java.time.DayOfWeek.MONDAY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -200,6 +203,37 @@ class ReportServiceRawTest {
         assertThat(actualReportWeek.reportDays().get(6).workDuration().duration()).isZero();
     }
 
+    @Test
+    void getReportWeek() {
+        final User user = anyUser();
+        LocalDate start = LocalDate.of(2024, 1, 1);
+        LocalDate endExclusive = LocalDate.of(2024, 1, 8);
+
+        when(userDateService.firstDayOfWeek(Year.of(2024), 1))
+                .thenReturn(start);
+
+        sut.getReportWeek(Year.of(2024), 1, List.of(user.userLocalId()));
+
+        verify(timeEntryService).getEntriesByUserLocalIds(start, endExclusive, List.of(user.userLocalId()));
+        verify(absenceService).getAbsencesByUserIds(List.of(user.userLocalId()), start, endExclusive);
+        verify(workingTimeCalendarService).getWorkingTimeCalendarForUsers(start, endExclusive, List.of(user.userLocalId()));
+    }
+
+    @Test
+    void getReportWeekForAllUsers() {
+        LocalDate start = LocalDate.of(2024, 1, 1);
+        LocalDate endExclusive = LocalDate.of(2024, 1, 8);
+
+        when(userDateService.firstDayOfWeek(Year.of(2024), 1))
+                .thenReturn(start);
+
+        sut.getReportWeekForAllUsers(Year.of(2024), 1);
+
+        verify(timeEntryService).getEntriesForAllUsers(start, endExclusive);
+        verify(absenceService).getAbsencesForAllUsers(start, endExclusive);
+        verify(workingTimeCalendarService).getWorkingTimeCalendarForAllUsers(start, endExclusive);
+    }
+
     // ------------------------------------------------------------
     // MONTH report
     // ------------------------------------------------------------
@@ -304,6 +338,39 @@ class ReportServiceRawTest {
         assertThat(actualReportMonth.weeks().get(2).workDuration().duration()).isEqualTo(Duration.ofHours(4));
         assertThat(actualReportMonth.weeks().get(3).workDuration().duration()).isEqualTo(Duration.ofHours(6));
         assertThat(actualReportMonth.weeks().get(4).workDuration().duration()).isEqualTo(Duration.ofHours(8));
+    }
+
+    @Test
+    void getReportMonth() {
+        final User user = anyUser();
+        YearMonth month = YearMonth.of(2024, 1);
+        LocalDate start = month.atDay(1);
+        LocalDate endExclusive = month.atEndOfMonth().plusDays(1);
+
+        when(userDateService.localDateToFirstDateOfWeek(start))
+                .thenReturn(start);
+
+        sut.getReportMonth(month, List.of(user.userLocalId()));
+
+        verify(timeEntryService).getEntriesByUserLocalIds(start, endExclusive, List.of(user.userLocalId()));
+        verify(absenceService).getAbsencesByUserIds(List.of(user.userLocalId()), start, endExclusive);
+        verify(workingTimeCalendarService).getWorkingTimeCalendarForUsers(start, endExclusive, List.of(user.userLocalId()));
+    }
+
+    @Test
+    void getReportMonthForAllUsers() {
+        YearMonth month = YearMonth.of(2024, 1);
+        LocalDate start = month.atDay(1);
+        LocalDate endExclusive = month.atEndOfMonth().plusDays(1);
+
+        when(userDateService.localDateToFirstDateOfWeek(start))
+                .thenReturn(start);
+
+        sut.getReportMonthForAllUsers(month);
+
+        verify(timeEntryService).getEntriesForAllUsers(start, endExclusive);
+        verify(absenceService).getAbsencesForAllUsers(start, endExclusive);
+        verify(workingTimeCalendarService).getWorkingTimeCalendarForAllUsers(start, endExclusive);
     }
 
     private static User anyUser() {

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
@@ -1,6 +1,5 @@
 package de.focusshift.zeiterfassung.report;
 
-import de.focusshift.zeiterfassung.absence.AbsenceService;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.timeentry.TimeEntry;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryId;
@@ -11,8 +10,6 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
-import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
-import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendarService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,12 +53,9 @@ class ReportServiceRawTest {
     @Mock
     private WorkingTimeCalendarService workingTimeCalendarService;
 
-    @Mock
-    private AbsenceService absenceService;
-
     @BeforeEach
     void setUp() {
-        sut = new ReportServiceRaw(timeEntryService, userManagementService, userDateService, workingTimeCalendarService, absenceService);
+        sut = new ReportServiceRaw(timeEntryService, userManagementService, userDateService, workingTimeCalendarService);
     }
 
     // ------------------------------------------------------------
@@ -215,7 +209,6 @@ class ReportServiceRawTest {
         sut.getReportWeek(Year.of(2024), 1, List.of(user.userLocalId()));
 
         verify(timeEntryService).getEntriesByUserLocalIds(start, endExclusive, List.of(user.userLocalId()));
-        verify(absenceService).getAbsencesByUserIds(List.of(user.userLocalId()), start, endExclusive);
         verify(workingTimeCalendarService).getWorkingTimeCalendarForUsers(start, endExclusive, List.of(user.userLocalId()));
     }
 
@@ -230,7 +223,6 @@ class ReportServiceRawTest {
         sut.getReportWeekForAllUsers(Year.of(2024), 1);
 
         verify(timeEntryService).getEntriesForAllUsers(start, endExclusive);
-        verify(absenceService).getAbsencesForAllUsers(start, endExclusive);
         verify(workingTimeCalendarService).getWorkingTimeCalendarForAllUsers(start, endExclusive);
     }
 
@@ -353,7 +345,6 @@ class ReportServiceRawTest {
         sut.getReportMonth(month, List.of(user.userLocalId()));
 
         verify(timeEntryService).getEntriesByUserLocalIds(start, endExclusive, List.of(user.userLocalId()));
-        verify(absenceService).getAbsencesByUserIds(List.of(user.userLocalId()), start, endExclusive);
         verify(workingTimeCalendarService).getWorkingTimeCalendarForUsers(start, endExclusive, List.of(user.userLocalId()));
     }
 
@@ -369,7 +360,6 @@ class ReportServiceRawTest {
         sut.getReportMonthForAllUsers(month);
 
         verify(timeEntryService).getEntriesForAllUsers(start, endExclusive);
-        verify(absenceService).getAbsencesForAllUsers(start, endExclusive);
         verify(workingTimeCalendarService).getWorkingTimeCalendarForAllUsers(start, endExclusive);
     }
 

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
@@ -10,6 +10,7 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
+import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -91,21 +92,34 @@ class ReportWeekControllerTest {
         final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
         final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
+        final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(
+            Map.of(
+                LocalDate.of(2023, 1, 30), PlannedWorkingHours.EIGHT,
+                LocalDate.of(2023, 1, 31), PlannedWorkingHours.EIGHT,
+                LocalDate.of(2023, 2, 1), PlannedWorkingHours.EIGHT,
+                LocalDate.of(2023, 2, 2), PlannedWorkingHours.EIGHT,
+                LocalDate.of(2023, 2, 3), PlannedWorkingHours.EIGHT,
+                LocalDate.of(2023, 2, 4), PlannedWorkingHours.ZERO,
+                LocalDate.of(2023, 2, 5), PlannedWorkingHours.ZERO
+            ),
+            Map.of()
+        );
+
         final ReportWeek reportWeek = new ReportWeek(LocalDate.of(2023, 1, 30), List.of(
-            eightHoursDay(LocalDate.of(2023, 1, 30), user),
-            eightHoursDay(LocalDate.of(2023, 1, 31), user),
-            eightHoursDay(LocalDate.of(2023, 2, 1), user),
-            eightHoursDay(LocalDate.of(2023, 2, 2), user),
-            eightHoursDay(LocalDate.of(2023, 2, 3), user),
+            eightHoursDay(LocalDate.of(2023, 1, 30), user, workingTimeCalendar),
+            eightHoursDay(LocalDate.of(2023, 1, 31), user, workingTimeCalendar),
+            eightHoursDay(LocalDate.of(2023, 2, 1), user, workingTimeCalendar),
+            eightHoursDay(LocalDate.of(2023, 2, 2), user, workingTimeCalendar),
+            eightHoursDay(LocalDate.of(2023, 2, 3), user, workingTimeCalendar),
             new ReportDay(
                 LocalDate.of(2023, 2, 4),
-                Map.of(userIdComposite, PlannedWorkingHours.ZERO),
+                Map.of(userIdComposite, workingTimeCalendar),
                 Map.of(userIdComposite, List.of()),
                 Map.of(userIdComposite, List.of())
             ),
             new ReportDay(
                 LocalDate.of(2023, 2, 5),
-                Map.of(userIdComposite, PlannedWorkingHours.ZERO),
+                Map.of(userIdComposite, workingTimeCalendar),
                 Map.of(userIdComposite, List.of()),
                 Map.of(userIdComposite, List.of())
             )
@@ -151,22 +165,29 @@ class ReportWeekControllerTest {
         final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
         final LocalDate absenceDate = LocalDate.of(2023, 2, 3);
+        Absence absence = new Absence(
+                user.userId(),
+                absenceDate.atStartOfDay(UTC),
+                absenceDate.atStartOfDay(UTC),
+                DayLength.FULL,
+                locale -> "absence-full-de",
+                ORANGE,
+                HOLIDAY
+        );
+
+        final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(
+            Map.of(LocalDate.of(2023, 2, 3), PlannedWorkingHours.EIGHT),
+            Map.of(LocalDate.of(2023, 2, 3), List.of(absence))
+        );
+
 
         final ReportWeek reportWeek = new ReportWeek(LocalDate.of(2023, 1, 30), List.of(
             new ReportDay(
                 absenceDate,
-                Map.of(userIdComposite, PlannedWorkingHours.EIGHT),
+                Map.of(userIdComposite, workingTimeCalendar),
                 Map.of(userIdComposite, List.of()),
                 Map.of(userIdComposite, List.of(
-                    new ReportDayAbsence(user, new Absence(
-                        user.userId(),
-                        absenceDate.atStartOfDay(UTC),
-                        absenceDate.atStartOfDay(UTC),
-                        DayLength.FULL,
-                        locale -> "absence-full-de",
-                        ORANGE,
-                        HOLIDAY
-                    ))
+                    new ReportDayAbsence(user, absence)
                 ))
             )
         ));
@@ -304,25 +325,25 @@ class ReportWeekControllerTest {
     @Test
     void ensureWeekReportUserFilterRelatedUrls() throws Exception {
 
-        final UserId userId_1 = new UserId("batman");
-        final UserLocalId userLocalId_1 = new UserLocalId(1L);
-        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
-        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        final UserId userId1 = new UserId("batman");
+        final UserLocalId userLocalId1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite1 = new UserIdComposite(userId1, userLocalId1);
+        final User user1 = new User(userIdComposite1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
-        final UserId userId_2 = new UserId("joker");
-        final UserLocalId userLocalId_2 = new UserLocalId(2L);
-        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
-        final User user_2 = new User(userIdComposite_2, "Jack", "Napier", new EMailAddress(""), Set.of());
+        final UserId userId2 = new UserId("joker");
+        final UserLocalId userLocalId2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite2 = new UserIdComposite(userId2, userLocalId2);
+        final User user2 = new User(userIdComposite2, "Jack", "Napier", new EMailAddress(""), Set.of());
 
-        final UserId userId_3 = new UserId("robin");
-        final UserLocalId userLocalId_3 = new UserLocalId(3L);
-        final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
-        final User user_3 = new User(userIdComposite_3, "Dick", "Grayson", new EMailAddress(""), Set.of());
+        final UserId userId3 = new UserId("robin");
+        final UserLocalId userLocalId3 = new UserLocalId(3L);
+        final UserIdComposite userIdComposite3 = new UserIdComposite(userId3, userLocalId3);
+        final User user3 = new User(userIdComposite3, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
         when(reportPermissionService.findAllPermittedUsersForCurrentUser())
-            .thenReturn(List.of(user_1, user_2, user_3));
+            .thenReturn(List.of(user1, user2, user3));
 
-        when(reportService.getReportWeek(Year.of(2022), 1, userId_1))
+        when(reportService.getReportWeek(Year.of(2022), 1, userId1))
             .thenReturn(anyReportWeek());
 
         perform(get("/report/year/2022/week/1").with(oidcLogin().userInfoToken(userInfo -> userInfo.subject("batman"))))
@@ -339,23 +360,23 @@ class ReportWeekControllerTest {
     @Test
     void ensureWeekReportUserFilterRelatedUrlsForEveryone() throws Exception {
 
-        final UserId userId_1 = new UserId("batman");
-        final UserLocalId userLocalId_1 = new UserLocalId(1L);
-        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
-        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        final UserId userId1 = new UserId("batman");
+        final UserLocalId userLocalId1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite1 = new UserIdComposite(userId1, userLocalId1);
+        final User user1 = new User(userIdComposite1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
-        final UserId userId_2 = new UserId("joker");
-        final UserLocalId userLocalId_2 = new UserLocalId(2L);
-        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
-        final User user_2 = new User(userIdComposite_2, "Jack", "Napier", new EMailAddress(""), Set.of());
+        final UserId userId2 = new UserId("joker");
+        final UserLocalId userLocalId2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite2 = new UserIdComposite(userId2, userLocalId2);
+        final User user2 = new User(userIdComposite2, "Jack", "Napier", new EMailAddress(""), Set.of());
 
-        final UserId userId_3 = new UserId("robin");
-        final UserLocalId userLocalId_3 = new UserLocalId(3L);
-        final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
-        final User user_3 = new User(userIdComposite_3, "Dick", "Grayson", new EMailAddress(""), Set.of());
+        final UserId userId3 = new UserId("robin");
+        final UserLocalId userLocalId3 = new UserLocalId(3L);
+        final UserIdComposite userIdComposite3 = new UserIdComposite(userId3, userLocalId3);
+        final User user3 = new User(userIdComposite3, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
         when(reportPermissionService.findAllPermittedUsersForCurrentUser())
-            .thenReturn(List.of(user_1, user_2, user_3));
+            .thenReturn(List.of(user1, user2, user3));
 
         when(reportService.getReportWeekForAllUsers(Year.of(2022), 1))
             .thenReturn(anyReportWeek());
@@ -378,25 +399,25 @@ class ReportWeekControllerTest {
     @Test
     void ensureWeekReportUserFilterRelatedUrlsForWithSelectedUser() throws Exception {
 
-        final UserId userId_1 = new UserId("batman");
-        final UserLocalId userLocalId_1 = new UserLocalId(1L);
-        final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
-        final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+        final UserId userId1 = new UserId("batman");
+        final UserLocalId userLocalId1 = new UserLocalId(1L);
+        final UserIdComposite userIdComposite1 = new UserIdComposite(userId1, userLocalId1);
+        final User user1 = new User(userIdComposite1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
 
-        final UserId userId_2 = new UserId("joker");
-        final UserLocalId userLocalId_2 = new UserLocalId(2L);
-        final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
-        final User user_2 = new User(userIdComposite_2, "Jack", "Napier", new EMailAddress(""), Set.of());
+        final UserId userId2 = new UserId("joker");
+        final UserLocalId userLocalId2 = new UserLocalId(2L);
+        final UserIdComposite userIdComposite2 = new UserIdComposite(userId2, userLocalId2);
+        final User user2 = new User(userIdComposite2, "Jack", "Napier", new EMailAddress(""), Set.of());
 
-        final UserId userId_3 = new UserId("robin");
-        final UserLocalId userLocalId_3 = new UserLocalId(3L);
-        final UserIdComposite userIdComposite_3 = new UserIdComposite(userId_3, userLocalId_3);
-        final User user_3 = new User(userIdComposite_3, "Dick", "Grayson", new EMailAddress(""), Set.of());
+        final UserId userId3 = new UserId("robin");
+        final UserLocalId userLocalId3 = new UserLocalId(3L);
+        final UserIdComposite userIdComposite3 = new UserIdComposite(userId3, userLocalId3);
+        final User user3 = new User(userIdComposite3, "Dick", "Grayson", new EMailAddress(""), Set.of());
 
         when(reportPermissionService.findAllPermittedUsersForCurrentUser())
-            .thenReturn(List.of(user_1, user_2, user_3));
+            .thenReturn(List.of(user1, user2, user3));
 
-        when(reportService.getReportWeek(Year.of(2022), 1, List.of(userLocalId_2, userLocalId_3)))
+        when(reportService.getReportWeek(Year.of(2022), 1, List.of(userLocalId2, userLocalId3)))
             .thenReturn(anyReportWeek());
 
         perform(
@@ -427,10 +448,10 @@ class ReportWeekControllerTest {
         return new ReportWeek(LocalDate.of(2022, 1, 1), List.of());
     }
 
-    private ReportDay eightHoursDay(LocalDate date, User user) {
+    private ReportDay eightHoursDay(LocalDate date, User user, WorkingTimeCalendar workingTimeCalendar) {
         return new ReportDay(
             date,
-            Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT),
+            Map.of(user.userIdComposite(), workingTimeCalendar),
             Map.of(user.userIdComposite(), List.of(reportDayEntry(user, date))),
             Map.of(user.userIdComposite(), List.of())
         );

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekTest.java
@@ -7,6 +7,7 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
+import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -36,13 +37,14 @@ class ReportWeekTest {
         final UserLocalId userLocalId = new UserLocalId(1L);
         final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
 
-        final ReportWeek sut = new ReportWeek(LocalDate.of(2023, 2, 13), List.of(
-            new ReportDay(LocalDate.of(2023, 2, 13), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 14), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 15), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 16), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 17), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 18), Map.of(userIdComposite, PlannedWorkingHours.ZERO), Map.of(userIdComposite, List.of()), Map.of())
+        LocalDate date = LocalDate.of(2023, 2, 13);
+        final ReportWeek sut = new ReportWeek(date, List.of(
+            new ReportDay(date, Map.of(userIdComposite, zeroHoursDay(date)), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(date.plusDays(1), Map.of(userIdComposite, zeroHoursDay(date.plusDays(1))), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(date.plusDays(2), Map.of(userIdComposite, zeroHoursDay(date.plusDays(2))), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(date.plusDays(3), Map.of(userIdComposite, zeroHoursDay(date.plusDays(3))), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(date.plusDays(4), Map.of(userIdComposite, zeroHoursDay(date.plusDays(4))), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(date.plusDays(5), Map.of(userIdComposite, zeroHoursDay(date.plusDays(5))), Map.of(userIdComposite, List.of()), Map.of())
         ));
 
         assertThat(sut.averageDayWorkDuration()).isEqualTo(WorkDuration.ZERO);
@@ -68,27 +70,36 @@ class ReportWeekTest {
         final LocalDate sunday = monday.plusDays(6);
 
         final ReportWeek sut = new ReportWeek(monday, List.of(
-            new ReportDay(monday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(monday, Map.of(user.userIdComposite(), eightHoursDay(monday)), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(monday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(monday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(tuesday, Map.of(user.userIdComposite(), eightHoursDay(tuesday)), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(tuesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(tuesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(wednesday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(wednesday, Map.of(user.userIdComposite(), eightHoursDay(wednesday)), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(thursday, Map.of(user.userIdComposite(), eightHoursDay(thursday)), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, Map.of(user.userIdComposite(), PlannedWorkingHours.EIGHT), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(friday, Map.of(user.userIdComposite(), eightHoursDay(friday)), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(user.userIdComposite(), PlannedWorkingHours.ZERO), Map.of(user.userIdComposite(), List.of()), Map.of())
+            new ReportDay(saturday, Map.of(user.userIdComposite(), zeroHoursDay(saturday)), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, Map.of(user.userIdComposite(), zeroHoursDay(sunday)), Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
 
         final WorkDuration actual = sut.averageDayWorkDuration();
 
         assertThat(actual).isEqualTo(new WorkDuration(Duration.ofHours(8)));
+    }
+
+
+    private WorkingTimeCalendar zeroHoursDay(LocalDate date) {
+        return new WorkingTimeCalendar(Map.of(date, PlannedWorkingHours.ZERO), Map.of(date, List.of()));
+    }
+
+    private WorkingTimeCalendar eightHoursDay(LocalDate date) {
+        return new WorkingTimeCalendar(Map.of(date, PlannedWorkingHours.EIGHT), Map.of(date, List.of()));
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
@@ -1026,7 +1026,7 @@ class TimeEntryServiceImplTest {
                 LocalDate.of(2022, 1, 7), PlannedWorkingHours.EIGHT,
                 LocalDate.of(2022, 1, 8), PlannedWorkingHours.ZERO, // saturday
                 LocalDate.of(2022, 1, 9), PlannedWorkingHours.ZERO  // sunday
-            )));
+            ), Map.of()));
 
         final TimeEntryWeekPage actual = sut.getEntryWeekPage(userId, 2022, 1);
 
@@ -1137,7 +1137,7 @@ class TimeEntryServiceImplTest {
                 LocalDate.of(2023, 2, 3), PlannedWorkingHours.EIGHT,
                 LocalDate.of(2023, 2, 4), PlannedWorkingHours.ZERO,
                 LocalDate.of(2023, 2, 5), PlannedWorkingHours.ZERO
-            )));
+            ), Map.of()));
 
         final TimeEntryWeekPage actual = sut.getEntryWeekPage(userId, 2023, 5);
 
@@ -1240,7 +1240,7 @@ class TimeEntryServiceImplTest {
                 LocalDate.of(2023, 6, 16), PlannedWorkingHours.EIGHT,
                 LocalDate.of(2023, 6, 17), PlannedWorkingHours.ZERO,
                 LocalDate.of(2023, 6, 18), PlannedWorkingHours.ZERO
-            )));
+            ), Map.of()));
 
         final TimeEntryWeekPage actual = sut.getEntryWeekPage(userId, 2023, 24);
 

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
@@ -1,6 +1,5 @@
 package de.focusshift.zeiterfassung.timeentry;
 
-import de.focusshift.zeiterfassung.absence.AbsenceService;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.UserDateService;
 import de.focusshift.zeiterfassung.user.UserId;
@@ -62,15 +61,13 @@ class TimeEntryServiceImplTest {
     private UserManagementService userManagementService;
     @Mock
     private UserSettingsProvider userSettingsProvider;
-    @Mock
-    private AbsenceService absenceService;
 
     private static final Clock clockFixed = Clock.fixed(Instant.now(), UTC);
 
     @BeforeEach
     void setUp() {
         sut = new TimeEntryServiceImpl(timeEntryRepository, userManagementService, workingTimeCalendarService,
-            userDateService, userSettingsProvider, absenceService, clockFixed);
+            userDateService, userSettingsProvider, clockFixed);
     }
 
     @Test

--- a/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImplTest.java
@@ -1,5 +1,7 @@
 package de.focusshift.zeiterfassung.workingtime;
 
+import de.focusshift.zeiterfassung.absence.Absence;
+import de.focusshift.zeiterfassung.absence.AbsenceService;
 import de.focusshift.zeiterfassung.publicholiday.PublicHoliday;
 import de.focusshift.zeiterfassung.publicholiday.PublicHolidayCalendar;
 import de.focusshift.zeiterfassung.publicholiday.PublicHolidaysService;
@@ -15,19 +17,28 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static de.focusshift.zeiterfassung.absence.AbsenceColor.RED;
+import static de.focusshift.zeiterfassung.absence.AbsenceTypeCategory.HOLIDAY;
+import static de.focusshift.zeiterfassung.absence.DayLength.FULL;
+import static de.focusshift.zeiterfassung.absence.DayLength.MORNING;
 import static de.focusshift.zeiterfassung.publicholiday.FederalState.GERMANY_BADEN_WUERTTEMBERG;
 import static de.focusshift.zeiterfassung.publicholiday.FederalState.GERMANY_BAYERN;
 import static de.focusshift.zeiterfassung.publicholiday.FederalState.NONE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class WorkingTimeCalendarServiceImplTest {
+
+    private static final ZoneId ZONE_ID_BERLIN = ZoneId.of("Europe/Berlin");
 
     private WorkingTimeCalendarServiceImpl sut;
 
@@ -35,10 +46,12 @@ class WorkingTimeCalendarServiceImplTest {
     private WorkingTimeService workingTimeService;
     @Mock
     private PublicHolidaysService publicHolidaysService;
+    @Mock
+    private AbsenceService absenceService;
 
     @BeforeEach
     void setUp() {
-        sut = new WorkingTimeCalendarServiceImpl(workingTimeService, publicHolidaysService);
+        sut = new WorkingTimeCalendarServiceImpl(workingTimeService, publicHolidaysService, absenceService);
     }
 
     @Nested
@@ -57,6 +70,7 @@ class WorkingTimeCalendarServiceImplTest {
             final LocalDate from = LocalDate.of(2023, 2, 13);
             final LocalDate toExclusive = LocalDate.of(2023, 2, 20);
 
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdComposite_1, List.of(), userIdComposite_2, List.of()));
             when(workingTimeService.getAllWorkingTimes(from, toExclusive)).thenReturn(Map.of(
                 userIdComposite_1, List.of(
                     WorkingTime.builder(userIdComposite_1, new WorkingTimeId(UUID.randomUUID()))
@@ -98,7 +112,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 17), new PlannedWorkingHours(Duration.ofHours(5)),
                     LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(6)),
                     LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(7))
-                )))
+                ), Map.of()))
                 .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(7)),
                     LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(6)),
@@ -107,7 +121,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 17), new PlannedWorkingHours(Duration.ofHours(3)),
                     LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(2)),
                     LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(1))
-                )));
+                ), Map.of()));
         }
 
         @Test
@@ -124,6 +138,7 @@ class WorkingTimeCalendarServiceImplTest {
             final LocalDate from = LocalDate.of(2023, 2, 13);
             final LocalDate toExclusive = LocalDate.of(2023, 2, 20);
 
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdComposite_1, List.of(), userIdComposite_2, List.of()));
             when(workingTimeService.getAllWorkingTimes(from, toExclusive)).thenReturn(Map.of(
                 userIdComposite_1, List.of(
                     WorkingTime.builder(userIdComposite_1, new WorkingTimeId(UUID.randomUUID()))
@@ -164,7 +179,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 17), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 18), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 19), PlannedWorkingHours.ZERO
-                )))
+                ), Map.of()))
                 .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), PlannedWorkingHours.EIGHT,
                     LocalDate.of(2023, 2, 14), PlannedWorkingHours.ZERO,
@@ -173,7 +188,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 17), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 18), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 19), PlannedWorkingHours.ZERO
-                )));
+                ), Map.of()));
         }
 
         @Test
@@ -188,6 +203,7 @@ class WorkingTimeCalendarServiceImplTest {
             final LocalDate friday = LocalDate.of(2023, 12, 8);
             final LocalDate mondayNextWeek = monday.plusWeeks(1);
 
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdComposite, List.of()));
             when(workingTimeService.getAllWorkingTimes(monday, mondayNextWeek)).thenReturn(Map.of(
                 userIdComposite, List.of(
                     WorkingTime.builder(userIdComposite, new WorkingTimeId(UUID.randomUUID()))
@@ -222,6 +238,86 @@ class WorkingTimeCalendarServiceImplTest {
                 assertThat(workingTimeCalendar.plannedWorkingHours(friday)).hasValue(PlannedWorkingHours.EIGHT);
             });
         }
+
+        @Test
+        void createWorkingTimeCalendarWithAbsences() {
+            final UserId userId_1 = new UserId("uuid-1");
+            final UserLocalId userLocalId_1 = new UserLocalId(1L);
+            final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+
+            final UserId userId_2 = new UserId("uuid-2");
+            final UserLocalId userLocalId_2 = new UserLocalId(2L);
+            final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+
+            final LocalDate from = LocalDate.of(2023, 2, 13);
+            final LocalDate toExclusive = LocalDate.of(2023, 2, 20);
+
+
+            Absence absenceUser1 = new Absence(userId_1, ZonedDateTime.of(from.atTime(0, 0), ZONE_ID_BERLIN), ZonedDateTime.of(from.atTime(23, 59), ZONE_ID_BERLIN), FULL, foo -> "", RED, HOLIDAY);
+            Absence absenceUser2 = new Absence(userId_2, ZonedDateTime.of(from.plusDays(1).atTime(0, 0), ZONE_ID_BERLIN), ZonedDateTime.of(from.plusDays(2).atTime(23, 59), ZONE_ID_BERLIN), MORNING, foo -> "", RED, HOLIDAY);
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(
+                    userIdComposite_1,
+                    List.of(absenceUser1),
+                    userIdComposite_2,
+                    List.of(absenceUser2)
+            ));
+            when(workingTimeService.getAllWorkingTimes(from, toExclusive)).thenReturn(Map.of(
+                    userIdComposite_1, List.of(
+                            WorkingTime.builder(userIdComposite_1, new WorkingTimeId(UUID.randomUUID()))
+                                    .federalState(NONE)
+                                    .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
+                                    .monday(1)
+                                    .tuesday(2)
+                                    .wednesday(3)
+                                    .thursday(4)
+                                    .friday(5)
+                                    .saturday(6)
+                                    .sunday(7)
+                                    .build()
+                    ),
+                    userIdComposite_2, List.of(
+                            WorkingTime.builder(userIdComposite_2, new WorkingTimeId(UUID.randomUUID()))
+                                    .federalState(NONE)
+                                    .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
+                                    .monday(7)
+                                    .tuesday(6)
+                                    .wednesday(5)
+                                    .thursday(4)
+                                    .friday(3)
+                                    .saturday(2)
+                                    .sunday(1)
+                                    .build()
+                    )
+            ));
+
+            final Map<UserIdComposite, WorkingTimeCalendar> actual = sut.getWorkingTimeCalendarForAllUsers(from, toExclusive);
+
+            assertThat(actual)
+                    .hasSize(2)
+                    .containsEntry(userIdComposite_1, new WorkingTimeCalendar(Map.of(
+                            LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(1)),
+                            LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(2)),
+                            LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(3)),
+                            LocalDate.of(2023, 2, 16), new PlannedWorkingHours(Duration.ofHours(4)),
+                            LocalDate.of(2023, 2, 17), new PlannedWorkingHours(Duration.ofHours(5)),
+                            LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(6)),
+                            LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(7))
+                    ), Map.of(
+                            LocalDate.of(2023, 2, 13), List.of(absenceUser1)
+                    )))
+                    .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
+                            LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(7)),
+                            LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(6)),
+                            LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(5)),
+                            LocalDate.of(2023, 2, 16), new PlannedWorkingHours(Duration.ofHours(4)),
+                            LocalDate.of(2023, 2, 17), new PlannedWorkingHours(Duration.ofHours(3)),
+                            LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(2)),
+                            LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(1))
+                    ), Map.of(
+                            LocalDate.of(2023, 2, 14), List.of(absenceUser2),
+                            LocalDate.of(2023, 2, 15), List.of(absenceUser2)
+                    )));
+        }
     }
 
     @Nested
@@ -240,6 +336,7 @@ class WorkingTimeCalendarServiceImplTest {
             final LocalDate from = LocalDate.of(2023, 2, 13);
             final LocalDate toExclusive = from.plusWeeks(1);
 
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdComposite_1, List.of(), userIdComposite_2, List.of()));
             when(workingTimeService.getWorkingTimesByUsers(from, toExclusive, List.of(userLocalId_1, userLocalId_2)))
                 .thenReturn(Map.of(
                     userIdComposite_1, List.of(
@@ -282,7 +379,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 17), new PlannedWorkingHours(Duration.ofHours(5)),
                     LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(6)),
                     LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(7))
-                )))
+                ), Map.of()))
                 .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(7)),
                     LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(6)),
@@ -291,7 +388,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 17), new PlannedWorkingHours(Duration.ofHours(3)),
                     LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(2)),
                     LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(1))
-                )));
+                ), Map.of()));
         }
 
         @Test
@@ -308,6 +405,7 @@ class WorkingTimeCalendarServiceImplTest {
             final LocalDate from = LocalDate.of(2023, 2, 13);
             final LocalDate toExclusive = from.plusWeeks(1);
 
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdComposite_1, List.of(), userIdComposite_2, List.of()));
             when(workingTimeService.getWorkingTimesByUsers(from, toExclusive, List.of(userLocalId_1, userLocalId_2)))
                 .thenReturn(Map.of(
                     userIdComposite_1, List.of(
@@ -349,7 +447,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 17), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 18), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 19), PlannedWorkingHours.ZERO
-                )))
+                ), Map.of()))
                 .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), PlannedWorkingHours.EIGHT,
                     LocalDate.of(2023, 2, 14), PlannedWorkingHours.ZERO,
@@ -358,7 +456,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 17), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 18), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 19), PlannedWorkingHours.ZERO
-                )));
+                ), Map.of()));
         }
 
         @Test
@@ -373,6 +471,7 @@ class WorkingTimeCalendarServiceImplTest {
             final LocalDate friday = LocalDate.of(2023, 12, 8);
             final LocalDate mondayNextWeek = monday.plusWeeks(1);
 
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdComposite, List.of()));
             when(workingTimeService.getWorkingTimesByUsers(monday, mondayNextWeek, List.of(userLocalId)))
                 .thenReturn(Map.of(
                     userIdComposite, List.of(

--- a/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarTest.java
@@ -16,7 +16,7 @@ class WorkingTimeCalendarTest {
 
     @Test
     void ensurePlannedWorkingHoursBetweenDatesIsZeroForEmptyCalendar() {
-        final WorkingTimeCalendar sut = new WorkingTimeCalendar(Map.of());
+        final WorkingTimeCalendar sut = new WorkingTimeCalendar(Map.of(), Map.of());
         final PlannedWorkingHours actual = sut.plannedWorkingHours(LocalDate.now(), LocalDate.now().plusDays(1));
         assertThat(actual).isEqualTo(PlannedWorkingHours.ZERO);
     }
@@ -34,7 +34,7 @@ class WorkingTimeCalendarTest {
     void ensurePlannedWorkingHoursBetweenDatesIsZeroWhenGivenDatesAreOutOfRange(LocalDate pivot, LocalDate from, LocalDate toExclusive) {
         final WorkingTimeCalendar sut = new WorkingTimeCalendar(Map.of(
             pivot, PlannedWorkingHours.EIGHT
-        ));
+        ), Map.of());
         final PlannedWorkingHours actual = sut.plannedWorkingHours(from, toExclusive);
         assertThat(actual).isEqualTo(PlannedWorkingHours.ZERO);
     }
@@ -49,7 +49,7 @@ class WorkingTimeCalendarTest {
             now.plusDays(1), PlannedWorkingHours.EIGHT,
             now.plusDays(2), PlannedWorkingHours.EIGHT,
             now.plusDays(3), PlannedWorkingHours.EIGHT
-        ));
+        ), Map.of());
 
         final PlannedWorkingHours actual = sut.plannedWorkingHours(now, now.plusDays(2));
         assertThat(actual).isEqualTo(new PlannedWorkingHours(Duration.ofHours(16)));


### PR DESCRIPTION
fixes #930

* `Planned` -> contract e.g. `40h week`
* `Should` -> contract - absences|public-holidays e.g. `40h - 8h (public-holiday) = 32h`

`ReportDay` is calculating Should on demand, since it contains information about `Planned` and `Absences`. Calculation is not required to be done in services.

Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
