### PR TITLE
fix multitenant permission reload filter

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/security/AuthenticationFacade.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/AuthenticationFacade.java
@@ -34,8 +34,30 @@ public class AuthenticationFacade {
      * @return the {@link UserIdComposite} of the current user
      */
     public UserIdComposite getCurrentUserIdComposite() {
+        final Authentication authentication = getCurrentAuthentication();
+        return userIdCompositeFromAuth(authentication);
+    }
+
+    /**
+     * Checks whether the current {@link Authentication} has the given {@link SecurityRole} or not.
+     *
+     * @param securityRole {@link SecurityRole} to check
+     * @return <code>true</code> when the current authentication has the securityRole, <code>false</code> otherwise.
+     */
+    public boolean hasSecurityRole(SecurityRole securityRole) {
 
         final Authentication authentication = getCurrentAuthentication();
+        final boolean hasRole = authentication.getAuthorities().contains(securityRole.authority());
+
+        if (LOG.isDebugEnabled()) {
+            final UserIdComposite userIdComposite = userIdCompositeFromAuth(authentication);
+            LOG.debug("user={} has permission={}", userIdComposite.id(), hasRole);
+        }
+
+        return hasRole;
+    }
+
+    private static UserIdComposite userIdCompositeFromAuth(Authentication authentication) {
 
         if (authentication instanceof OAuth2AuthenticationToken token) {
             final OAuth2User oAuth2User = token.getPrincipal();
@@ -51,23 +73,5 @@ public class AuthenticationFacade {
         }
 
         throw new IllegalStateException("unexpected authentication token: " + authentication.getPrincipal());
-    }
-
-    /**
-     * Checks whether the current {@link Authentication} has the given {@link SecurityRole} or not.
-     *
-     * @param securityRole {@link SecurityRole} to check
-     * @return <code>true</code> when the current authentication has the securityRole, <code>false</code> otherwise.
-     */
-    public boolean hasSecurityRole(SecurityRole securityRole) {
-
-        final Authentication authentication = getCurrentAuthentication();
-        final boolean hasRole = authentication.getAuthorities().contains(securityRole.authority());
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("user={} has permission={}", authentication.getName(), hasRole);
-        }
-
-        return hasRole;
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/security/ReloadAuthenticationAuthoritiesFilter.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/ReloadAuthenticationAuthoritiesFilter.java
@@ -96,7 +96,7 @@ class ReloadAuthenticationAuthoritiesFilter extends OncePerRequestFilter {
         if (principal instanceof OidcUser oidcUser) {
             return oidcUser.getSubject();
         }
-        return authentication.getName();
+        throw new IllegalStateException("unexpected authentication token: " + authentication.getPrincipal());
     }
 
     private static Set<GrantedAuthority> mergeAuthorities(OAuth2AuthenticationToken token, User user) {

--- a/src/main/java/de/focusshift/zeiterfassung/security/ReloadAuthenticationAuthoritiesFilter.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/ReloadAuthenticationAuthoritiesFilter.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.context.DelegatingSecurityContextRepository;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -74,7 +75,8 @@ class ReloadAuthenticationAuthoritiesFilter extends OncePerRequestFilter {
         final OAuth2User oAuth2User = oAuth2Auth.getPrincipal();
 
         tenantContextHolder.runInTenantIdContext(oAuth2Auth.getAuthorizedClientRegistrationId(), tenantId -> {
-            final User user = userManagementService.findUserById(new UserId(oAuth2User.getName()))
+            final String authSubject = getSubject(authentication);
+            final User user = userManagementService.findUserById(new UserId(authSubject))
                 .orElseThrow(() -> new IllegalStateException("no user found with userId=" + authentication.getName()));
 
             final Set<GrantedAuthority> updatedAuthorities = mergeAuthorities(oAuth2Auth, user);
@@ -87,6 +89,14 @@ class ReloadAuthenticationAuthoritiesFilter extends OncePerRequestFilter {
         });
 
         chain.doFilter(request, response);
+    }
+
+    private String getSubject(Authentication authentication) {
+        final Object principal = authentication.getPrincipal();
+        if (principal instanceof OidcUser oidcUser) {
+            return oidcUser.getSubject();
+        }
+        return authentication.getName();
     }
 
     private static Set<GrantedAuthority> mergeAuthorities(OAuth2AuthenticationToken token, User user) {


### PR DESCRIPTION
`ClientRegistrationFactory` configures the user_name_attribute_name to `preferred_username` (don't know why). Therefore `authentication.getName` returns the username instead of the subject.

Fixed this with checking which Authentication implementation is used in runtime, trying to use `.getSubject()` and using `.getName()` as fallback.


closes #1153

Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
