### PR TITLE
Fix highlighting of edited, not saved, entries

### DIFF
--- a/src/main/css/time-entries.css
+++ b/src/main/css/time-entries.css
@@ -203,7 +203,8 @@
   border-radius: 27px;
 }
 
-.timeslot-form-existing.edited button[type="submit"] {
+/* highlight save button for edited timeslot. not the delete button. */
+.timeslot-form-existing.edited button[type="submit"]:not([name]) {
   color: theme("colors.gray.700");
   background-color: theme("colors.blue.100");
   padding: 0.25rem 0.5rem;

--- a/src/main/javascript/components/time-entry-element/TimeEntryElement.ts
+++ b/src/main/javascript/components/time-entry-element/TimeEntryElement.ts
@@ -48,10 +48,10 @@ export class TimeEntryElement extends HTMLDivElement {
       if (originalFormData.get(name) === nextFormData.get(name)) {
         element.classList.remove("edited");
         if (!isFormChanged()) {
-          form.classList.remove("edited");
+          form.querySelector("div").classList.remove("edited");
         }
       } else {
-        form.classList.add("edited");
+        form.querySelector("div").classList.add("edited");
         element.classList.add("edited");
       }
     }

--- a/src/main/javascript/components/time-entry-element/TimeEntryElement.ts
+++ b/src/main/javascript/components/time-entry-element/TimeEntryElement.ts
@@ -39,6 +39,12 @@ export class TimeEntryElement extends HTMLDivElement {
       }
     });
 
+    form.addEventListener("reset", () => {
+      for (const element of form.querySelectorAll(".edited")) {
+        element.classList.remove("edited");
+      }
+    });
+
     function handleValueChanged(
       fieldName: string,
       newValue: string | boolean,

--- a/src/main/javascript/components/time-entry-element/TimeEntryElement.ts
+++ b/src/main/javascript/components/time-entry-element/TimeEntryElement.ts
@@ -45,13 +45,14 @@ export class TimeEntryElement extends HTMLDivElement {
       element: HTMLElement,
     ) {
       const nextFormData = new FormData(form);
+      const timeslot = form.querySelector(".timeslot-form-existing");
       if (originalFormData.get(name) === nextFormData.get(name)) {
         element.classList.remove("edited");
         if (!isFormChanged()) {
-          form.querySelector("div").classList.remove("edited");
+          timeslot.classList.remove("edited");
         }
       } else {
-        form.querySelector("div").classList.add("edited");
+        timeslot.classList.add("edited");
         element.classList.add("edited");
       }
     }

--- a/src/main/javascript/components/time-entry-element/TimeEntryElement.ts
+++ b/src/main/javascript/components/time-entry-element/TimeEntryElement.ts
@@ -40,20 +40,20 @@ export class TimeEntryElement extends HTMLDivElement {
     });
 
     function handleValueChanged(
-      name: string,
+      fieldName: string,
       newValue: string | boolean,
-      element: HTMLElement,
+      inputElement: HTMLElement,
     ) {
       const nextFormData = new FormData(form);
       const timeslot = form.querySelector(".timeslot-form-existing");
-      if (originalFormData.get(name) === nextFormData.get(name)) {
-        element.classList.remove("edited");
+      if (originalFormData.get(fieldName) === nextFormData.get(fieldName)) {
+        inputElement.classList.remove("edited");
         if (!isFormChanged()) {
           timeslot.classList.remove("edited");
         }
       } else {
         timeslot.classList.add("edited");
-        element.classList.add("edited");
+        inputElement.classList.add("edited");
       }
     }
 


### PR DESCRIPTION
Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

closes #1106 

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
