### PR TITLE
First version of daylightsaving time issue

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/absence/Absence.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/Absence.java
@@ -2,7 +2,7 @@ package de.focusshift.zeiterfassung.absence;
 
 import de.focusshift.zeiterfassung.user.UserId;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Function;
@@ -20,8 +20,8 @@ import java.util.function.Function;
  */
 public record Absence(
     UserId userId,
-    ZonedDateTime startDate,
-    ZonedDateTime endDate,
+    Instant startDate,
+    Instant endDate,
     DayLength dayLength,
     Function<Locale, String> label,
     AbsenceColor color,

--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImpl.java
@@ -10,9 +10,8 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -21,6 +20,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiPredicate;
 
+import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
 @Component
@@ -77,10 +78,10 @@ class WorkingTimeCalendarServiceImpl implements WorkingTimeCalendarService {
 
             final Map<LocalDate, List<Absence>> absencesByDate = new HashMap<>();
             for (Absence absence : absencesByUser.get(userIdComposite)) {
-                ZonedDateTime date = absence.startDate().withZoneSameInstant(ZoneId.of("UTC"));
-                while (!date.isAfter(absence.endDate().withZoneSameInstant(ZoneId.of("UTC")))) {
-                    absencesByDate.computeIfAbsent(date.toLocalDate(), unused -> new ArrayList<>()).add(absence);
-                    date = date.plusDays(1);
+                Instant date = absence.startDate();
+                while (!date.isAfter(absence.endDate())) {
+                    absencesByDate.computeIfAbsent(LocalDate.ofInstant(date, UTC), unused -> new ArrayList<>()).add(absence);
+                    date = date.plus(1, DAYS);
                 }
             }
 

--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImpl.java
@@ -11,6 +11,7 @@ import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -76,8 +77,8 @@ class WorkingTimeCalendarServiceImpl implements WorkingTimeCalendarService {
 
             final Map<LocalDate, List<Absence>> absencesByDate = new HashMap<>();
             for (Absence absence : absencesByUser.get(userIdComposite)) {
-                ZonedDateTime date = absence.startDate();
-                while (!date.isAfter(absence.endDate())) {
+                ZonedDateTime date = absence.startDate().withZoneSameInstant(ZoneId.of("UTC"));
+                while (!date.isAfter(absence.endDate().withZoneSameInstant(ZoneId.of("UTC")))) {
                     absencesByDate.computeIfAbsent(date.toLocalDate(), unused -> new ArrayList<>()).add(absence);
                     date = date.plusDays(1);
                 }

--- a/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceIT.java
@@ -25,7 +25,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -130,7 +129,7 @@ class AbsenceIT extends SingleTenantTestContainersBase {
 
         final UserId userId = new UserId("boss");
         final Function<Locale, String> anyLabel = locale -> "";
-        final Absence expectedAbsence = new Absence(userId, ZonedDateTime.ofInstant(startOfDay, UTC), ZonedDateTime.ofInstant(startOfDay, ZONE_ID), DayLength.FULL, anyLabel, erholungsUrlaubColor, erholungsurlaubCategory);
+        final Absence expectedAbsence = new Absence(userId, startOfDay, startOfDay, DayLength.FULL, anyLabel, erholungsUrlaubColor, erholungsurlaubCategory);
 
         await().untilAsserted(() -> {
             final Map<LocalDate, List<Absence>> absences = absenceService.findAllAbsences(userId, startOfDay, startOfNextDay);

--- a/src/test/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmqIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmqIT.java
@@ -30,7 +30,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -120,8 +120,7 @@ class SickNoteEventHandlerRabbitmqIT extends SingleTenantTestContainersBase {
         final Function<Locale, String> anyLabel = locale -> "";
 
         await().untilAsserted(() -> {
-            final ZonedDateTime start = ZonedDateTime.ofInstant(startOfDay, ZONE_ID);
-            final Absence expected = new Absence(userId, start, start, FULL, anyLabel, RED, SICK);
+            final Absence expected = new Absence(userId, startOfDay, startOfDay, FULL, anyLabel, RED, SICK);
             final Map<LocalDate, List<Absence>> absences = absenceService.findAllAbsences(userId, startOfDay, startOfNextDay);
             assertThat(absences)
                 .hasSize(1)
@@ -147,8 +146,7 @@ class SickNoteEventHandlerRabbitmqIT extends SingleTenantTestContainersBase {
             .build());
 
         await().untilAsserted(() -> {
-            final ZonedDateTime start = ZonedDateTime.ofInstant(startOfDay, ZONE_ID);
-            final Absence expected = new Absence(userId, start, start.plusDays(1), FULL, anyLabel, RED, SICK);
+            final Absence expected = new Absence(userId, startOfDay, startOfDay.plus(1, ChronoUnit.DAYS), FULL, anyLabel, RED, SICK);
             final Map<LocalDate, List<Absence>> absences = absenceService.findAllAbsences(userId, startOfDay, startOfNextDay);
             assertThat(absences)
                 .hasSize(2)

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -133,7 +134,7 @@ class ReportDayTest {
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        final Absence absence = new Absence(batmanId, from, to, FULL, locale -> "foo", RED, HOLIDAY);
+        final Absence absence = new Absence(batmanId, from.toInstant(), to.toInstant(), FULL, locale -> "foo", RED, HOLIDAY);
 
         final LocalDate reportDate = LocalDate.of(2021, 1, 4);
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of(reportDate, List.of(absence)));
@@ -151,8 +152,8 @@ class ReportDayTest {
         final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
         final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
 
-        final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
-        final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
+        final Instant from = dateTime(2021, 1, 4, 1, 0).toInstant();
+        final Instant to = dateTime(2021, 1, 4, 2, 0).toInstant();
         final Absence absence = new Absence(batmanId, from, to, dayLength, locale -> "foo", RED, HOLIDAY);
 
         final LocalDate reportDate = LocalDate.of(2021, 1, 4);
@@ -172,7 +173,7 @@ class ReportDayTest {
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        final Absence absence = new Absence(batmanId, from, to, FULL, locale -> "foo", RED, HOLIDAY);
+        final Absence absence = new Absence(batmanId, from.toInstant(), to.toInstant(), FULL, locale -> "foo", RED, HOLIDAY);
 
         final UserId robinId = new UserId("uuid2");
         final UserLocalId robinLocalId = new UserLocalId(1337L);
@@ -206,7 +207,7 @@ class ReportDayTest {
 
         final ZonedDateTime from = dateTime(2021, 1, 4, 1, 0);
         final ZonedDateTime to = dateTime(2021, 1, 4, 2, 0);
-        final Absence absence = new Absence(batmanId, from, to, dayLength, locale -> "foo", RED, HOLIDAY);
+        final Absence absence = new Absence(batmanId, from.toInstant(), to.toInstant(), dayLength, locale -> "foo", RED, HOLIDAY);
 
         final UserId robinId = new UserId("uuid2");
         final UserLocalId robinLocalId = new UserLocalId(1337L);

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
@@ -166,8 +166,8 @@ class ReportWeekControllerTest {
         final LocalDate absenceDate = LocalDate.of(2023, 2, 3);
         Absence absence = new Absence(
                 user.userId(),
-                absenceDate.atStartOfDay(UTC),
-                absenceDate.atStartOfDay(UTC),
+                absenceDate.atStartOfDay(UTC).toInstant(),
+                absenceDate.atStartOfDay(UTC).toInstant(),
                 DayLength.FULL,
                 locale -> "absence-full-de",
                 ORANGE,

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -75,8 +76,8 @@ class TimeEntryControllerTest {
         final ZonedDateTime expectedStart = ZonedDateTime.of(2022, 9, 22, 14, 30, 0, 0, zoneIdBerlin);
         final ZonedDateTime expectedEnd = ZonedDateTime.of(2022, 9, 22, 15, 0, 0, 0, zoneIdBerlin);
         final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hack the planet", expectedStart, expectedEnd, false);
-        final ZonedDateTime absenceStart = ZonedDateTime.of(2022, 9, 22, 14, 30, 0, 0, zoneIdBerlin);
-        final ZonedDateTime absenceEnd = ZonedDateTime.of(2022, 9, 22, 15, 0, 0, 0, zoneIdBerlin);
+        final Instant absenceStart = ZonedDateTime.of(2022, 9, 22, 14, 30, 0, 0, zoneIdBerlin).toInstant();
+        final Instant absenceEnd = ZonedDateTime.of(2022, 9, 22, 15, 0, 0, 0, zoneIdBerlin).toInstant();
         final Absence absence = new Absence(new UserId("batman"), absenceStart, absenceEnd, DayLength.FULL, locale -> "", YELLOW, HOLIDAY);
 
         final TimeEntryDay timeEntryDay = new TimeEntryDay(LocalDate.of(2022, 9, 19), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());

--- a/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImplTest.java
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -31,14 +30,13 @@ import static de.focusshift.zeiterfassung.absence.DayLength.MORNING;
 import static de.focusshift.zeiterfassung.publicholiday.FederalState.GERMANY_BADEN_WUERTTEMBERG;
 import static de.focusshift.zeiterfassung.publicholiday.FederalState.GERMANY_BAYERN;
 import static de.focusshift.zeiterfassung.publicholiday.FederalState.NONE;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class WorkingTimeCalendarServiceImplTest {
-
-    private static final ZoneId ZONE_ID_BERLIN = ZoneId.of("Europe/Berlin");
 
     private WorkingTimeCalendarServiceImpl sut;
 
@@ -59,21 +57,21 @@ class WorkingTimeCalendarServiceImplTest {
         @Test
         void ensureGetWorkingTimesForAll() {
 
-            final UserId userId_1 = new UserId("uuid-1");
-            final UserLocalId userLocalId_1 = new UserLocalId(1L);
-            final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+            final UserId userIdOne = new UserId("uuid-1");
+            final UserLocalId userLocalIdOne = new UserLocalId(1L);
+            final UserIdComposite userIdCompositeOne = new UserIdComposite(userIdOne, userLocalIdOne);
 
-            final UserId userId_2 = new UserId("uuid-2");
-            final UserLocalId userLocalId_2 = new UserLocalId(2L);
-            final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+            final UserId userIdTwo = new UserId("uuid-2");
+            final UserLocalId userLocalIdTwo = new UserLocalId(2L);
+            final UserIdComposite userIdCompositeTwo = new UserIdComposite(userIdTwo, userLocalIdTwo);
 
             final LocalDate from = LocalDate.of(2023, 2, 13);
             final LocalDate toExclusive = LocalDate.of(2023, 2, 20);
 
-            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdComposite_1, List.of(), userIdComposite_2, List.of()));
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdCompositeOne, List.of(), userIdCompositeTwo, List.of()));
             when(workingTimeService.getAllWorkingTimes(from, toExclusive)).thenReturn(Map.of(
-                userIdComposite_1, List.of(
-                    WorkingTime.builder(userIdComposite_1, new WorkingTimeId(UUID.randomUUID()))
+                userIdCompositeOne, List.of(
+                    WorkingTime.builder(userIdCompositeOne, new WorkingTimeId(UUID.randomUUID()))
                         .federalState(NONE)
                         .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
                         .monday(1)
@@ -85,8 +83,8 @@ class WorkingTimeCalendarServiceImplTest {
                         .sunday(7)
                         .build()
                 ),
-                userIdComposite_2, List.of(
-                    WorkingTime.builder(userIdComposite_2, new WorkingTimeId(UUID.randomUUID()))
+                userIdCompositeTwo, List.of(
+                    WorkingTime.builder(userIdCompositeTwo, new WorkingTimeId(UUID.randomUUID()))
                         .federalState(NONE)
                         .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
                         .monday(7)
@@ -104,7 +102,7 @@ class WorkingTimeCalendarServiceImplTest {
 
             assertThat(actual)
                 .hasSize(2)
-                .containsEntry(userIdComposite_1, new WorkingTimeCalendar(Map.of(
+                .containsEntry(userIdCompositeOne, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(1)),
                     LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(2)),
                     LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(3)),
@@ -113,7 +111,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(6)),
                     LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(7))
                 ), Map.of()))
-                .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
+                .containsEntry(userIdCompositeTwo, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(7)),
                     LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(6)),
                     LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(5)),
@@ -127,29 +125,29 @@ class WorkingTimeCalendarServiceImplTest {
         @Test
         void ensureGetWorkingTimesForAllConsidersPublicHolidays() {
 
-            final UserId userId_1 = new UserId("uuid-1");
-            final UserLocalId userLocalId_1 = new UserLocalId(1L);
-            final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+            final UserId userIdOne = new UserId("uuid-1");
+            final UserLocalId userLocalIdOne = new UserLocalId(1L);
+            final UserIdComposite userIdCompositeOne = new UserIdComposite(userIdOne, userLocalIdOne);
 
-            final UserId userId_2 = new UserId("uuid-2");
-            final UserLocalId userLocalId_2 = new UserLocalId(2L);
-            final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+            final UserId userIdTwo = new UserId("uuid-2");
+            final UserLocalId userLocalIdTwo = new UserLocalId(2L);
+            final UserIdComposite userIdCompositeTwo = new UserIdComposite(userIdTwo, userLocalIdTwo);
 
             final LocalDate from = LocalDate.of(2023, 2, 13);
             final LocalDate toExclusive = LocalDate.of(2023, 2, 20);
 
-            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdComposite_1, List.of(), userIdComposite_2, List.of()));
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdCompositeOne, List.of(), userIdCompositeTwo, List.of()));
             when(workingTimeService.getAllWorkingTimes(from, toExclusive)).thenReturn(Map.of(
-                userIdComposite_1, List.of(
-                    WorkingTime.builder(userIdComposite_1, new WorkingTimeId(UUID.randomUUID()))
+                userIdCompositeOne, List.of(
+                    WorkingTime.builder(userIdCompositeOne, new WorkingTimeId(UUID.randomUUID()))
                         .federalState(GERMANY_BADEN_WUERTTEMBERG)
                         .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
                         .monday(8)
                         .tuesday(8)
                         .build()
                 ),
-                userIdComposite_2, List.of(
-                    WorkingTime.builder(userIdComposite_2, new WorkingTimeId(UUID.randomUUID()))
+                userIdCompositeTwo, List.of(
+                    WorkingTime.builder(userIdCompositeTwo, new WorkingTimeId(UUID.randomUUID()))
                         .federalState(GERMANY_BAYERN)
                         .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
                         .monday(8)
@@ -171,7 +169,7 @@ class WorkingTimeCalendarServiceImplTest {
 
             assertThat(actual)
                 .hasSize(2)
-                .containsEntry(userIdComposite_1, new WorkingTimeCalendar(Map.of(
+                .containsEntry(userIdCompositeOne, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 14), PlannedWorkingHours.EIGHT,
                     LocalDate.of(2023, 2, 15), PlannedWorkingHours.ZERO,
@@ -180,7 +178,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 18), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 19), PlannedWorkingHours.ZERO
                 ), Map.of()))
-                .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
+                .containsEntry(userIdCompositeTwo, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), PlannedWorkingHours.EIGHT,
                     LocalDate.of(2023, 2, 14), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 15), PlannedWorkingHours.ZERO,
@@ -241,29 +239,29 @@ class WorkingTimeCalendarServiceImplTest {
 
         @Test
         void createWorkingTimeCalendarWithAbsences() {
-            final UserId userId_1 = new UserId("uuid-1");
-            final UserLocalId userLocalId_1 = new UserLocalId(1L);
-            final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+            final UserId userIdOne = new UserId("uuid-1");
+            final UserLocalId userLocalIdOne = new UserLocalId(1L);
+            final UserIdComposite userIdCompositeOne = new UserIdComposite(userIdOne, userLocalIdOne);
 
-            final UserId userId_2 = new UserId("uuid-2");
-            final UserLocalId userLocalId_2 = new UserLocalId(2L);
-            final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+            final UserId userIdTwo = new UserId("uuid-2");
+            final UserLocalId userLocalIdTwo = new UserLocalId(2L);
+            final UserIdComposite userIdCompositeTwo = new UserIdComposite(userIdTwo, userLocalIdTwo);
 
             final LocalDate from = LocalDate.of(2023, 2, 13);
             final LocalDate toExclusive = LocalDate.of(2023, 2, 20);
 
 
-            Absence absenceUser1 = new Absence(userId_1, ZonedDateTime.of(from.atTime(0, 0), ZONE_ID_BERLIN), ZonedDateTime.of(from.atTime(23, 59), ZONE_ID_BERLIN), FULL, foo -> "", RED, HOLIDAY);
-            Absence absenceUser2 = new Absence(userId_2, ZonedDateTime.of(from.plusDays(1).atTime(0, 0), ZONE_ID_BERLIN), ZonedDateTime.of(from.plusDays(2).atTime(23, 59), ZONE_ID_BERLIN), MORNING, foo -> "", RED, HOLIDAY);
+            Absence absenceUser1 = new Absence(userIdOne, ZonedDateTime.of(from.atTime(0, 0), UTC).toInstant(), ZonedDateTime.of(from.atTime(23, 59), UTC).toInstant(), FULL, foo -> "", RED, HOLIDAY);
+            Absence absenceUser2 = new Absence(userIdTwo, ZonedDateTime.of(from.plusDays(1).atTime(0, 0), UTC).toInstant(), ZonedDateTime.of(from.plusDays(2).atTime(23, 59), UTC).toInstant(), MORNING, foo -> "", RED, HOLIDAY);
             when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(
-                    userIdComposite_1,
+                    userIdCompositeOne,
                     List.of(absenceUser1),
-                    userIdComposite_2,
+                    userIdCompositeTwo,
                     List.of(absenceUser2)
             ));
             when(workingTimeService.getAllWorkingTimes(from, toExclusive)).thenReturn(Map.of(
-                    userIdComposite_1, List.of(
-                            WorkingTime.builder(userIdComposite_1, new WorkingTimeId(UUID.randomUUID()))
+                    userIdCompositeOne, List.of(
+                            WorkingTime.builder(userIdCompositeOne, new WorkingTimeId(UUID.randomUUID()))
                                     .federalState(NONE)
                                     .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
                                     .monday(1)
@@ -275,8 +273,8 @@ class WorkingTimeCalendarServiceImplTest {
                                     .sunday(7)
                                     .build()
                     ),
-                    userIdComposite_2, List.of(
-                            WorkingTime.builder(userIdComposite_2, new WorkingTimeId(UUID.randomUUID()))
+                    userIdCompositeTwo, List.of(
+                            WorkingTime.builder(userIdCompositeTwo, new WorkingTimeId(UUID.randomUUID()))
                                     .federalState(NONE)
                                     .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
                                     .monday(7)
@@ -294,7 +292,7 @@ class WorkingTimeCalendarServiceImplTest {
 
             assertThat(actual)
                     .hasSize(2)
-                    .containsEntry(userIdComposite_1, new WorkingTimeCalendar(Map.of(
+                    .containsEntry(userIdCompositeOne, new WorkingTimeCalendar(Map.of(
                             LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(1)),
                             LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(2)),
                             LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(3)),
@@ -305,7 +303,7 @@ class WorkingTimeCalendarServiceImplTest {
                     ), Map.of(
                             LocalDate.of(2023, 2, 13), List.of(absenceUser1)
                     )))
-                    .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
+                    .containsEntry(userIdCompositeTwo, new WorkingTimeCalendar(Map.of(
                             LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(7)),
                             LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(6)),
                             LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(5)),
@@ -325,22 +323,22 @@ class WorkingTimeCalendarServiceImplTest {
         @Test
         void ensureGetWorkingTimesForUsers() {
 
-            final UserId userId_1 = new UserId("uuid-1");
-            final UserLocalId userLocalId_1 = new UserLocalId(1L);
-            final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+            final UserId userIdOne = new UserId("uuid-1");
+            final UserLocalId userLocalIdOne = new UserLocalId(1L);
+            final UserIdComposite userIdCompositeOne = new UserIdComposite(userIdOne, userLocalIdOne);
 
-            final UserId userId_2 = new UserId("uuid-2");
-            final UserLocalId userLocalId_2 = new UserLocalId(2L);
-            final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+            final UserId userIdTwo = new UserId("uuid-2");
+            final UserLocalId userLocalIdTwo = new UserLocalId(2L);
+            final UserIdComposite userIdCompositeTwo = new UserIdComposite(userIdTwo, userLocalIdTwo);
 
             final LocalDate from = LocalDate.of(2023, 2, 13);
             final LocalDate toExclusive = from.plusWeeks(1);
 
-            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdComposite_1, List.of(), userIdComposite_2, List.of()));
-            when(workingTimeService.getWorkingTimesByUsers(from, toExclusive, List.of(userLocalId_1, userLocalId_2)))
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdCompositeOne, List.of(), userIdCompositeTwo, List.of()));
+            when(workingTimeService.getWorkingTimesByUsers(from, toExclusive, List.of(userLocalIdOne, userLocalIdTwo)))
                 .thenReturn(Map.of(
-                    userIdComposite_1, List.of(
-                        WorkingTime.builder(userIdComposite_1, new WorkingTimeId(UUID.randomUUID()))
+                    userIdCompositeOne, List.of(
+                        WorkingTime.builder(userIdCompositeOne, new WorkingTimeId(UUID.randomUUID()))
                             .federalState(NONE)
                             .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
                             .monday(1)
@@ -352,8 +350,8 @@ class WorkingTimeCalendarServiceImplTest {
                             .sunday(7)
                             .build()
                     ),
-                    userIdComposite_2, List.of(
-                        WorkingTime.builder(userIdComposite_2, new WorkingTimeId(UUID.randomUUID()))
+                    userIdCompositeTwo, List.of(
+                        WorkingTime.builder(userIdCompositeTwo, new WorkingTimeId(UUID.randomUUID()))
                             .federalState(NONE)
                             .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
                             .monday(7)
@@ -367,11 +365,11 @@ class WorkingTimeCalendarServiceImplTest {
                     )
                 ));
 
-            final Map<UserIdComposite, WorkingTimeCalendar> actual = sut.getWorkingTimeCalendarForUsers(from, toExclusive, List.of(userLocalId_1, userLocalId_2));
+            final Map<UserIdComposite, WorkingTimeCalendar> actual = sut.getWorkingTimeCalendarForUsers(from, toExclusive, List.of(userLocalIdOne, userLocalIdTwo));
 
             assertThat(actual)
                 .hasSize(2)
-                .containsEntry(userIdComposite_1, new WorkingTimeCalendar(Map.of(
+                .containsEntry(userIdCompositeOne, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(1)),
                     LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(2)),
                     LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(3)),
@@ -380,7 +378,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(6)),
                     LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(7))
                 ), Map.of()))
-                .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
+                .containsEntry(userIdCompositeTwo, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), new PlannedWorkingHours(Duration.ofHours(7)),
                     LocalDate.of(2023, 2, 14), new PlannedWorkingHours(Duration.ofHours(6)),
                     LocalDate.of(2023, 2, 15), new PlannedWorkingHours(Duration.ofHours(5)),
@@ -394,30 +392,30 @@ class WorkingTimeCalendarServiceImplTest {
         @Test
         void ensureGetWorkingTimesForUsersConsidersPublicHolidays() {
 
-            final UserId userId_1 = new UserId("uuid-1");
-            final UserLocalId userLocalId_1 = new UserLocalId(1L);
-            final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+            final UserId userIdOne = new UserId("uuid-1");
+            final UserLocalId userLocalIdOne = new UserLocalId(1L);
+            final UserIdComposite userIdCompositeOne = new UserIdComposite(userIdOne, userLocalIdOne);
 
-            final UserId userId_2 = new UserId("uuid-2");
-            final UserLocalId userLocalId_2 = new UserLocalId(2L);
-            final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+            final UserId userIdTwo = new UserId("uuid-2");
+            final UserLocalId userLocalIdTwo = new UserLocalId(2L);
+            final UserIdComposite userIdCompositeTwo = new UserIdComposite(userIdTwo, userLocalIdTwo);
 
             final LocalDate from = LocalDate.of(2023, 2, 13);
             final LocalDate toExclusive = from.plusWeeks(1);
 
-            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdComposite_1, List.of(), userIdComposite_2, List.of()));
-            when(workingTimeService.getWorkingTimesByUsers(from, toExclusive, List.of(userLocalId_1, userLocalId_2)))
+            when(absenceService.getAbsencesByUserIds(any(), any(), any())).thenReturn(Map.of(userIdCompositeOne, List.of(), userIdCompositeTwo, List.of()));
+            when(workingTimeService.getWorkingTimesByUsers(from, toExclusive, List.of(userLocalIdOne, userLocalIdTwo)))
                 .thenReturn(Map.of(
-                    userIdComposite_1, List.of(
-                        WorkingTime.builder(userIdComposite_1, new WorkingTimeId(UUID.randomUUID()))
+                    userIdCompositeOne, List.of(
+                        WorkingTime.builder(userIdCompositeOne, new WorkingTimeId(UUID.randomUUID()))
                             .federalState(GERMANY_BADEN_WUERTTEMBERG)
                             .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
                             .monday(8)
                             .tuesday(8)
                             .build()
                     ),
-                    userIdComposite_2, List.of(
-                        WorkingTime.builder(userIdComposite_2, new WorkingTimeId(UUID.randomUUID()))
+                    userIdCompositeTwo, List.of(
+                        WorkingTime.builder(userIdCompositeTwo, new WorkingTimeId(UUID.randomUUID()))
                             .federalState(GERMANY_BAYERN)
                             .worksOnPublicHoliday(WorksOnPublicHoliday.NO)
                             .monday(8)
@@ -435,11 +433,11 @@ class WorkingTimeCalendarServiceImplTest {
             when(publicHolidaysService.getPublicHolidays(from, toExclusive, Set.of(GERMANY_BADEN_WUERTTEMBERG, GERMANY_BAYERN)))
                 .thenReturn(Map.of(GERMANY_BADEN_WUERTTEMBERG, publicHolidayCalendar_bw, GERMANY_BAYERN, publicHolidayCalendar_ba));
 
-            final Map<UserIdComposite, WorkingTimeCalendar> actual = sut.getWorkingTimeCalendarForUsers(from, toExclusive, List.of(userLocalId_1, userLocalId_2));
+            final Map<UserIdComposite, WorkingTimeCalendar> actual = sut.getWorkingTimeCalendarForUsers(from, toExclusive, List.of(userLocalIdOne, userLocalIdTwo));
 
             assertThat(actual)
                 .hasSize(2)
-                .containsEntry(userIdComposite_1, new WorkingTimeCalendar(Map.of(
+                .containsEntry(userIdCompositeOne, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 14), PlannedWorkingHours.EIGHT,
                     LocalDate.of(2023, 2, 15), PlannedWorkingHours.ZERO,
@@ -448,7 +446,7 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 18), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 19), PlannedWorkingHours.ZERO
                 ), Map.of()))
-                .containsEntry(userIdComposite_2, new WorkingTimeCalendar(Map.of(
+                .containsEntry(userIdCompositeTwo, new WorkingTimeCalendar(Map.of(
                     LocalDate.of(2023, 2, 13), PlannedWorkingHours.EIGHT,
                     LocalDate.of(2023, 2, 14), PlannedWorkingHours.ZERO,
                     LocalDate.of(2023, 2, 15), PlannedWorkingHours.ZERO,


### PR DESCRIPTION
An absence which starts in dst (day light saving time) and end in (normal time) the preparation of day to absence map does not recognize that a day exits with 23h.

We should further investigate to move timezone-dependend parts from domain layer to view / dto layer and stay with instants in domain

fixes #1001


Here are some things you should have thought about:

**Multi-Tenancy**
- [x] ~~Extended new entities with `AbstractTenantAwareEntity`?~~
- [x] ~~New entity added to `TenantAwareDatabaseConfiguration`?~~
- [x] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
