### PR TITLE
Sort time entries descending by start

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryRepository.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryRepository.java
@@ -12,9 +12,9 @@ interface TimeEntryRepository extends CrudRepository<TimeEntryEntity, Long>, Rev
 
     long countAllByOwner(String owner);
 
-    List<TimeEntryEntity> findAllByStartGreaterThanEqualAndStartLessThan(Instant start, Instant endExclusive);
+    List<TimeEntryEntity> findAllByStartGreaterThanEqualAndStartLessThanOrderByStartDesc(Instant start, Instant endExclusive);
 
-    List<TimeEntryEntity> findAllByOwnerAndStartGreaterThanEqualAndStartLessThan(String owner, Instant start, Instant endExclusive);
+    List<TimeEntryEntity> findAllByOwnerAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(String owner, Instant start, Instant endExclusive);
 
-    List<TimeEntryEntity> findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThan(List<String> owners, Instant start, Instant endExclusive);
+    List<TimeEntryEntity> findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(List<String> owners, Instant start, Instant endExclusive);
 }

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
@@ -129,11 +129,8 @@ class TimeEntryServiceImpl implements TimeEntryService {
         final Instant fromInstant = toInstant(from);
         final Instant toInstant = toInstant(toExclusive);
 
-        final List<TimeEntryEntity> result = timeEntryRepository
-            .findAllByOwnerAndStartGreaterThanEqualAndStartLessThan(userId.value(), fromInstant, toInstant);
-
-        return result
-            .stream()
+        return timeEntryRepository
+            .findAllByOwnerAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(userId.value(), fromInstant, toInstant).stream()
             .map(timeEntryEntity -> toTimeEntry(timeEntryEntity, user))
             .sorted(comparing(TimeEntry::start).reversed())
             .toList();
@@ -149,8 +146,7 @@ class TimeEntryServiceImpl implements TimeEntryService {
             .stream()
             .collect(toMap(User::userId, identity()));
 
-        return timeEntryRepository.findAllByStartGreaterThanEqualAndStartLessThan(fromInstant, toInstant)
-            .stream()
+        return timeEntryRepository.findAllByStartGreaterThanEqualAndStartLessThanOrderByStartDesc(fromInstant, toInstant).stream()
             .map(timeEntryEntity -> toTimeEntry(timeEntryEntity, userByUserId))
             .filter(Objects::nonNull)
             .collect(groupingBy(TimeEntry::userIdComposite));
@@ -172,8 +168,7 @@ class TimeEntryServiceImpl implements TimeEntryService {
         }
 
         final Map<UserIdComposite, List<TimeEntry>> result = timeEntryRepository
-            .findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThan(userIdValues, fromInstant, toInstant)
-            .stream()
+            .findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(userIdValues, fromInstant, toInstant).stream()
             .map(timeEntryEntity -> toTimeEntry(timeEntryEntity, userByUserId))
             .filter(Objects::nonNull)
             .collect(groupingBy(TimeEntry::userIdComposite));
@@ -196,9 +191,8 @@ class TimeEntryServiceImpl implements TimeEntryService {
         final Instant from = Instant.from(fromDateTime);
         final Instant toExclusive = Instant.from(toDateTimeExclusive);
 
-        final Map<LocalDate, List<TimeEntry>> timeEntriesByDate = timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThan(userId.value(), from, toExclusive)
+        final Map<LocalDate, List<TimeEntry>> timeEntriesByDate = timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(userId.value(), from, toExclusive)
             .stream()
-            .sorted(comparing(TimeEntryEntity::getStart).thenComparing(TimeEntryEntity::getUpdatedAt).reversed())
             .map(timeEntryEntity -> toTimeEntry(timeEntryEntity, user))
             .collect(groupingBy(entry -> LocalDate.ofInstant(entry.start().toInstant(), userZoneId)));
 
@@ -326,6 +320,7 @@ class TimeEntryServiceImpl implements TimeEntryService {
         entity.setStart(start.toInstant());
         entity.setStartZoneId(start.getZone().getId());
     }
+
     private static void setEnd(TimeEntryEntity entity, ZonedDateTime end) {
         entity.setEnd(end.toInstant());
         entity.setEndZoneId(end.getZone().getId());

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryRepositoryIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryRepositoryIT.java
@@ -68,7 +68,7 @@ class TimeEntryRepositoryIT extends SingleTenantTestContainersBase {
     }
 
     @Test
-    void countAllEnsureFindAllByOwnerAndStartGreaterThanEqualAndStartLessThan() {
+    void countAllEnsureFindAllByOwnerAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc() {
 
         final TenantUser batman = tenantUserService.createNewUser("1a432ba3-cb93-463b-813b-8e065c1e0a24", "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
         final TenantUser superman = tenantUserService.createNewUser("8b913da0-2711-4da8-9216-9904e11944ac", "Kent", "Clark", new EMailAddress("Clark@example.org"), Set.of());
@@ -98,13 +98,13 @@ class TimeEntryRepositoryIT extends SingleTenantTestContainersBase {
         final Instant periodFromStartOfDayInstant = periodFrom.atStartOfDay(ZoneOffset.UTC).toInstant();
         final Instant periodToStartOfDayInstant = periodToExclusive.atStartOfDay(ZoneOffset.UTC).toInstant();
 
-        final List<TimeEntryEntity> actualEntries = sut.findAllByOwnerAndStartGreaterThanEqualAndStartLessThan(batman.id(), periodFromStartOfDayInstant, periodToStartOfDayInstant);
+        final List<TimeEntryEntity> actualEntries = sut.findAllByOwnerAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(batman.id(), periodFromStartOfDayInstant, periodToStartOfDayInstant);
 
         assertThat(actualEntries).hasSize(2);
         assertThat(actualEntries.get(0).getOwner()).isEqualTo(batman.id());
-        assertThat(actualEntries.get(0).getComment()).isEqualTo("hard work period start");
+        assertThat(actualEntries.get(0).getComment()).isEqualTo("hard work in between");
         assertThat(actualEntries.get(1).getOwner()).isEqualTo(batman.id());
-        assertThat(actualEntries.get(1).getComment()).isEqualTo("hard work in between");
+        assertThat(actualEntries.get(1).getComment()).isEqualTo("hard work period start");
     }
 
     private static TimeEntryEntity createTimeEntryEntity(String owner, String comment, LocalDateTime start, LocalDateTime end) {

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
@@ -929,7 +929,7 @@ class TimeEntryServiceImplTest {
         final LocalDateTime entryBreakEnd = LocalDateTime.of(toExclusive, LocalTime.of(13, 0, 0));
         final TimeEntryEntity timeEntryBreakEntity = new TimeEntryEntity(2L, "pinguin", "deserved break", entryBreakStart.toInstant(UTC), ZONE_ID_UTC, entryBreakEnd.toInstant(UTC), ZONE_ID_UTC, now, true);
 
-        when(timeEntryRepository.findAllByStartGreaterThanEqualAndStartLessThan(from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
+        when(timeEntryRepository.findAllByStartGreaterThanEqualAndStartLessThanOrderByStartDesc(from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
             .thenReturn(List.of(timeEntryEntity, timeEntryBreakEntity));
 
         final UserId batmanId = new UserId("batman");
@@ -994,7 +994,7 @@ class TimeEntryServiceImplTest {
         final LocalDateTime entryBreakEnd = LocalDateTime.of(toExclusive, LocalTime.of(13, 0, 0));
         final TimeEntryEntity timeEntryBreakEntity = new TimeEntryEntity(2L, "uuid-2", "deserved break", entryBreakStart.toInstant(UTC), ZONE_ID_UTC, entryBreakEnd.toInstant(UTC), ZONE_ID_UTC, now, true);
 
-        when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThan(List.of("uuid-1", "uuid-2"), from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
+        when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(List.of("uuid-1", "uuid-2"), from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
             .thenReturn(List.of(timeEntryEntity, timeEntryBreakEntity));
 
         final Map<UserIdComposite, List<TimeEntry>> actual = sut.getEntriesByUserLocalIds(from, toExclusive, List.of(batmanLocalId, robinLocalId));
@@ -1031,7 +1031,7 @@ class TimeEntryServiceImplTest {
         final LocalDate from = LocalDate.of(2023, 1, 1);
         final LocalDate toExclusive = LocalDate.of(2023, 2, 1);
 
-        when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThan(List.of("batman"), from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
+        when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(List.of("batman"), from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
             .thenReturn(List.of());
 
         final Map<UserIdComposite, List<TimeEntry>> actual = sut.getEntriesByUserLocalIds(from, toExclusive, List.of(userLocalId));
@@ -1063,7 +1063,7 @@ class TimeEntryServiceImplTest {
 
         final Instant periodStartInstant = periodFrom.atStartOfDay(UTC).toInstant();
         final Instant periodEndInstant = periodToExclusive.atStartOfDay(UTC).toInstant();
-        when(timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThan("batman", periodStartInstant, periodEndInstant))
+        when(timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc("batman", periodStartInstant, periodEndInstant))
             .thenReturn(List.of(timeEntryEntity, timeEntryBreakEntity, timeEntryEntity2));
 
         final UserId userId = new UserId("batman");
@@ -1111,7 +1111,7 @@ class TimeEntryServiceImplTest {
         final Instant from = Instant.from(fromDateTime);
         final Instant to = Instant.from(fromDateTime.plusWeeks(1));
 
-        when(timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThan("batman", from, to))
+        when(timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc("batman", from, to))
             .thenReturn(List.of(timeEntryEntity, timeEntryBreakEntity));
 
         when(timeEntryRepository.countAllByOwner("batman")).thenReturn(3L);
@@ -1182,8 +1182,8 @@ class TimeEntryServiceImplTest {
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(
-                                new TimeEntry(new TimeEntryId(2L), userIdComposite, "deserved break", timeEntryBreakStart, timeEntryBreakEnd, true),
-                                new TimeEntry(new TimeEntryId(1L), userIdComposite, "hack the planet!", timeEntryStart, timeEntryEnd, false)
+                                new TimeEntry(new TimeEntryId(1L), userIdComposite, "hack the planet!", timeEntryStart, timeEntryEnd, false),
+                                new TimeEntry(new TimeEntryId(2L), userIdComposite, "deserved break", timeEntryBreakStart, timeEntryBreakEnd, true)
                             ),
                             List.of()
                         ),
@@ -1222,7 +1222,7 @@ class TimeEntryServiceImplTest {
         final Instant from = Instant.from(fromDateTime);
         final Instant to = Instant.from(fromDateTime.plusWeeks(1));
 
-        when(timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThan("batman", from, to))
+        when(timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc("batman", from, to))
             .thenReturn(List.of(lastDayOfWeekTimeEntry, firstDayOfWeekTimeEntry));
 
         when(timeEntryRepository.countAllByOwner("batman")).thenReturn(6L);
@@ -1325,7 +1325,7 @@ class TimeEntryServiceImplTest {
 
         final Instant from = Instant.from(firstDateOfWeek.atStartOfDay().atZone(userZoneId));
         final Instant to = Instant.from(toDateExclusive.atStartOfDay().atZone(userZoneId));
-        when(timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThan("batman", from, to))
+        when(timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc("batman", from, to))
             .thenReturn(List.of());
 
         when(timeEntryRepository.countAllByOwner("batman")).thenReturn(6L);


### PR DESCRIPTION
The sorting is now based in the start time ascending. What means that the earlier start time is at the beginning

![image](https://github.com/user-attachments/assets/574c52c1-4e73-467a-bcb6-b4bae2ca3d3f)



Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

closes #1026

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
