### PR TITLE
add timeentry history item for timeentry locked event

### DIFF
--- a/.examples/docker-compose/keycloak/import/zeiterfassung-realm-realm.json
+++ b/.examples/docker-compose/keycloak/import/zeiterfassung-realm-realm.json
@@ -109,6 +109,14 @@
       "containerId" : "zeiterfassung-realm",
       "attributes" : { }
     }, {
+      "id" : "5ff04ece-718e-4c73-959e-96656c6c4789",
+      "name" : "zeiterfassung_settings_global",
+      "description" : "",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "zeiterfassung-realm",
+      "attributes" : { }
+    }, {
       "id" : "d0fcc3dd-7e1e-46fa-89ce-f7727e1a46f3",
       "name" : "zeiterfassung_overtime_account_edit_all",
       "description" : "",
@@ -409,6 +417,7 @@
       "zeiterfassung_view_report_all",
       "zeiterfassung_working_time_edit_all",
       "zeiterfassung_working_time_edit_global",
+      "zeiterfassung_settings_global",
       "zeiterfassung_overtime_account_edit_all",
       "zeiterfassung_permissions_edit_all",
       "zeiterfassung_time_entry_edit_all"

--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ Zeiterfassung is using user permissions from oidc claim `groups` for mapping pos
 * `ZEITERFASSUNG_USER`: General access to the application and time tracking features
 * `ZEITERFASSUNG_VIEW_REPORT_ALL`: Access to reports of other users
 * `ZEITERFASSUNG_WORKING_TIME_EDIT_ALL`: Allowed to edit working time of all users
-* `ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL`: Allowed to edit global (company-wide default) working time
+* `ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL`: (deprecated, use ZEITERFASSUNG_SETTINGS_GLOBAL instead) Allowed to edit global (company-wide default) working time
 * `ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL`: Allowed to edit overtime account of all users
 * `ZEITERFASSUNG_PERMISSIONS_EDIT_ALL`: Allowed to edit permissions of all users
 * `ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL`: Allowed to create/update/delete time entries of all users
+* `ZEITERFASSUNG_SETTINGS_GLOBAL`: Allowed to configure application settings
 
 If you're using Keycloak, this can be configured via a predefined OIDC client mapper with name `groups`.
 Create both permissions as `Realm roles` and assign user to those roles.

--- a/src/main/css/components/checkbox-switch.css
+++ b/src/main/css/components/checkbox-switch.css
@@ -15,7 +15,8 @@
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%280, 0, 0, 0.25%29'/%3e%3c/svg%3e");
   background-position: left center;
   border-radius: 9999px;
-  transition: background-position 0.15s ease-in-out,
+  transition:
+    background-position 0.15s ease-in-out,
     background-color 0.15s ease-in-out;
   @apply bg-zinc-200 !important;
 }
@@ -24,4 +25,8 @@
   @apply bg-blue-500 !important;
   background-position: right center;
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23fff'/%3e%3c/svg%3e");
+}
+
+.checkbox-switch input[type="checkbox"]:disabled {
+  cursor: default;
 }

--- a/src/main/css/components/checkbox-switch.css
+++ b/src/main/css/components/checkbox-switch.css
@@ -21,6 +21,10 @@
   @apply bg-zinc-200 !important;
 }
 
+.checkbox-switch input[type="checkbox"]:disabled {
+  background-color: white !important;
+}
+
 .checkbox-switch input:checked[type="checkbox"] {
   @apply bg-blue-500 !important;
   background-position: right center;

--- a/src/main/css/time-entries.css
+++ b/src/main/css/time-entries.css
@@ -158,33 +158,21 @@
 }
 
 .timeslot-form-new {
-  --timeslot-form-color: theme("colors.blue.700");
   --timeslot-form-datepicker-background-color: theme("colors.blue.700");
   --timeslot-form-day-color: theme("colors.white");
-  --timeslot-form-day-background-color: theme("colors.blue.50");
   --timeslot-form-border-color: theme("colors.blue.700");
-  --timeslot-form-input-color: theme("colors.gray.900");
-  --timeslot-form-label-color: theme("colors.blue.700");
 }
 
 .timeslot-form-existing {
-  --timeslot-form-color: theme("colors.gray.700");
   --timeslot-form-datepicker-background-color: theme("colors.gray.200");
   --timeslot-form-day-color: theme("colors.black");
-  --timeslot-form-day-background-color: theme("colors.white");
   --timeslot-form-border-color: theme("colors.gray.200");
-  --timeslot-form-input-color: theme("colors.gray.900");
-  --timeslot-form-label-color: theme("colors.gray.500");
 }
 
 .time-entry-slot-form--disabled {
-  --timeslot-form-color: theme("colors.gray.50");
   --timeslot-form-datepicker-background-color: theme("colors.gray.100");
   --timeslot-form-day-color: theme("colors.gray.500");
-  --timeslot-form-day-background-color: theme("colors.gray.50");
   --timeslot-form-border-color: theme("colors.gray.200");
-  --timeslot-form-input-color: theme("colors.gray.50");
-  --timeslot-form-label-color: theme("colors.gray.50");
 }
 
 .timeslot-form-existing input.edited {

--- a/src/main/css/time-entries.css
+++ b/src/main/css/time-entries.css
@@ -216,6 +216,10 @@
   margin-top: 0.5rem;
 }
 
+.time-entry-slot-form--disabled label {
+  cursor: default;
+}
+
 .time-entry-box,
 .time-entry-box-absence {
   display: flex;

--- a/src/main/css/time-entries.css
+++ b/src/main/css/time-entries.css
@@ -177,6 +177,16 @@
   --timeslot-form-label-color: theme("colors.gray.500");
 }
 
+.time-entry-slot-form--disabled {
+  --timeslot-form-color: theme("colors.gray.50");
+  --timeslot-form-datepicker-background-color: theme("colors.gray.100");
+  --timeslot-form-day-color: theme("colors.gray.500");
+  --timeslot-form-day-background-color: theme("colors.gray.50");
+  --timeslot-form-border-color: theme("colors.gray.200");
+  --timeslot-form-input-color: theme("colors.gray.50");
+  --timeslot-form-label-color: theme("colors.gray.50");
+}
+
 .timeslot-form-existing input.edited {
   background-color: theme("colors.blue.100");
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/DetailDayDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/DetailDayDto.java
@@ -7,6 +7,7 @@ record DetailDayDto(
     String dayOfWeek,
     String dayOfWeekFull,
     String date,
+    boolean locked,
     String workedWorkingHours,
     String shouldWorkingHours,
     String hoursDelta,

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportDay.java
@@ -23,12 +23,14 @@ import static java.util.stream.Collectors.toMap;
  * All byUser Maps contains values for the same keys. (Please ensure this on constructing this object.)
  *
  * @param date
+ * @param locked                    true if date is locked for adding/editing time entries
  * @param workingTimeCalendarByUser {@linkplain WorkingTimeCalendar} for all relevant users
- * @param reportDayEntriesByUser {@linkplain ReportDayEntry entries} for all relevant users
- * @param detailDayAbsencesByUser {@linkplain ReportDayAbsence absences} for all relevant users
+ * @param reportDayEntriesByUser    {@linkplain ReportDayEntry entries} for all relevant users
+ * @param detailDayAbsencesByUser   {@linkplain ReportDayAbsence absences} for all relevant users
  */
 record ReportDay(
     LocalDate date,
+    boolean locked,
     Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser,
     Map<UserIdComposite, List<ReportDayEntry>> reportDayEntriesByUser,
     Map<UserIdComposite, List<ReportDayAbsence>> detailDayAbsencesByUser

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportServiceRaw.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportServiceRaw.java
@@ -2,6 +2,7 @@ package de.focusshift.zeiterfassung.report;
 
 import de.focusshift.zeiterfassung.absence.Absence;
 import de.focusshift.zeiterfassung.timeentry.TimeEntry;
+import de.focusshift.zeiterfassung.timeentry.TimeEntryLockService;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryService;
 import de.focusshift.zeiterfassung.user.UserDateService;
 import de.focusshift.zeiterfassung.user.UserId;
@@ -37,22 +38,20 @@ import static java.util.stream.Collectors.toMap;
 class ReportServiceRaw {
 
     private static final Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());
-
-    record Period(LocalDate from, LocalDate toExclusive) {
-    }
-
     private final TimeEntryService timeEntryService;
     private final UserManagementService userManagementService;
     private final UserDateService userDateService;
     private final WorkingTimeCalendarService workingTimeCalendarService;
+    private final TimeEntryLockService timeEntryLockService;
 
     ReportServiceRaw(TimeEntryService timeEntryService, UserManagementService userManagementService,
-                     UserDateService userDateService, WorkingTimeCalendarService workingTimeCalendarService) {
+                     UserDateService userDateService, WorkingTimeCalendarService workingTimeCalendarService, TimeEntryLockService timeEntryLockService) {
 
         this.timeEntryService = timeEntryService;
         this.userManagementService = userManagementService;
         this.userDateService = userDateService;
         this.workingTimeCalendarService = workingTimeCalendarService;
+        this.timeEntryLockService = timeEntryLockService;
     }
 
     ReportWeek getReportWeek(Year year, int week, UserLocalId userLocalId) {
@@ -181,14 +180,21 @@ class ReportServiceRaw {
         final Function<LocalDate, Map<UserIdComposite, List<ReportDayEntry>>> resolveReportDayEntries =
             (LocalDate date) -> reportEntriesByDate.getOrDefault(date, new HashMap<>());
 
+        final Optional<LocalDate> minValidTimeEntryDate = timeEntryLockService.getMinValidTimeEntryDate();
+
         final List<ReportDay> reportDays = IntStream.rangeClosed(0, 6)
             .mapToObj(daysToAdd ->
-                toReportDay(
-                    startOfWeekDate.plusDays(daysToAdd),
+            {
+                LocalDate date = startOfWeekDate.plusDays(daysToAdd);
+                boolean locked = isDateLocked(date, minValidTimeEntryDate);
+                return toReportDay(
+                    date,
                     userById,
                     workingTimeCalendars,
-                    resolveReportDayEntries
-                ))
+                    resolveReportDayEntries,
+                    locked
+                );
+            })
             .toList();
 
         return new ReportWeek(startOfWeekDate, reportDays);
@@ -206,6 +212,9 @@ class ReportServiceRaw {
         }
 
         return startOfWeekDates;
+    }
+
+    record Period(LocalDate from, LocalDate toExclusive) {
     }
 
     private static Optional<ReportDayEntry> timeEntryToReportDayEntry(TimeEntry timeEntry, Function<UserIdComposite, User> userProvider) {
@@ -228,7 +237,8 @@ class ReportServiceRaw {
     private static ReportDay toReportDay(LocalDate date,
                                          Map<UserIdComposite, User> userById,
                                          Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendars,
-                                         Function<LocalDate, Map<UserIdComposite, List<ReportDayEntry>>> reportDayEntriesForDate) {
+                                         Function<LocalDate, Map<UserIdComposite, List<ReportDayEntry>>> reportDayEntriesForDate,
+                                         boolean dateIsLocked) {
 
         final Map<UserIdComposite, List<ReportDayEntry>> reportDayEntriesByUser = reportDayEntriesForDate.apply(date);
         final Map<UserIdComposite, List<ReportDayAbsence>> reportDayAbsencesByUser = new HashMap<>();
@@ -251,10 +261,14 @@ class ReportServiceRaw {
             }
         }
 
-        return new ReportDay(date, workingTimeCalendars, reportDayEntriesByUser, reportDayAbsencesByUser);
+        return new ReportDay(date, dateIsLocked, workingTimeCalendars, reportDayEntriesByUser, reportDayAbsencesByUser);
     }
 
     private static boolean isPreviousMonth(LocalDate possiblePreviousMonthDate, YearMonth yearMonth) {
         return YearMonth.from(possiblePreviousMonthDate).until(yearMonth, MONTHS) == 1;
+    }
+
+    private static boolean isDateLocked(LocalDate date, Optional<LocalDate> minValidTimeEntryDate) {
+        return minValidTimeEntryDate.map(date::isBefore).orElse(false);
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportViewHelper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportViewHelper.java
@@ -221,7 +221,7 @@ class ReportViewHelper {
         final Duration deltaDuration = workDuration.duration().minus(shouldWorkingHours.duration());
         final String deltaHours = durationToTimeString(deltaDuration);
 
-        return new DetailDayDto(differentMonth, dayOfWeekNarrow, dayOfWeekFull, dateString, workedWorkingHoursString,
+        return new DetailDayDto(differentMonth, dayOfWeekNarrow, dayOfWeekFull, dateString, reportDay.locked(), workedWorkingHoursString,
             shouldWorkingHoursString, deltaHours, deltaDuration.isNegative(), dayEntryDtos, detailDayAbsenceDto);
     }
 

--- a/src/main/java/de/focusshift/zeiterfassung/security/SecurityRole.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/SecurityRole.java
@@ -8,12 +8,40 @@ import java.util.Optional;
 public enum SecurityRole {
 
     ZEITERFASSUNG_OPERATOR, // used by fss employees only!
+    /**
+     * Allowed to use the application. Users without this role are not able to see anything!
+     */
     ZEITERFASSUNG_USER,
+    /**
+     * Allowed to view {@link de.focusshift.zeiterfassung.report.ReportWeek} and
+     * {@link de.focusshift.zeiterfassung.report.ReportMonth} of all persons.
+     */
     ZEITERFASSUNG_VIEW_REPORT_ALL,
+    /**
+     * Allowed to edit (CRUD) {@link de.focusshift.zeiterfassung.timeentry.TimeEntry} of all persons.
+     */
     ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL,
+    /**
+     * Allowed to edit {@link de.focusshift.zeiterfassung.workingtime.WorkingTime} settings of all persons.
+     */
     ZEITERFASSUNG_WORKING_TIME_EDIT_ALL,
+    /**
+     * @deprecated for removal in 3.x. Use {@link SecurityRole#ZEITERFASSUNG_SETTINGS_GLOBAL} instead.
+     */
+    @Deprecated(forRemoval = true)
     ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL,
+    /**
+     * Allowed to edit global application settings like {@link de.focusshift.zeiterfassung.settings.FederalStateSettings}
+     * or {@link de.focusshift.zeiterfassung.settings.LockTimeEntriesSettings}.
+     */
+    ZEITERFASSUNG_SETTINGS_GLOBAL,
+    /**
+     * Allowed to edit {@link de.focusshift.zeiterfassung.usermanagement.OvertimeAccount} settings of all persons.
+     */
     ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL,
+    /**
+     * Allowed to edit permissions of all persons.
+     */
     ZEITERFASSUNG_PERMISSIONS_EDIT_ALL;
 
     private GrantedAuthority authority;

--- a/src/main/java/de/focusshift/zeiterfassung/security/oidc/CurrentOidcUser.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/oidc/CurrentOidcUser.java
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -49,6 +50,14 @@ public class CurrentOidcUser implements OidcUser {
 
     public OidcUser getOidcUser() {
         return oidcUser;
+    }
+
+    public List<SecurityRole> getRoles() {
+        return getAuthorities().stream()
+            .map(SecurityRole::fromAuthority)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .toList();
     }
 
     public boolean hasRole(SecurityRole role) {

--- a/src/main/java/de/focusshift/zeiterfassung/settings/FederalStateSettingsDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/FederalStateSettingsDto.java
@@ -1,6 +1,0 @@
-package de.focusshift.zeiterfassung.settings;
-
-import de.focusshift.zeiterfassung.publicholiday.FederalState;
-
-record FederalStateSettingsDto(FederalState federalState, boolean worksOnPublicHoliday) {
-}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/FederalStateSettingsService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/FederalStateSettingsService.java
@@ -2,5 +2,11 @@ package de.focusshift.zeiterfassung.settings;
 
 public interface FederalStateSettingsService {
 
+    /**
+     * Returns the persisted {@link FederalStateSettings} or a default when nothing has been configured yet,
+     * never {@code null}.
+     *
+     * @return the {@link FederalStateSettings}
+     */
     FederalStateSettings getFederalStateSettings();
 }

--- a/src/main/java/de/focusshift/zeiterfassung/settings/LockTimeEntriesSettings.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/LockTimeEntriesSettings.java
@@ -1,0 +1,35 @@
+package de.focusshift.zeiterfassung.settings;
+
+import de.focusshift.zeiterfassung.timeentry.TimeEntry;
+
+/**
+ * Global setting for locking time entries.
+ *
+ * <p>
+ * Example for {@link LockTimeEntriesSettings#lockTimeEntriesDaysInPast}:
+ * <ul>
+ *     <li>{@code 0} - allowed to create, update or delete {@link TimeEntry} only for today.</li>
+ *     <li>{@code 1} - allowed to create, update or delete {@link TimeEntry} today and yesterday, but not the day before yesterday.</li>
+ * </ul>
+ *
+ * <p>
+ * Note that privileged persons are allowed to bypass this restriction.
+ *
+ * @param lockingIsActive           whether this feature is enabled or not
+ * @param lockTimeEntriesDaysInPast number of days time entries in past get locked. can be negative when
+ *                                  {@link LockTimeEntriesSettings#lockingIsActive} is set to {@code false}. must be
+ *                                  zero or positive when {@link LockTimeEntriesSettings#lockingIsActive} is set to
+ *                                  {@code true}.
+ */
+public record LockTimeEntriesSettings(boolean lockingIsActive, int lockTimeEntriesDaysInPast) {
+
+    /**
+     * Default LockTimeSettings.
+     *
+     * <ul>
+     *     <li>{@link LockTimeEntriesSettings#lockingIsActive()} = {@code false}</li>
+     *     <li>{@link LockTimeEntriesSettings#lockTimeEntriesDaysInPast()} = {@code 2}</li>
+     * </ul>
+     */
+    public static final LockTimeEntriesSettings DEFAULT = new LockTimeEntriesSettings(false, 2);
+}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/LockTimeEntriesSettingsDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/LockTimeEntriesSettingsDto.java
@@ -1,0 +1,3 @@
+package de.focusshift.zeiterfassung.settings;
+
+record LockTimeEntriesSettingsDto(boolean lockingIsActive, int lockTimeEntriesDaysInPast){}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/LockTimeEntriesSettingsEntity.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/LockTimeEntriesSettingsEntity.java
@@ -1,0 +1,81 @@
+package de.focusshift.zeiterfassung.settings;
+
+import de.focusshift.zeiterfassung.publicholiday.FederalState;
+import de.focusshift.zeiterfassung.tenancy.tenant.AbstractTenantAwareEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+
+import java.util.Objects;
+
+import static jakarta.persistence.EnumType.STRING;
+
+@Entity(name = "settings_locking_time_entries")
+public class LockTimeEntriesSettingsEntity extends AbstractTenantAwareEntity {
+
+    @Id
+    @Column(name = "id", unique = true, nullable = false, updatable = false)
+    @SequenceGenerator(name = "settings_locking_time_entries_seq", sequenceName = "settings_locking_time_entries_seq")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "settings_locking_time_entries_seq")
+    protected Long id;
+
+    @Column(name = "lock_time_entries_days_in_past")
+    private int lockTimeEntriesDaysInPast;
+
+    @Column(name = "locking_is_active")
+    private boolean lockingIsActive;
+
+    protected LockTimeEntriesSettingsEntity() {
+        super(null);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public int getLockTimeEntriesDaysInPast() {
+        return lockTimeEntriesDaysInPast;
+    }
+
+    public void setLockTimeEntriesDaysInPast(int lockTimeEntriesDaysInPast) {
+        this.lockTimeEntriesDaysInPast = lockTimeEntriesDaysInPast;
+    }
+
+    public boolean isLockingIsActive() {
+        return lockingIsActive;
+    }
+
+    public void setLockingIsActive(boolean lockingIsActive) {
+        this.lockingIsActive = lockingIsActive;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LockTimeEntriesSettingsEntity that = (LockTimeEntriesSettingsEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "LockTimeEntriesSettingsEntity{" +
+            "id=" + id +
+            ", lockTimeEntriesDaysInPast=" + lockTimeEntriesDaysInPast +
+            ", lockingIsActive=" + lockingIsActive +
+            '}';
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/LockTimeEntriesSettingsRepository.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/LockTimeEntriesSettingsRepository.java
@@ -1,0 +1,6 @@
+package de.focusshift.zeiterfassung.settings;
+
+import org.springframework.data.repository.CrudRepository;
+
+interface LockTimeEntriesSettingsRepository extends CrudRepository<LockTimeEntriesSettingsEntity, Long> {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/LockTimeEntriesSettingsService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/LockTimeEntriesSettingsService.java
@@ -1,0 +1,12 @@
+package de.focusshift.zeiterfassung.settings;
+
+public interface LockTimeEntriesSettingsService {
+
+    /**
+     * Returns the persisted {@link LockTimeEntriesSettings} or a default when nothing has been configured yet,
+     * never {@code null}.
+     *
+     * @return the {@link LockTimeEntriesSettings}
+     */
+    LockTimeEntriesSettings getLockTimeEntriesSettings();
+}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/SettingsController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/SettingsController.java
@@ -2,9 +2,11 @@ package de.focusshift.zeiterfassung.settings;
 
 import de.focus_shift.launchpad.api.HasLaunchpad;
 import de.focusshift.zeiterfassung.timeclock.HasTimeClock;
+import jakarta.validation.Valid;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -13,11 +15,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 
 import static de.focusshift.zeiterfassung.settings.FederalStateSelectDtoFactory.federalStateSelectDto;
+import static java.util.Objects.requireNonNullElse;
 
 @Controller
 @RequestMapping("/settings")
-@PreAuthorize("hasAuthority('ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL')")
+@PreAuthorize("hasAnyAuthority('ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL', 'ZEITERFASSUNG_SETTINGS_GLOBAL')")
 class SettingsController implements HasLaunchpad, HasTimeClock {
+
+    private static final String ATTRIBUTE_NAME_SETTINGS = "settings";
 
     private final SettingsService settingsService;
 
@@ -26,35 +31,60 @@ class SettingsController implements HasLaunchpad, HasTimeClock {
     }
 
     @GetMapping
-    String getSettings() {
-        return "redirect:settings/federal-state";
-    }
-
-    @GetMapping("/federal-state")
-    String getFederalStateSettings(Model model) {
-
-        final FederalStateSettings settings = settingsService.getFederalStateSettings();
-        final FederalStateSettingsDto federalStateSettingsDto = toFederalStateSettingsDto(settings);
-
-        model.addAttribute("federalStateSettings", federalStateSettingsDto);
-        model.addAttribute("federalStateSelect", federalStateSelectDto(federalStateSettingsDto.federalState()));
-
+    String getSettings(Model model) {
+        fillFederalStateSettings(model);
         return "settings/settings";
     }
 
-    @PostMapping("/federal-state")
-    ModelAndView saveSettings(@ModelAttribute("federalStateSettings") FederalStateSettingsDto federalStateSettings, BindingResult result) {
+    void fillFederalStateSettings(Model model) {
 
-        if (result.hasErrors()) {
+        final FederalStateSettings federalStateSettings = settingsService.getFederalStateSettings();
+        final LockTimeEntriesSettings lockTimeEntriesSettings = settingsService.getLockTimeEntriesSettings();
+        final SettingsDto settingsDto = toSettingsDto(federalStateSettings, lockTimeEntriesSettings);
+
+        prepareModel(model, settingsDto);
+    }
+
+    @PostMapping
+    ModelAndView saveSettings(@Valid @ModelAttribute(ATTRIBUTE_NAME_SETTINGS) SettingsDto settingsDto, BindingResult bindingResult, Model model) {
+
+        if (bindingResult.getTarget() == null) {
+            // entering a string for lockTimeEntriesDaysInPast results in a TypeMismatchException which skips
+            // spring bean validation and therefore there is no binding yet.
+            bindingResult = new BeanPropertyBindingResult(settingsDto, ATTRIBUTE_NAME_SETTINGS);
+        }
+
+        final int lockTimeEntriesDaysInPast = requireNonNullElse(settingsDto.lockTimeEntriesDaysInPast(), -1);
+        if (settingsDto.lockingIsActive() && lockTimeEntriesDaysInPast < 0)  {
+            bindingResult.rejectValue( "lockTimeEntriesDaysInPast", "settings.lock-timeentries-days-in-past.validation.positiveOrZero");
+        }
+
+        if (bindingResult.hasErrors()) {
+            prepareModel(model, settingsDto);
+            model.addAttribute(BindingResult.MODEL_KEY_PREFIX + ATTRIBUTE_NAME_SETTINGS, bindingResult);
             return new ModelAndView("settings/settings");
         }
 
-        settingsService.updateFederalStateSettings(federalStateSettings.federalState(), federalStateSettings.worksOnPublicHoliday());
+        settingsService.updateFederalStateSettings(settingsDto.federalState(), settingsDto.worksOnPublicHoliday());
+        settingsService.updateLockTimeEntriesSettings(settingsDto.lockingIsActive(), lockTimeEntriesDaysInPast);
 
-        return new ModelAndView("redirect:/settings/federal-state");
+        return new ModelAndView("redirect:/settings");
     }
 
-    private FederalStateSettingsDto toFederalStateSettingsDto(FederalStateSettings federalStateSettings) {
-        return new FederalStateSettingsDto(federalStateSettings.federalState(), federalStateSettings.worksOnPublicHoliday());
+    private void prepareModel(Model model, SettingsDto settingsDto) {
+        model.addAttribute(ATTRIBUTE_NAME_SETTINGS, settingsDto);
+        model.addAttribute("federalStateSelect", federalStateSelectDto(settingsDto.federalState()));
+    }
+
+    private SettingsDto toSettingsDto(FederalStateSettings federalStateSettings, LockTimeEntriesSettings lockTimeEntriesSettings) {
+
+        final int lockTimeEntriesDaysInPast = lockTimeEntriesSettings.lockTimeEntriesDaysInPast();
+
+        return new SettingsDto(
+            federalStateSettings.federalState(),
+            federalStateSettings.worksOnPublicHoliday(),
+            lockTimeEntriesSettings.lockingIsActive(),
+            lockTimeEntriesDaysInPast >= 0 ? lockTimeEntriesDaysInPast : null
+        );
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/settings/SettingsDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/SettingsDto.java
@@ -1,0 +1,17 @@
+package de.focusshift.zeiterfassung.settings;
+
+import de.focusshift.zeiterfassung.publicholiday.FederalState;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+record SettingsDto(
+    @NotNull
+    FederalState federalState,
+    boolean worksOnPublicHoliday,
+    boolean lockingIsActive,
+    @Nullable
+    @PositiveOrZero(message = "{settings.lock-timeentries-days-in-past.validation.positiveOrZero}")
+    Integer lockTimeEntriesDaysInPast
+) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/SettingsService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/SettingsService.java
@@ -8,18 +8,30 @@ import java.util.Optional;
 import static java.util.stream.StreamSupport.stream;
 
 @Service
-class SettingsService implements FederalStateSettingsService {
+class SettingsService implements FederalStateSettingsService, LockTimeEntriesSettingsService {
 
     private final FederalStateSettingsRepository federalStateSettingsRepository;
+    private final LockTimeEntriesSettingsRepository lockTimeEntriesSettingsRepository;
 
-    SettingsService(FederalStateSettingsRepository federalStateSettingsRepository) {
+    SettingsService(
+        FederalStateSettingsRepository federalStateSettingsRepository,
+        LockTimeEntriesSettingsRepository lockTimeEntriesSettingsRepository
+    ) {
         this.federalStateSettingsRepository = federalStateSettingsRepository;
+        this.lockTimeEntriesSettingsRepository = lockTimeEntriesSettingsRepository;
     }
 
     private static FederalStateSettings toFederalStateSettings(FederalStateSettingsEntity federalStateSettingsEntity) {
         return new FederalStateSettings(
             federalStateSettingsEntity.getFederalState(),
             federalStateSettingsEntity.isWorksOnPublicHoliday()
+        );
+    }
+
+    private static LockTimeEntriesSettings toLockTimeEntriesSettings(LockTimeEntriesSettingsEntity lockTimeEntriesSettingsEntity) {
+        return new LockTimeEntriesSettings(
+            lockTimeEntriesSettingsEntity.isLockingIsActive(),
+            lockTimeEntriesSettingsEntity.getLockTimeEntriesDaysInPast()
         );
     }
 
@@ -30,6 +42,14 @@ class SettingsService implements FederalStateSettingsService {
             .orElse(FederalStateSettings.DEFAULT);
     }
 
+    /**
+     * Updates {@link FederalStateSettings}.
+     *
+     * @param federalState {@link FederalState} used for every person if not overridden
+     * @param worksOnPublicHoliday whether persons have to work or not on public holidays
+     *
+     * @return the updated {@link FederalStateSettings}
+     */
     FederalStateSettings updateFederalStateSettings(FederalState federalState, boolean worksOnPublicHoliday) {
 
         final FederalStateSettingsEntity entity = getFederalStateEntity().orElseGet(FederalStateSettingsEntity::new);
@@ -45,6 +65,39 @@ class SettingsService implements FederalStateSettingsService {
         // `findFirst` is sufficient as there exists only one FederalStateSettingsEntity per tenant.
         // however, the tenantId is handled transparently in the background. and we only have the public API of `findAll`.
         final Iterable<FederalStateSettingsEntity> settings = federalStateSettingsRepository.findAll();
+        return stream(settings.spliterator(), false).findFirst();
+    }
+
+    @Override
+    public LockTimeEntriesSettings getLockTimeEntriesSettings() {
+        return getLockTimeEntriesSettingsEntity()
+            .map(SettingsService::toLockTimeEntriesSettings)
+            .orElse(LockTimeEntriesSettings.DEFAULT);
+    }
+
+    /**
+     * Update {@link LockTimeEntriesSettings}.
+     *
+     * @param lockingIsActive whether locking is active or not
+     * @param lockTimeEntriesDaysInPast number of days time entries in past get locked
+     *
+     * @return the updated {@link LockTimeEntriesSettings}
+     */
+    LockTimeEntriesSettings updateLockTimeEntriesSettings(boolean lockingIsActive, int lockTimeEntriesDaysInPast) {
+
+        final LockTimeEntriesSettingsEntity entity = getLockTimeEntriesSettingsEntity().orElseGet(LockTimeEntriesSettingsEntity::new);
+        entity.setLockingIsActive(lockingIsActive);
+        entity.setLockTimeEntriesDaysInPast(lockTimeEntriesDaysInPast);
+
+        final LockTimeEntriesSettingsEntity saved = lockTimeEntriesSettingsRepository.save(entity);
+
+        return toLockTimeEntriesSettings(saved);
+    }
+
+    private Optional<LockTimeEntriesSettingsEntity> getLockTimeEntriesSettingsEntity() {
+        // `findFirst` is sufficient as there exists only one FederalStateSettingsEntity per tenant.
+        // however, the tenantId is handled transparently in the background. and we only have the public API of `findAll`.
+        final Iterable<LockTimeEntriesSettingsEntity> settings = lockTimeEntriesSettingsRepository.findAll();
         return stream(settings.spliterator(), false).findFirst();
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/timeclock/TimeClockController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeclock/TimeClockController.java
@@ -3,9 +3,13 @@ package de.focusshift.zeiterfassung.timeclock;
 import de.focus_shift.launchpad.api.HasLaunchpad;
 import de.focusshift.zeiterfassung.security.CurrentUser;
 import de.focusshift.zeiterfassung.security.oidc.CurrentOidcUser;
+import de.focusshift.zeiterfassung.timeentry.TimeEntryLockService;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserSettingsProvider;
+import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import org.slf4j.Logger;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -18,11 +22,16 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static de.focusshift.zeiterfassung.web.HotwiredTurboConstants.TURBO_FRAME_HEADER;
 import static java.lang.String.format;
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.PRECONDITION_REQUIRED;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
@@ -32,12 +41,15 @@ import static org.springframework.util.StringUtils.hasText;
 @RequestMapping("timeclock")
 class TimeClockController implements HasTimeClock, HasLaunchpad {
 
+    private static final Logger LOG = getLogger(lookup().lookupClass());
     private static final String IS_REDIRECTED = "isRedirected";
 
     private final TimeClockService timeClockService;
+    private final TimeEntryLockService timeEntryLockService;
 
-    TimeClockController(TimeClockService timeClockService) {
+    TimeClockController(TimeClockService timeClockService, TimeEntryLockService timeEntryLockService) {
         this.timeClockService = timeClockService;
+        this.timeEntryLockService = timeEntryLockService;
     }
 
     @GetMapping
@@ -59,6 +71,13 @@ class TimeClockController implements HasTimeClock, HasLaunchpad {
         @RequestHeader(name = TURBO_FRAME_HEADER, required = false) String turboFrame,
         RedirectAttributes redirectAttributes
     ) {
+        timeEntryLockService.getMinValidTimeEntryDate().ifPresent(date -> {
+         if (timeClockUpdateDto.getDate().isBefore(date) || !timeEntryLockService.isUserAllowedToBypassLock(currentUser.getRoles())) {
+                LOG.info("Editing TimeClock is not allowed since currentUser is not privileged to bypass timespan lock.");
+                errors.reject("time-entry.validation.timespan.locked");
+            }
+        });
+
         if (errors.hasErrors()) {
             if (hasText(turboFrame)) {
                 return new ModelAndView("timeclock/timeclock-edit-form::navigation-box-update", UNPROCESSABLE_ENTITY);

--- a/src/main/java/de/focusshift/zeiterfassung/timeclock/TimeClockControllerAdvice.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeclock/TimeClockControllerAdvice.java
@@ -1,5 +1,8 @@
 package de.focusshift.zeiterfassung.timeclock;
 
+import de.focusshift.zeiterfassung.security.CurrentUser;
+import de.focusshift.zeiterfassung.security.oidc.CurrentOidcUser;
+import de.focusshift.zeiterfassung.timeentry.TimeEntryLockService;
 import de.focusshift.zeiterfassung.user.UserId;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -7,27 +10,42 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
-@ControllerAdvice(assignableTypes = { HasTimeClock.class })
+@ControllerAdvice(assignableTypes = {HasTimeClock.class})
 class TimeClockControllerAdvice {
 
     private final TimeClockService timeClockService;
+    private TimeEntryLockService timeEntryLockService;
 
-    TimeClockControllerAdvice(TimeClockService timeClockService) {
+    TimeClockControllerAdvice(TimeClockService timeClockService, TimeEntryLockService timeEntryLockService) {
         this.timeClockService = timeClockService;
+        this.timeEntryLockService = timeEntryLockService;
+    }
+
+    private static UserId userId(OidcUser oidcUser) {
+        return new UserId(oidcUser.getUserInfo().getSubject());
     }
 
     @ModelAttribute
-    public void addAttributes(Model model, @AuthenticationPrincipal OidcUser principal) {
+    public void addAttributes(Model model, @CurrentUser CurrentOidcUser principal) {
         final UserId userId = userId(principal);
         final Optional<TimeClock> currentTimeClock = timeClockService.getCurrentTimeClock(userId);
 
         currentTimeClock.map(TimeClockMapper::timeClockToTimeClockDto)
             .ifPresent(timeClockDto -> model.addAttribute("timeClock", timeClockDto));
+
+        getMinValidTimeEntryDate(principal).ifPresent(date ->
+            model.addAttribute("minValidTimeEntryDate", date)
+        );
     }
 
-    private static UserId userId(OidcUser oidcUser) {
-        return new UserId(oidcUser.getUserInfo().getSubject());
+    private Optional<LocalDate> getMinValidTimeEntryDate(CurrentOidcUser currentUser) {
+        if (timeEntryLockService.isUserAllowedToBypassLock(currentUser.getRoles())) {
+            return Optional.empty();
+        } else {
+            return timeEntryLockService.getMinValidTimeEntryDate();
+        }
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryController.java
@@ -64,18 +64,16 @@ class TimeEntryController implements HasTimeClock, HasLaunchpad {
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
     private final TimeEntryService timeEntryService;
-    private final TimeEntryLockService timeEntryLockService;
     private final UserManagementService userManagementService;
     private final UserSettingsProvider userSettingsProvider;
     private final DateFormatter dateFormatter;
     private final TimeEntryViewHelper viewHelper;
     private final Clock clock;
 
-    public TimeEntryController(TimeEntryService timeEntryService, TimeEntryLockService timeEntryLockService,
+    public TimeEntryController(TimeEntryService timeEntryService,
                                UserManagementService userManagementService, UserSettingsProvider userSettingsProvider,
                                DateFormatter dateFormatter, TimeEntryViewHelper viewHelper, Clock clock) {
         this.timeEntryService = timeEntryService;
-        this.timeEntryLockService = timeEntryLockService;
         this.userManagementService = userManagementService;
         this.userSettingsProvider = userSettingsProvider;
         this.dateFormatter = dateFormatter;
@@ -113,10 +111,6 @@ class TimeEntryController implements HasTimeClock, HasLaunchpad {
 
     private ModelAndView prepareTimeEntriesForYearAndWeekOfYear(YearAndWeek yearAndWeek, UserLocalId ownerLocalId, CurrentOidcUser currentUser, Model model, Locale locale, String turboFrame) {
 
-        getMinValidTimeEntryDate(currentUser).ifPresent(date ->
-            model.addAttribute("minValidTimeEntryDate", date)
-        );
-
         if (!model.containsAttribute(IS_REDIRECTED) && hasText(turboFrame)) {
             prepareTimeEntriesForYearAndWeekOfYear(yearAndWeek, ownerLocalId, model, locale);
             model.addAttribute("turboStreamsEnabled", true);
@@ -135,14 +129,6 @@ class TimeEntryController implements HasTimeClock, HasLaunchpad {
         addTimeEntryWeeksPageToModel(yearAndWeek, model, ownerLocalId, locale);
 
         return new ModelAndView("timeentries/index");
-    }
-
-    private Optional<LocalDate> getMinValidTimeEntryDate(CurrentOidcUser currentUser) {
-        if (timeEntryLockService.isUserAllowedToBypassLock(currentUser.getRoles())) {
-            return Optional.empty();
-        } else {
-            return timeEntryLockService.getMinValidTimeEntryDate();
-        }
     }
 
     @PostMapping("/timeentries")

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDay.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDay.java
@@ -8,14 +8,16 @@ import java.time.LocalDate;
 import java.util.List;
 
 /**
- *
- * @param date of the time entry day
+ * @param locked              whether this day is locked or not.
+ *                            Note that this does not include whether it can be bypassed or not by a privileged person!
+ * @param date                of the time entry day
  * @param plannedWorkingHours planned working hours
- * @param shouldWorkingHours should working hours
- * @param timeEntries list of time entries
- * @param absences list of absences. could be one FULL absence or two absences MORNING and NOON
+ * @param shouldWorkingHours  should working hours
+ * @param timeEntries         list of time entries
+ * @param absences            list of absences. could be one FULL absence or two absences MORNING and NOON
  */
 record TimeEntryDay(
+    boolean locked,
     LocalDate date,
     PlannedWorkingHours plannedWorkingHours,
     ShouldWorkingHours shouldWorkingHours,

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDayDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDayDto.java
@@ -3,21 +3,25 @@ package de.focusshift.zeiterfassung.timeentry;
 import java.time.DayOfWeek;
 import java.util.List;
 
-record TimeEntryDayDto(String date,
-                       DayOfWeek dayOfWeek,
-                       String hoursWorked,
-                       String hoursWorkedShould,
-                       String hoursDelta,
-                       boolean hoursDeltaNegative,
-                       double hoursWorkedRatio,
-                       List<TimeEntryDTO> timeEntries,
-                       List<AbsenceEntryDto> absenceEntries) {
+record TimeEntryDayDto(
+    boolean isLocked,
+    String date,
+    DayOfWeek dayOfWeek,
+    String hoursWorked,
+    String hoursWorkedShould,
+    String hoursDelta,
+    boolean hoursDeltaNegative,
+    double hoursWorkedRatio,
+    List<TimeEntryDTO> timeEntries,
+    List<AbsenceEntryDto> absenceEntries
+) {
 
     static Builder builder() {
         return new Builder();
     }
 
     static class Builder {
+        private boolean isLocked;
         private String date;
         private DayOfWeek dayOfWeek;
         private String hoursWorked;
@@ -27,6 +31,11 @@ record TimeEntryDayDto(String date,
         private double hoursWorkedRatio;
         private List<TimeEntryDTO> timeEntries;
         private List<AbsenceEntryDto> absenceEntries;
+
+        public Builder isLocked(boolean isLocked) {
+            this.isLocked = isLocked;
+            return this;
+        }
 
         public Builder date(String date) {
             this.date = date;
@@ -74,8 +83,8 @@ record TimeEntryDayDto(String date,
         }
 
         public TimeEntryDayDto build() {
-            return new TimeEntryDayDto(date, dayOfWeek, hoursWorked, hoursWorkedShould, hoursDelta, hoursDeltaNegative,
-                hoursWorkedRatio, timeEntries, absenceEntries);
+            return new TimeEntryDayDto(isLocked, date, dayOfWeek, hoursWorked, hoursWorkedShould, hoursDelta,
+                hoursDeltaNegative, hoursWorkedRatio, timeEntries, absenceEntries);
         }
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDialogHelper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDialogHelper.java
@@ -116,9 +116,9 @@ public class TimeEntryDialogHelper {
             .map(history -> {
 
                 final ZoneId zoneId = userSettingsProvider.zoneId();
-                final List<TimeEntryUpdatedHistoryItem> revisions = history.revisions();
+                final List<TimeEntryHistoryItem> revisions = history.revisions();
 
-                final List<UserId> userIds = revisions.stream().map(TimeEntryUpdatedHistoryItem::metadata)
+                final List<UserId> userIds = revisions.stream().map(TimeEntryHistoryItem::metadata)
                     .map(EntityRevisionMetadata::modifiedBy)
                     .filter(Optional::isPresent)
                     .map(Optional::get)
@@ -137,7 +137,7 @@ public class TimeEntryDialogHelper {
             });
     }
 
-    private TimeEntryHistoryItemDto timeEntryHistoryItemDto(TimeEntryUpdatedHistoryItem historyItem, Function<UserId, User> userSupplier, ZoneId zoneId) {
+    private TimeEntryHistoryItemDto timeEntryHistoryItemDto(TimeEntryHistoryItem historyItem, Function<UserId, User> userSupplier, ZoneId zoneId) {
 
         final EntityRevisionMetadata metadata = historyItem.metadata();
 

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDialogHelper.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDialogHelper.java
@@ -116,9 +116,9 @@ public class TimeEntryDialogHelper {
             .map(history -> {
 
                 final ZoneId zoneId = userSettingsProvider.zoneId();
-                final List<TimeEntryHistoryItem> revisions = history.revisions();
+                final List<TimeEntryUpdatedHistoryItem> revisions = history.revisions();
 
-                final List<UserId> userIds = revisions.stream().map(TimeEntryHistoryItem::metadata)
+                final List<UserId> userIds = revisions.stream().map(TimeEntryUpdatedHistoryItem::metadata)
                     .map(EntityRevisionMetadata::modifiedBy)
                     .filter(Optional::isPresent)
                     .map(Optional::get)
@@ -137,7 +137,7 @@ public class TimeEntryDialogHelper {
             });
     }
 
-    private TimeEntryHistoryItemDto timeEntryHistoryItemDto(TimeEntryHistoryItem historyItem, Function<UserId, User> userSupplier, ZoneId zoneId) {
+    private TimeEntryHistoryItemDto timeEntryHistoryItemDto(TimeEntryUpdatedHistoryItem historyItem, Function<UserId, User> userSupplier, ZoneId zoneId) {
 
         final EntityRevisionMetadata metadata = historyItem.metadata();
 

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryHistory.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryHistory.java
@@ -11,10 +11,10 @@ import static java.util.Collections.unmodifiableList;
  * @param revisions sorted revisions. first element is the initially created instance.
  *                  while the last element is the last/current modification.
  */
-public record TimeEntryHistory(TimeEntryId timeEntryId, List<TimeEntryHistoryItem> revisions) {
+public record TimeEntryHistory(TimeEntryId timeEntryId, List<TimeEntryUpdatedHistoryItem> revisions) {
 
     @Override
-    public List<TimeEntryHistoryItem> revisions() {
+    public List<TimeEntryUpdatedHistoryItem> revisions() {
         return unmodifiableList(revisions);
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryHistory.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryHistory.java
@@ -11,10 +11,10 @@ import static java.util.Collections.unmodifiableList;
  * @param revisions sorted revisions. first element is the initially created instance.
  *                  while the last element is the last/current modification.
  */
-public record TimeEntryHistory(TimeEntryId timeEntryId, List<TimeEntryUpdatedHistoryItem> revisions) {
+public record TimeEntryHistory(TimeEntryId timeEntryId, List<TimeEntryHistoryItem> revisions) {
 
     @Override
-    public List<TimeEntryUpdatedHistoryItem> revisions() {
+    public List<TimeEntryHistoryItem> revisions() {
         return unmodifiableList(revisions);
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryHistoryItem.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryHistoryItem.java
@@ -1,0 +1,18 @@
+package de.focusshift.zeiterfassung.timeentry;
+
+import de.focusshift.zeiterfassung.data.history.EntityRevisionMetadata;
+
+public interface TimeEntryHistoryItem {
+
+    EntityRevisionMetadata metadata();
+
+    TimeEntry timeEntry();
+
+    boolean commentModified();
+
+    boolean startModified();
+
+    boolean endModified();
+
+    boolean isBreakModified();
+}

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockService.java
@@ -2,8 +2,10 @@ package de.focusshift.zeiterfassung.timeentry;
 
 import de.focusshift.zeiterfassung.security.SecurityRole;
 
+import java.time.LocalDate;
 import java.time.temporal.Temporal;
 import java.util.Collection;
+import java.util.Optional;
 
 public interface TimeEntryLockService {
 
@@ -24,4 +26,11 @@ public interface TimeEntryLockService {
      * @return {@code true} when the user is allowed to bypass the lock, {@link false} otherwise
      */
     boolean isUserAllowedToBypassLock(Collection<SecurityRole> roles);
+
+    /**
+     * Returns the minimum valid date in the past a {@link TimeEntry} can be created for, if there is one.
+     *
+     * @return Optional#empty when locking {@link TimeEntry} is disabled, the min valid date otherwise.
+     */
+    Optional<LocalDate> getMinValidTimeEntryDate();
 }

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockService.java
@@ -1,0 +1,27 @@
+package de.focusshift.zeiterfassung.timeentry;
+
+import de.focusshift.zeiterfassung.security.SecurityRole;
+
+import java.time.temporal.Temporal;
+import java.util.Collection;
+
+public interface TimeEntryLockService {
+
+    /**
+     * Checks whether the given timespan is locked or not. This can be configured by privileged persons with
+     * {@link de.focusshift.zeiterfassung.settings.LockTimeEntriesSettings}
+     *
+     * @param start start date of the timespan
+     * @param end end date of the timespan
+     * @return {@code true} when the timespan is locked, {@code false} otherwise
+     */
+    boolean isTimespanLocked(Temporal start, Temporal end);
+
+    /**
+     * Checks whether the given user is allowed to create, edit or delete {@link TimeEntry} despite a locked timespan.
+     *
+     * @param roles user roles to check
+     * @return {@code true} when the user is allowed to bypass the lock, {@link false} otherwise
+     */
+    boolean isUserAllowedToBypassLock(Collection<SecurityRole> roles);
+}

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockServiceImpl.java
@@ -1,0 +1,64 @@
+package de.focusshift.zeiterfassung.timeentry;
+
+import de.focusshift.zeiterfassung.security.SecurityRole;
+import de.focusshift.zeiterfassung.settings.LockTimeEntriesSettings;
+import de.focusshift.zeiterfassung.settings.LockTimeEntriesSettingsService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import java.util.Collection;
+
+import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.slf4j.LoggerFactory.getLogger;
+
+@Service
+class TimeEntryLockServiceImpl implements TimeEntryLockService {
+
+    private static final Logger LOG = getLogger(lookup().lookupClass());
+
+    private final LockTimeEntriesSettingsService lockTimeEntriesSettingsService;
+    private final Clock clock;
+
+    TimeEntryLockServiceImpl(LockTimeEntriesSettingsService lockTimeEntriesSettingsService, Clock clock) {
+        this.lockTimeEntriesSettingsService = lockTimeEntriesSettingsService;
+        this.clock = clock;
+    }
+
+    @Override
+    public boolean isTimespanLocked(Temporal start, Temporal end) {
+
+        final LockTimeEntriesSettings settings = lockTimeEntriesSettingsService.getLockTimeEntriesSettings();
+        if (!settings.lockingIsActive()) {
+            LOG.debug("Timespan is not locked. Feature is disabled in settings.");
+            return false;
+        }
+
+        final int daysInPastAllowed = settings.lockTimeEntriesDaysInPast();
+
+        final boolean startLocked = isDateLocked(start, daysInPastAllowed);
+        final boolean endLocked = isDateLocked(end, daysInPastAllowed);
+        final boolean isLocked = startLocked || endLocked;
+
+        LOG.debug("{} locked={}", start, isLocked);
+
+        return isLocked;
+    }
+
+    @Override
+    public boolean isUserAllowedToBypassLock(Collection<SecurityRole> roles) {
+        return roles.contains(ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL);
+    }
+
+    private boolean isDateLocked(Temporal date, int daysInPastAllowed) {
+
+        final ZonedDateTime now = ZonedDateTime.now(clock);
+        final long daysBetween = DAYS.between(date, now);
+
+        return daysBetween > daysInPastAllowed;
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockServiceImpl.java
@@ -3,13 +3,17 @@ package de.focusshift.zeiterfassung.timeentry;
 import de.focusshift.zeiterfassung.security.SecurityRole;
 import de.focusshift.zeiterfassung.settings.LockTimeEntriesSettings;
 import de.focusshift.zeiterfassung.settings.LockTimeEntriesSettingsService;
+import de.focusshift.zeiterfassung.user.UserSettingsProvider;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.Temporal;
 import java.util.Collection;
+import java.util.Optional;
 
 import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL;
 import static java.lang.invoke.MethodHandles.lookup;
@@ -22,10 +26,12 @@ class TimeEntryLockServiceImpl implements TimeEntryLockService {
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
     private final LockTimeEntriesSettingsService lockTimeEntriesSettingsService;
+    private final UserSettingsProvider userSettingsProvider;
     private final Clock clock;
 
-    TimeEntryLockServiceImpl(LockTimeEntriesSettingsService lockTimeEntriesSettingsService, Clock clock) {
+    TimeEntryLockServiceImpl(LockTimeEntriesSettingsService lockTimeEntriesSettingsService, UserSettingsProvider userSettingsProvider, Clock clock) {
         this.lockTimeEntriesSettingsService = lockTimeEntriesSettingsService;
+        this.userSettingsProvider = userSettingsProvider;
         this.clock = clock;
     }
 
@@ -52,6 +58,23 @@ class TimeEntryLockServiceImpl implements TimeEntryLockService {
     @Override
     public boolean isUserAllowedToBypassLock(Collection<SecurityRole> roles) {
         return roles.contains(ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL);
+    }
+
+    @Override
+    public Optional<LocalDate> getMinValidTimeEntryDate() {
+
+        final LockTimeEntriesSettings settings = lockTimeEntriesSettingsService.getLockTimeEntriesSettings();
+
+        final LocalDate minimumValidDate;
+        if (settings.lockingIsActive()) {
+            final int daysInPast = settings.lockTimeEntriesDaysInPast();
+            final ZoneId userZoneId = userSettingsProvider.zoneId();
+            minimumValidDate = LocalDate.ofInstant(clock.instant(), userZoneId).minusDays(daysInPast);
+        } else {
+            minimumValidDate = null;
+        }
+
+        return Optional.ofNullable(minimumValidDate);
     }
 
     private boolean isDateLocked(Temporal date, int daysInPastAllowed) {

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryService.java
@@ -74,6 +74,10 @@ public interface TimeEntryService {
     /**
      * Creates a new {@linkplain TimeEntry}.
      *
+     * <p>
+     * Note that this method does not check if it is allowed to create a new {@link TimeEntry} for the given timespan.
+     * You have to check yourself whether these days are locked or not!
+     *
      * @param userLocalId id of the linked user
      * @param comment     optional comment
      * @param start       start of the time entry.
@@ -86,6 +90,10 @@ public interface TimeEntryService {
 
     /**
      * Updates the existing {@linkplain TimeEntry}
+     *
+     * <p>
+     * Note that this method does not check if it is allowed to update the {@link TimeEntry}.
+     * You have to check yourself whether the {@link TimeEntry#start()} is locked or not!
      *
      * @param id of the {@linkplain TimeEntry} to update
      * @param comment optional comment. not that {@code null} overrides the existing comment.

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
@@ -95,7 +95,7 @@ class TimeEntryServiceImpl implements TimeEntryService {
         final UserId userId = new UserId(revisions.iterator().next().getEntity().getOwner());
         final User user = findUser(userId);
 
-        final List<TimeEntryHistoryItem> historyItems = new ArrayList<>();
+        final List<TimeEntryUpdatedHistoryItem> historyItems = new ArrayList<>();
         TimeEntry previousTimeEntry = null;
 
         for (Revision<Long, TimeEntryEntity> revision : revisions.getContent()) {
@@ -104,12 +104,12 @@ class TimeEntryServiceImpl implements TimeEntryService {
             final TimeEntry timeEntry = toTimeEntry(entity, user);
             final EntityRevisionMetadata entityRevisionMetadata = entityRevisionMapper.toEntityRevisionMetadata(revision);
 
-            TimeEntryHistoryItem historyItem;
+            TimeEntryUpdatedHistoryItem historyItem;
 
             if (previousTimeEntry == null) {
-                historyItem = new TimeEntryHistoryItem(entityRevisionMetadata, timeEntry, true, true, true, true);
+                historyItem = new TimeEntryUpdatedHistoryItem(entityRevisionMetadata, timeEntry, true, true, true, true);
             } else {
-                historyItem = new TimeEntryHistoryItem(
+                historyItem = new TimeEntryUpdatedHistoryItem(
                     entityRevisionMetadata,
                     timeEntry,
                     hasBeenModified(previousTimeEntry::comment, timeEntry::comment),

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
@@ -95,7 +95,7 @@ class TimeEntryServiceImpl implements TimeEntryService {
         final UserId userId = new UserId(revisions.iterator().next().getEntity().getOwner());
         final User user = findUser(userId);
 
-        final List<TimeEntryUpdatedHistoryItem> historyItems = new ArrayList<>();
+        final List<TimeEntryHistoryItem> historyItems = new ArrayList<>();
         TimeEntry previousTimeEntry = null;
 
         for (Revision<Long, TimeEntryEntity> revision : revisions.getContent()) {

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryUpdatedHistoryItem.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryUpdatedHistoryItem.java
@@ -9,5 +9,5 @@ public record TimeEntryUpdatedHistoryItem(
     boolean startModified,
     boolean endModified,
     boolean isBreakModified
-) {
+) implements TimeEntryHistoryItem {
 }

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryUpdatedHistoryItem.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryUpdatedHistoryItem.java
@@ -2,7 +2,7 @@ package de.focusshift.zeiterfassung.timeentry;
 
 import de.focusshift.zeiterfassung.data.history.EntityRevisionMetadata;
 
-public record TimeEntryHistoryItem(
+public record TimeEntryUpdatedHistoryItem(
     EntityRevisionMetadata metadata,
     TimeEntry timeEntry,
     boolean commentModified,

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/PermissionsController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/PermissionsController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -124,7 +125,7 @@ class PermissionsController implements HasLaunchpad, HasTimeClock {
             switch (role) {
                 case ZEITERFASSUNG_VIEW_REPORT_ALL -> permissionsDto.setViewReportAll(true);
                 case ZEITERFASSUNG_WORKING_TIME_EDIT_ALL -> permissionsDto.setWorkingTimeEditAll(true);
-                case ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL -> permissionsDto.setWorkingTimeEditGlobal(true);
+                case ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL, ZEITERFASSUNG_SETTINGS_GLOBAL -> permissionsDto.setGlobalSettings(true);
                 case ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL -> permissionsDto.setOvertimeEditAll(true);
                 case ZEITERFASSUNG_PERMISSIONS_EDIT_ALL -> permissionsDto.setPermissionsEditAll(true);
                 case ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL -> permissionsDto.setTimeEntryEditAll(true);
@@ -148,7 +149,7 @@ class PermissionsController implements HasLaunchpad, HasTimeClock {
             switch (role) {
                 case ZEITERFASSUNG_VIEW_REPORT_ALL -> adder.accept(permissionsDto::isViewReportAll, role);
                 case ZEITERFASSUNG_WORKING_TIME_EDIT_ALL -> adder.accept(permissionsDto::isWorkingTimeEditAll, role);
-                case ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL -> adder.accept(permissionsDto::isWorkingTimeEditGlobal, role);
+                case ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL, ZEITERFASSUNG_SETTINGS_GLOBAL -> adder.accept(permissionsDto::isGlobalSettings, role);
                 case ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL -> adder.accept(permissionsDto::isOvertimeEditAll, role);
                 case ZEITERFASSUNG_PERMISSIONS_EDIT_ALL -> adder.accept(permissionsDto::isPermissionsEditAll, role);
                 case ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL -> adder.accept(permissionsDto::isTimeEntryEditAll, role);

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/PermissionsDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/PermissionsDto.java
@@ -1,15 +1,13 @@
 package de.focusshift.zeiterfassung.usermanagement;
 
-import java.util.Objects;
-
 class PermissionsDto {
 
     private boolean viewReportAll;
     private boolean workingTimeEditAll;
-    private boolean workingTimeEditGlobal;
     private boolean overtimeEditAll;
     private boolean permissionsEditAll;
     private boolean timeEntryEditAll;
+    private boolean globalSettings;
 
     public boolean isViewReportAll() {
         return viewReportAll;
@@ -25,14 +23,6 @@ class PermissionsDto {
 
     public void setWorkingTimeEditAll(boolean workingTimeEditAll) {
         this.workingTimeEditAll = workingTimeEditAll;
-    }
-
-    public boolean isWorkingTimeEditGlobal() {
-        return workingTimeEditGlobal;
-    }
-
-    public void setWorkingTimeEditGlobal(boolean workingTimeEditGlobal) {
-        this.workingTimeEditGlobal = workingTimeEditGlobal;
     }
 
     public boolean isOvertimeEditAll() {
@@ -59,21 +49,36 @@ class PermissionsDto {
         return timeEntryEditAll;
     }
 
+    public boolean isGlobalSettings() {
+        return globalSettings;
+    }
+
+    public void setGlobalSettings(boolean globalSettings) {
+        this.globalSettings = globalSettings;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+
         PermissionsDto that = (PermissionsDto) o;
         return viewReportAll == that.viewReportAll
             && workingTimeEditAll == that.workingTimeEditAll
             && overtimeEditAll == that.overtimeEditAll
             && permissionsEditAll == that.permissionsEditAll
-            && timeEntryEditAll == that.timeEntryEditAll;
+            && timeEntryEditAll == that.timeEntryEditAll
+            && globalSettings == that.globalSettings;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(viewReportAll, workingTimeEditAll, overtimeEditAll, permissionsEditAll, timeEntryEditAll);
+        int result = Boolean.hashCode(viewReportAll);
+        result = 31 * result + Boolean.hashCode(workingTimeEditAll);
+        result = 31 * result + Boolean.hashCode(overtimeEditAll);
+        result = 31 * result + Boolean.hashCode(permissionsEditAll);
+        result = 31 * result + Boolean.hashCode(timeEntryEditAll);
+        result = 31 * result + Boolean.hashCode(globalSettings);
+        return result;
     }
 
     @Override
@@ -84,6 +89,7 @@ class PermissionsDto {
             ", overtimeEditAll=" + overtimeEditAll +
             ", permissionsEditAll=" + permissionsEditAll +
             ", timeEntryEditAll=" + timeEntryEditAll +
+            ", globalSettings=" + globalSettings +
             '}';
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/web/AuthoritiesModelProvider.java
+++ b/src/main/java/de/focusshift/zeiterfassung/web/AuthoritiesModelProvider.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL;
 import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_PERMISSIONS_EDIT_ALL;
+import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_SETTINGS_GLOBAL;
 import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_WORKING_TIME_EDIT_ALL;
 import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL;
 import static java.lang.invoke.MethodHandles.lookup;
@@ -58,7 +59,7 @@ class AuthoritiesModelProvider implements HandlerInterceptor {
             contains(roles, ZEITERFASSUNG_WORKING_TIME_EDIT_ALL, ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL, ZEITERFASSUNG_PERMISSIONS_EDIT_ALL));
 
         modelAndView.addObject("showMainNavigationSettings",
-            contains(roles, ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL));
+            contains(roles, ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL, ZEITERFASSUNG_SETTINGS_GLOBAL));
     }
 
     private static boolean contains(Collection<SecurityRole> roles, SecurityRole... anyOf) {

--- a/src/main/javascript/components/datepicker/datepicker.ts
+++ b/src/main/javascript/components/datepicker/datepicker.ts
@@ -30,5 +30,9 @@ export function createDatepicker(selector: string): HTMLDuetDatePickerElement {
   duetDateElement.setAttribute("value", dateElement.dataset.isoValue || "");
   duetDateElement.setAttribute("identifier", dateElement.getAttribute("id"));
 
+  if (dateElement.hasAttribute("min")) {
+    duetDateElement.setAttribute("min", dateElement.getAttribute("min"));
+  }
+
   return duetDateElement;
 }

--- a/src/main/javascript/components/time-entry-datepicker/TimeEntryDatePicker.ts
+++ b/src/main/javascript/components/time-entry-datepicker/TimeEntryDatePicker.ts
@@ -12,6 +12,11 @@ class TimeEntryDatePicker extends HTMLDivElement {
 
   #initDatepicker() {
     const originalDateInput = this.querySelector("input[type=date]");
+
+    if (originalDateInput.hasAttribute("disabled")) {
+      return;
+    }
+
     const originalDateInputId = originalDateInput.getAttribute("id");
     const label = document.querySelector(`[for='${originalDateInputId}']`);
 

--- a/src/main/resources/db/changelog/changelog-2.20.0-add-setting-for-locking-time-entries.xml
+++ b/src/main/resources/db/changelog/changelog-2.20.0-add-setting-for-locking-time-entries.xml
@@ -1,0 +1,57 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd">
+
+  <changeSet author="honnel" id="add-setting-for-locking-time-entries">
+    <preConditions>
+      <not>
+        <tableExists tableName="settings_locking_time_entries"/>
+      </not>
+    </preConditions>
+
+    <createSequence sequenceName="settings_locking_time_entries_seq" incrementBy="50"/>
+
+    <createTable tableName="settings_locking_time_entries">
+      <column name="id" type="BIGINT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="PK_SETTINGS_LOCKING_TIME_ENTRIES"/>
+      </column>
+      <column name="tenant_id" type="VARCHAR(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="locking_is_active" type="BOOLEAN" defaultValue="false">
+        <constraints nullable="false"/>
+      </column>
+      <column name="lock_time_entries_days_in_past" type="INT" defaultValue="2">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <addForeignKeyConstraint
+      constraintName="FK_SETTINGS_LOCKING_TIME_ENTRIES_TENANT_ID__TENANT_ID"
+      baseColumnNames="tenant_id"
+      baseTableName="settings_locking_time_entries"
+      referencedColumnNames="tenant_id"
+      referencedTableName="tenant"
+      deferrable="false"
+      initiallyDeferred="false"
+      onDelete="CASCADE"
+      onUpdate="NO ACTION"
+    />
+
+    <createIndex tableName="settings_locking_time_entries" indexName="IDX_SETTINGS_LOCKING_TIME_ENTRIES_TENANT_ID">
+      <column name="tenant_id"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet author="honnel" id="enable-row-level-security-on-settings_locking_time_entries">
+    <sql dbms="postgresql">
+      ALTER TABLE settings_locking_time_entries ENABLE ROW LEVEL SECURITY;
+      DROP
+      POLICY IF EXISTS settings_locking_time_entries_tenant_isolation_policy ON settings_locking_time_entries;
+            CREATE
+      POLICY settings_locking_time_entries_tenant_isolation_policy ON settings_locking_time_entries
+                USING (tenant_id = current_setting('app.tenant_id')::VARCHAR);
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-main.xml
+++ b/src/main/resources/db/changelog/db.changelog-main.xml
@@ -32,5 +32,6 @@
   <include relativeToChangelogFile="true" file="changelog-2.14.0-remove-leading-trailing-whitespaces-username.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.16.0-add-time-entry-versioning.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.18.0-add-missing-indices.xml"/>
+  <include relativeToChangelogFile="true" file="changelog-2.20.0-add-setting-for-locking-time-entries.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -257,6 +257,7 @@ time-entry.validation.startOrDuration.required=Von oder Dauer wird benötigt.
 time-entry.validation.endOrDuration.required=Bis oder Dauer wird benötigt.
 time-entry.validation.startOrEnd.required=Von oder Bis wird benötigt.
 time-entry.validation.plausible=Bitte ändere nur zwei Felder (z.B. Von/Bis oder Von/Dauer oder Bis/Dauer). Das dritte wird automatisch berechnet.
+time-entry.validation.timespan.locked=Für den Zeitraum kann kein Zeitslot mehr erfasst werden. Bitte wende dich an eine berechtigte Person.
 
 time-entry.head.title=Zeiterfassung
 time-entry.create.title=Neuen Zeiteintrag erfassen

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -447,6 +447,8 @@ usermanagement.permissions.permissions.title=Berechtigungen
 usermanagement.permissions.permissions-edit-all.allowed.label=darf die Berechtigungen aller Personen bearbeiten
 usermanagement.permissions.timeentries.title=Zeiteinträge
 usermanagement.permissions.timeentry-edit-all.allowed.label=darf die Zeiteinträge aller Personen bearbeiten
+usermanagement.permissions.global-settings.title=Einstellungen
+usermanagement.permissions.global-settings.allowed.label=darf die globalen Einstellungen bearbeiten
 
 
 settings.heading=Einstellungen
@@ -454,6 +456,11 @@ settings.teaser-text=Globale Einstellungen für die Zeiterfassung.
 settings.federal-state.heading=Bundesland und Feiertagsregelung
 settings.federal-state.teaser-text=Standard Bundesland für die Feiertagsregelung. Kann bei Personen individuell überschrieben werden.
 settings.federal-state.works-on-public-holiday.label=arbeitet an Feiertagen
+settings.lock-timeentries.heading=Festschreiben von Zeitslots
+settings.lock-timeentries.teaser-text=Lege fest wie weit in die Vergangenheit Zeitslots durch die Person selbst angepasst oder hinzugefügt werden können.
+settings.lock-timeentries-is-active.label=Festschreibung aktivieren
+settings.lock-timeentries-days-in-past.label=Anzahl der Tage vor Festschreibung
+settings.lock-timeentries-days-in-past.validation.positiveOrZero=Anzahl der Tage muss 0 oder positiv sein.
 settings.save=Speichern
 settings.reset=Zurücksetzen
 
@@ -470,3 +477,6 @@ absence.label.FULL={0}
 absence.label.MORNING={0} (Morgens)
 absence.label.NOON={0} (Nachmittags)
 absence.type.category.SICK=Krankmeldung
+
+# common constraints
+typeMismatch.java.lang.Integer=Bitte eine gültige Zahl eingeben.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -213,6 +213,8 @@ month.december.short=Dez
 date-range={0} bis {1}
 date-range.with-calendar-week=KW {0} | {1}
 
+date.locked=Gesperrt
+
 datepicker.today=Heute
 
 # duet-date-picker localization

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -446,12 +446,19 @@ usermanagement.permissions.permissions.title=Permissions
 usermanagement.permissions.permissions-edit-all.allowed.label=may edit the permissions of all persons
 usermanagement.permissions.timeentries.title=Time entries
 usermanagement.permissions.timeentry-edit-all.allowed.label=may edit the time entries of all persons
+usermanagement.permissions.global-settings.title=Settings
+usermanagement.permissions.global-settings.allowed.label=may edit global settings
 
 settings.heading=Settings
 settings.teaser-text=Global settings for Zeiterfassung.
 settings.federal-state.heading=Federal state and public holiday regulations
 settings.federal-state.teaser-text=Standard federal state for the public holiday regulation. Can be overwritten individually for persons.
 settings.federal-state.works-on-public-holiday.label=works on public holidays
+settings.lock-timeentries.heading=Locking of time slots
+settings.lock-timeentries.teaser-text=Specify how far in the past time entries can be adjusted or added by the person themselves.
+settings.lock-timeentries-is-active.label=Activate locking of time slots
+settings.lock-timeentries-days-in-past.label=Number of days before locking
+settings.lock-timeentries-days-in-past.validation.positiveOrZero=Number of days must be 0 or positive.
 settings.save=Save
 settings.reset=Reset
 

--- a/src/main/resources/templates/fragments/select.html
+++ b/src/main/resources/templates/fragments/select.html
@@ -14,7 +14,7 @@
       <select
         th:id="${id}"
         th:name="${name}"
-        class="appearance-none py-1 px-2 pr-8 border border-gray-300 rounded"
+        class="w-full appearance-none py-1 px-2 pr-8 border border-gray-300 rounded"
         th:attrappend="data-auto-submit=${autosubmit}, data-testid=${testId}, is=${is}"
       >
         <option th:replace="${options}"></option>

--- a/src/main/resources/templates/icons/lock-keyhole.html
+++ b/src/main/resources/templates/icons/lock-keyhole.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Title</title>
+  </head>
+  <body>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      role="img"
+      aria-hidden="true"
+      focusable="false"
+      th:classappend="${className}"
+    >
+      <circle cx="12" cy="16" r="1" />
+      <rect x="3" y="10" width="18" height="12" rx="2" />
+      <path d="M7 10V7a5 5 0 0 1 10 0v3" />
+    </svg>
+  </body>
+</html>

--- a/src/main/resources/templates/reports/_report-time-entries.html
+++ b/src/main/resources/templates/reports/_report-time-entries.html
@@ -35,6 +35,14 @@
             style="top: calc(var(--navigation-header-height) + 1rem)"
             th:attrappend="aria-hidden=${hasEntries ? 'true' : null}"
           >
+            <span class="content-center" th:if="${day.locked}">
+              <svg
+                th:replace="~{icons/lock-keyhole::svg(className='w-4 h-4')}"
+              />
+              <span class="sr-only" th:text="#{date.locked}"
+              >Gesperrt</span
+              >
+            </span>
             <span
               th:id="${listLabelId}"
               class="flex-1 font-medium"

--- a/src/main/resources/templates/settings/settings.html
+++ b/src/main/resources/templates/settings/settings.html
@@ -34,50 +34,48 @@
                 Lorem ipsum...
               </p>
               <div class="mt-4">
-                <div class="flex flex-col gap-8">
-                  <div class="flex items-center gap-4">
-                    <div class="flex items-center">
-                      <label
-                        for="federal-state-select"
-                        class="sr-only"
-                        th:text="#{usermanagement.working-time.federalstate.select.label}"
-                      >
-                        Bundesland
-                      </label>
-                      <select
-                        id="federal-state-select"
-                        name="federalState"
-                        th:replace="~{fragments/select::one(id='federal-state-select', name='federalState', options=~{::federal-state-select-options}, testId='federal-state-select')}"
-                      >
-                        <th:block th:ref="federal-state-select-options">
-                          <optgroup
-                            th:each="optgroup : ${federalStateSelect.optgroups}"
-                            th:label="${#messages.msg(optgroup.labelMessageKey)}"
-                          >
-                            <option
-                              th:each="option : ${optgroup.options}"
-                              th:value="${option.value}"
-                              th:text="${#messages.msg(option.textMessageKey)}"
-                              th:selected="${option.selected}"
-                            ></option>
-                          </optgroup>
-                        </th:block>
-                      </select>
-                    </div>
-                    <div class="flex items-center gap-2">
-                      <input
-                        type="checkbox"
-                        id="works-on-public-holiday-checkbox"
-                        data-testid="works-on-public-holiday-checkbox"
-                        th:field="*{worksOnPublicHoliday}"
-                      />
-                      <label
-                        for="works-on-public-holiday-checkbox"
-                        th:text="#{settings.federal-state.works-on-public-holiday.label}"
-                      >
-                        arbeitet an Feiertagen
-                      </label>
-                    </div>
+                <div class="flex items-center gap-4">
+                  <div class="flex items-center">
+                    <label
+                      for="federal-state-select"
+                      class="sr-only"
+                      th:text="#{usermanagement.working-time.federalstate.select.label}"
+                    >
+                      Bundesland
+                    </label>
+                    <select
+                      id="federal-state-select"
+                      name="federalState"
+                      th:replace="~{fragments/select::one(id='federal-state-select', name='federalState', options=~{::federal-state-select-options}, testId='federal-state-select')}"
+                    >
+                      <th:block th:ref="federal-state-select-options">
+                        <optgroup
+                          th:each="optgroup : ${federalStateSelect.optgroups}"
+                          th:label="${#messages.msg(optgroup.labelMessageKey)}"
+                        >
+                          <option
+                            th:each="option : ${optgroup.options}"
+                            th:value="${option.value}"
+                            th:text="${#messages.msg(option.textMessageKey)}"
+                            th:selected="${option.selected}"
+                          ></option>
+                        </optgroup>
+                      </th:block>
+                    </select>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id="works-on-public-holiday-checkbox"
+                      data-testid="works-on-public-holiday-checkbox"
+                      th:field="*{worksOnPublicHoliday}"
+                    />
+                    <label
+                      for="works-on-public-holiday-checkbox"
+                      th:text="#{settings.federal-state.works-on-public-holiday.label}"
+                    >
+                      arbeitet an Feiertagen
+                    </label>
                   </div>
                 </div>
               </div>

--- a/src/main/resources/templates/settings/settings.html
+++ b/src/main/resources/templates/settings/settings.html
@@ -34,7 +34,7 @@
                 Lorem ipsum...
               </p>
               <div class="mt-4">
-                <div class="flex items-center gap-4">
+                <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
                   <div class="flex items-center">
                     <label
                       for="federal-state-select"

--- a/src/main/resources/templates/settings/settings.html
+++ b/src/main/resources/templates/settings/settings.html
@@ -17,94 +17,153 @@
               Lorem ipsum...
             </p>
           </div>
-          <div class="mt-8 lg:mt-12">
-            <h2 class="font-bold" th:text="#{settings.federal-state.heading}">
-              Feiertagsregelung
-            </h2>
-            <p
-              class="mt-2 text-gray-600"
-              th:text="#{settings.federal-state.teaser-text}"
-            >
-              Lorem ipsum...
-            </p>
-            <form
-              action="#"
-              th:action="@{/settings/federal-state}"
-              method="post"
-              th:object="${federalStateSettings}"
-              class="mt-4"
-            >
-              <div class="flex flex-col gap-8">
-                <div class="flex items-center gap-4">
-                  <div class="flex items-center">
-                    <label
-                      for="federal-state-select"
-                      class="sr-only"
-                      th:text="#{usermanagement.working-time.federalstate.select.label}"
-                    >
-                      Bundesland
-                    </label>
-                    <select
-                      id="federal-state-select"
-                      name="federalState"
-                      th:replace="~{fragments/select::one(id='federal-state-select', name='federalState', options=~{::federal-state-select-options}, testId='federal-state-select')}"
-                    >
-                      <th:block th:ref="federal-state-select-options">
-                        <optgroup
-                          th:each="optgroup : ${federalStateSelect.optgroups}"
-                          th:label="${#messages.msg(optgroup.labelMessageKey)}"
-                        >
-                          <option
-                            th:each="option : ${optgroup.options}"
-                            th:value="${option.value}"
-                            th:text="${#messages.msg(option.textMessageKey)}"
-                            th:selected="${option.selected}"
-                          ></option>
-                        </optgroup>
-                      </th:block>
-                    </select>
+          <form
+            action="#"
+            th:action="@{/settings}"
+            method="post"
+            th:object="${settings}"
+          >
+            <div class="mt-8 lg:mt-12">
+              <h2 class="font-bold" th:text="#{settings.federal-state.heading}">
+                Feiertagsregelung
+              </h2>
+              <p
+                class="mt-2 text-gray-600"
+                th:text="#{settings.federal-state.teaser-text}"
+              >
+                Lorem ipsum...
+              </p>
+              <div class="mt-4">
+                <div class="flex flex-col gap-8">
+                  <div class="flex items-center gap-4">
+                    <div class="flex items-center">
+                      <label
+                        for="federal-state-select"
+                        class="sr-only"
+                        th:text="#{usermanagement.working-time.federalstate.select.label}"
+                      >
+                        Bundesland
+                      </label>
+                      <select
+                        id="federal-state-select"
+                        name="federalState"
+                        th:replace="~{fragments/select::one(id='federal-state-select', name='federalState', options=~{::federal-state-select-options}, testId='federal-state-select')}"
+                      >
+                        <th:block th:ref="federal-state-select-options">
+                          <optgroup
+                            th:each="optgroup : ${federalStateSelect.optgroups}"
+                            th:label="${#messages.msg(optgroup.labelMessageKey)}"
+                          >
+                            <option
+                              th:each="option : ${optgroup.options}"
+                              th:value="${option.value}"
+                              th:text="${#messages.msg(option.textMessageKey)}"
+                              th:selected="${option.selected}"
+                            ></option>
+                          </optgroup>
+                        </th:block>
+                      </select>
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        id="works-on-public-holiday-checkbox"
+                        data-testid="works-on-public-holiday-checkbox"
+                        th:field="*{worksOnPublicHoliday}"
+                      />
+                      <label
+                        for="works-on-public-holiday-checkbox"
+                        th:text="#{settings.federal-state.works-on-public-holiday.label}"
+                      >
+                        arbeitet an Feiertagen
+                      </label>
+                    </div>
                   </div>
-                  <div class="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      id="works-on-public-holiday-checkbox"
-                      data-testid="works-on-public-holiday-checkbox"
-                      th:field="*{worksOnPublicHoliday}"
-                    />
-                    <label
-                      for="works-on-public-holiday-checkbox"
-                      th:text="#{settings.federal-state.works-on-public-holiday.label}"
-                    >
-                      arbeitet an Feiertagen
-                    </label>
-                  </div>
-                </div>
-                <div
-                  class="mt-8 flex flex-col gap-2 sm:flex-row sm:items-center"
-                >
-                  <button
-                    type="submit"
-                    class="button-primary button-primary-icon"
-                    data-testid="settings-submit-button"
-                  >
-                    <svg
-                      th:replace="~{icons/save::svg(className='w-5 h-5')}"
-                    ></svg>
-                    <th:block th:text="#{settings.save}"> Speichern </th:block>
-                  </button>
-                  <a
-                    id="settings-reset-button"
-                    href="#"
-                    th:href="@{/settings}"
-                    class="button-secondary"
-                    th:text="#{settings.reset}"
-                  >
-                    Zurücksetzen
-                  </a>
                 </div>
               </div>
-            </form>
-          </div>
+            </div>
+            <div class="mt-8 lg:mt-12">
+              <h2
+                class="font-bold"
+                th:text="#{settings.lock-timeentries.heading}"
+              >
+                Festschreiben von Zeitslots
+              </h2>
+              <p
+                class="mt-2 text-gray-600"
+                th:text="#{settings.lock-timeentries.teaser-text}"
+              >
+                Lorem ipsum...
+              </p>
+              <div class="mt-4">
+                <div class="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    id="locking-timeentries-is-active-checkbox"
+                    data-testid="locking-timeentries-is-active-checkbox"
+                    th:field="*{lockingIsActive}"
+                  />
+                  <label
+                    for="locking-timeentries-is-active-checkbox"
+                    th:text="#{settings.lock-timeentries-is-active.label}"
+                  >
+                    Festschreibung aktivieren
+                  </label>
+                </div>
+                <div
+                  class="mt-2"
+                  th:with="fieldName=${'lockTimeEntriesDaysInPast'}, hasError=${#fields.hasErrors(fieldName)}"
+                >
+                  <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <label
+                      for="lock-timeentries-days-in-past"
+                      th:text="#{settings.lock-timeentries-days-in-past.label}"
+                    >
+                      Anzahl der Tage vor Festschreibung
+                    </label>
+                    <input
+                      type="text"
+                      inputmode="numeric"
+                      id="lock-timeentries-days-in-past"
+                      data-testid="lock-timeentries-days-in-past"
+                      class="w-full border border-gray-300 px-2 py-1 sm:w-14"
+                      th:classappend="${hasError ? 'invalid' : ''}"
+                      th:aria-invalid="${hasError}"
+                      th:aria-message="${hasError ? fieldName + '-error-message' : ''}"
+                      th:field="*{lockTimeEntriesDaysInPast}"
+                    />
+                  </div>
+                  <p
+                    th:id="${fieldName + '-error-message'}"
+                    th:text="${#fields.errors(fieldName)[0]}"
+                    th:if="${hasError}"
+                    class="invalid"
+                  >
+                    Fehlernachricht
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div class="mt-8 flex flex-col gap-2 sm:flex-row sm:items-center">
+              <button
+                type="submit"
+                class="button-primary button-primary-icon"
+                data-testid="settings-submit-button"
+              >
+                <svg th:replace="~{icons/save::svg(className='w-5 h-5')}"></svg>
+                <th:block th:text="#{settings.save}"> Speichern </th:block>
+              </button>
+              <a
+                id="settings-reset-button"
+                href="#"
+                th:href="@{/settings}"
+                class="button-secondary"
+                th:text="#{settings.reset}"
+              >
+                Zurücksetzen
+              </a>
+            </div>
+          </form>
         </div>
       </main>
     </th:block>

--- a/src/main/resources/templates/timeclock/timeclock-edit-form.html
+++ b/src/main/resources/templates/timeclock/timeclock-edit-form.html
@@ -69,6 +69,7 @@
               id="input-clock-start-date"
               class="border border-gray-300 px-2 py-1 text-sm tabular-nums"
               name="date"
+              th:min="${minValidTimeEntryDate eq null ? null : #temporals.format(minValidTimeEntryDate, 'yyyy-MM-dd')}"
               th:value="${timeClock.date}"
               th:classappend="${hasDateError ? 'border-red-300' : ''}"
               th:aria-invalid="${hasDateError ?: 'true'}"

--- a/src/main/resources/templates/timeentries/fragments/time-entry-form.html
+++ b/src/main/resources/templates/timeentries/fragments/time-entry-form.html
@@ -16,7 +16,7 @@
         th:fragment="timeentry-slot-form-content(timeEntry, actions, class)"
         th:with="rnd=${#strings.randomAlphanumeric(6)}, disabled=${disabled ?: false}, showErrors=${showErrors ?: true}"
         class="flex flex-col-reverse md:flex-col"
-        th:classappend="${class}"
+        th:classappend="${class} + ' ' + ${disabled ? 'time-entry-slot-form--disabled' : ''}"
         th:object="${timeEntry}"
       >
         <input type="hidden" name="id" th:value="*{id}" />

--- a/src/main/resources/templates/timeentries/fragments/time-entry-form.html
+++ b/src/main/resources/templates/timeentries/fragments/time-entry-form.html
@@ -40,6 +40,7 @@
                 class="text-black"
                 value="2021-11-27"
                 th:value="${#temporals.format(timeEntry.date, 'yyyy-MM-dd')}"
+                th:min="${minValidTimeEntryDate eq null ? null : #temporals.format(minValidTimeEntryDate, 'yyyy-MM-dd')}"
                 data-iso-value="2021-11-27"
                 th:data-iso-value="${#temporals.format(timeEntry.date, 'yyyy-MM-dd')}"
                 data-js-hidden

--- a/src/main/resources/templates/timeentries/fragments/time-entry-form.html
+++ b/src/main/resources/templates/timeentries/fragments/time-entry-form.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <form
-      th:fragment="timeentry-slot-form(formAction, timeEntry, actions, class)"
+      th:fragment="timeentry-slot-form(formAction, timeEntry, actions, disabled, class)"
       is="z-time-entry-slot-form"
       action="#"
       th:action="${formAction}"
@@ -49,7 +49,8 @@
               <label
                 for="input-entry-date"
                 th:for="|${rnd}-input-entry-date|"
-                class="w-full flex cursor-pointer"
+                class="w-full flex"
+                th:classappend="${disabled ? '' : 'cursor-pointer'}"
               >
                 <span
                   data-day
@@ -218,7 +219,11 @@
             </div>
           </div>
           <th:block th:if="${actions}">
-            <div class="time-entry-box__controls" th:insert="${actions}"></div>
+            <div class="time-entry-box__controls">
+              <th:block th:if="${!disabled}">
+                <div th:replace="${actions}"></div>
+              </th:block>
+            </div>
           </th:block>
         </div>
         <div

--- a/src/main/resources/templates/timeentries/fragments/time-entry-form.html
+++ b/src/main/resources/templates/timeentries/fragments/time-entry-form.html
@@ -225,7 +225,9 @@
           data-error-container
           xtra:strip-whitespace="deep"
         >
-          <ul th:if="${showErrors && #fields.hasGlobalErrors()}">
+          <ul
+            th:if="${showErrors && timeEntry.id eq timeEntryErrorId && #fields.hasGlobalErrors()}"
+          >
             <li th:each="err : ${#fields.globalErrors()}" th:text="${err}">
               Etwas stimmt nicht, Jim.
             </li>

--- a/src/main/resources/templates/timeentries/index.html
+++ b/src/main/resources/templates/timeentries/index.html
@@ -75,7 +75,7 @@
               th:with="action=@{/timeentries}"
             >
               <th:block
-                th:insert="~{timeentries/fragments/time-entry-form::timeentry-slot-form(formAction=${action}, timeEntry=${timeEntry}, actions=~{::timeentry-slot-form-actions-new}, class='timeslot-form-new')}"
+                th:insert="~{timeentries/fragments/time-entry-form::timeentry-slot-form(formAction=${action}, timeEntry=${timeEntry}, actions=~{::timeentry-slot-form-actions-new}, disabled=false, class='timeslot-form-new')}"
               ></th:block>
             </th:block>
             <th:block
@@ -84,7 +84,7 @@
               th:with="action=@{/timeentries/users/{id} (id=${viewedUser.localId()})}"
             >
               <th:block
-                th:insert="~{timeentries/fragments/time-entry-form::timeentry-slot-form(formAction=${action}, timeEntry=${timeEntry}, actions=~{::timeentry-slot-form-actions-new}, class='timeslot-form-new')}"
+                th:insert="~{timeentries/fragments/time-entry-form::timeentry-slot-form(formAction=${action}, timeEntry=${timeEntry}, actions=~{::timeentry-slot-form-actions-new}, disabled=false, class='timeslot-form-new')}"
               ></th:block>
             </th:block>
           </div>
@@ -295,7 +295,17 @@
                           <div
                             class="relative flex justify-between gap-x-2 flex-wrap text-green-900 text-sm"
                           >
-                            <h4 class="font-medium" th:text="${day.date}"></h4>
+                            <h4 class="font-medium flex gap-1">
+                              <span th:if="${day.locked}">
+                                <svg
+                                  th:replace="~{icons/lock-keyhole::svg(className='w-4 h-4')}"
+                                />
+                                <span class="sr-only" th:text="#{date.locked}"
+                                  >Gesperrt</span
+                                >
+                              </span>
+                              <span th:text="${day.date}"></span>
+                            </h4>
                             <p
                               class="tabular-nums text-sm text-gray-800 font-medium sm:flex-1 sm:absolute sm:left-0 sm:right-0 sm:text-center"
                             >
@@ -403,7 +413,7 @@
                           data-turbo="true"
                         >
                           <th:block
-                            th:insert="~{timeentries/fragments/time-entry-form::timeentry-slot-form(formAction=${action}, timeEntry=${timeEntry}, actions=~{::timeentry-slot-form-actions-existing(${timeEntry})}, class='timeslot-form-existing')}"
+                            th:insert="~{timeentries/fragments/time-entry-form::timeentry-slot-form(formAction=${action}, timeEntry=${timeEntry}, actions=~{::timeentry-slot-form-actions-existing(${timeEntry})}, disabled=${day.locked}, class='timeslot-form-existing')}"
                           ></th:block>
                         </div>
                       </th:block>

--- a/src/main/resources/templates/timeentries/index.html
+++ b/src/main/resources/templates/timeentries/index.html
@@ -296,7 +296,7 @@
                             class="relative flex justify-between gap-x-2 flex-wrap text-green-900 text-sm"
                           >
                             <h4 class="font-medium flex gap-1">
-                              <span th:if="${day.locked}">
+                              <span class="content-center" th:if="${day.locked}">
                                 <svg
                                   th:replace="~{icons/lock-keyhole::svg(className='w-4 h-4')}"
                                 />

--- a/src/main/resources/templates/usermanagement/user/permission-settings.html
+++ b/src/main/resources/templates/usermanagement/user/permission-settings.html
@@ -83,22 +83,6 @@
                 </label>
               </div>
             </div>
-            <div class="mt-2 sm:mt-4">
-              <div class="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  id="permissions-working-time-edit-global-checkbox"
-                  th:field="*{workingTimeEditGlobal}"
-                />
-                <label
-                  for="permissions-working-time-edit-global-checkbox"
-                  th:text="#{usermanagement.permissions.working-time-edit-global.allowed.label}"
-                >
-                  darf die globale Arbeitszeit und Feiertagseinstellung
-                  bearbeiten
-                </label>
-              </div>
-            </div>
           </fieldset>
           <fieldset class="border-t border-gray-100">
             <legend
@@ -143,6 +127,30 @@
                   th:text="#{usermanagement.permissions.permissions-edit-all.allowed.label}"
                 >
                   darf die Berechtigungen aller Personen bearbeiten
+                </label>
+              </div>
+            </div>
+          </fieldset>
+          <fieldset class="border-t border-gray-100">
+            <legend
+              class="text-sm font-medium text-gray-400"
+              th:text="#{usermanagement.permissions.global-settings.title}"
+            >
+              Globale Einstellungen
+            </legend>
+            <div class="mt-2 sm:mt-4">
+              <div class="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="permissions-global-settings-checkbox"
+                  data-testid="global-settings-checkbox"
+                  th:field="*{globalSettings}"
+                />
+                <label
+                  for="permissions-global-settings-checkbox"
+                  th:text="#{usermanagement.permissions.global-settings.allowed.label}"
+                >
+                  darf die globalen Einstellungen bearbeiten
                 </label>
               </div>
             </div>

--- a/src/test/java/de/focusshift/zeiterfassung/ControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/ControllerTest.java
@@ -7,6 +7,7 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.OidcLoginRequestPostProcessor;
 
@@ -66,7 +67,13 @@ public interface ControllerTest {
 
         final List<GrantedAuthority> authorities =roles.stream().map(SecurityRole::authority).toList();
 
-        final DefaultOidcUser defaultOidcUser = new DefaultOidcUser(authorities, OidcIdToken.withTokenValue("token-value").claim("sub", userIdComposite.id().value()).build());
+        final OidcIdToken.Builder tokenBuilder = OidcIdToken.withTokenValue("token-value")
+            .claim("sub", userIdComposite.id().value());
+
+        final OidcUserInfo.Builder userInfoBuilder = OidcUserInfo.builder()
+            .subject(userIdComposite.id().value());
+
+        final DefaultOidcUser defaultOidcUser = new DefaultOidcUser(authorities, tokenBuilder.build(), userInfoBuilder.build());
         final CurrentOidcUser currentUser = new CurrentOidcUser(defaultOidcUser, List.of(), authorities, userIdComposite.localId());
 
         return oidcLogin().oidcUser(currentUser);

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
@@ -102,7 +102,7 @@ class ReportCsvServiceTest {
         final ZonedDateTime from = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
         final ZonedDateTime to = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 30), ZONE_ID_BERLIN);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(null, batman, "hard work", from, to, false);
-        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), false, workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
 
         when(reportService.getReportWeek(Year.of(2021), 1, List.of(batmanLocalId)))
             .thenReturn(new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDay)));
@@ -145,13 +145,13 @@ class ReportCsvServiceTest {
         final ZonedDateTime dayOneSecondFrom = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
         final ZonedDateTime dayOneSecondTo = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
         final ReportDayEntry dayOneSecondReportDayEntry = new ReportDayEntry(null, batman, "hard work", dayOneSecondFrom, dayOneSecondTo, false);
-        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayOneFirstReportDayEntry, dayOneSecondReportDayEntry)), Map.of());
+        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), false, workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayOneFirstReportDayEntry, dayOneSecondReportDayEntry)), Map.of());
 
         // day two
         final ZonedDateTime dayTwoFrom = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
         final ZonedDateTime dayTwoTo = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
         final ReportDayEntry dayTwoReportDayEntry = new ReportDayEntry(null, batman, "hard work", dayTwoFrom, dayTwoTo, false);
-        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayTwoReportDayEntry)), Map.of());
+        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), false, workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayTwoReportDayEntry)), Map.of());
 
         when(reportService.getReportWeek(Year.of(2021), 1, List.of(batmanLocalId)))
             .thenReturn(new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDayOne, reportDayTwo)));
@@ -209,7 +209,7 @@ class ReportCsvServiceTest {
         final ZonedDateTime from = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
         final ZonedDateTime to = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 30), ZONE_ID_BERLIN);
         final ReportDayEntry reportDayEntry = new ReportDayEntry(null, batman, "hard work", from, to, false);
-        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), false, workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
 
         final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDay));
         final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of());
@@ -258,13 +258,13 @@ class ReportCsvServiceTest {
         final ZonedDateTime dayOneSecondFrom = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 14, 0), ZONE_ID_BERLIN);
         final ZonedDateTime dayOneSecondTo = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 15, 0), ZONE_ID_BERLIN);
         final ReportDayEntry dayOneSecondReportDayEntry = new ReportDayEntry(null, batman, "hard work", dayOneSecondFrom, dayOneSecondTo, false);
-        final ReportDay weekOneReportDay = new ReportDay(LocalDate.of(2021, 1, 4), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayOneFirstReportDayEntry, dayOneSecondReportDayEntry)), Map.of());
+        final ReportDay weekOneReportDay = new ReportDay(LocalDate.of(2021, 1, 4), false, workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayOneFirstReportDayEntry, dayOneSecondReportDayEntry)), Map.of());
 
         // week two, day one
         final ZonedDateTime dayTwoFrom = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 9, 0), ZONE_ID_BERLIN);
         final ZonedDateTime dayTwoTo = ZonedDateTime.of(LocalDateTime.of(2021, 1, 5, 17, 0), ZONE_ID_BERLIN);
         final ReportDayEntry dayTwoReportDayEntry = new ReportDayEntry(null, batman, "hard work", dayTwoFrom, dayTwoTo, false);
-        final ReportDay weekTwoReportDay = new ReportDay(LocalDate.of(2021, 1, 5), workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayTwoReportDayEntry)), Map.of());
+        final ReportDay weekTwoReportDay = new ReportDay(LocalDate.of(2021, 1, 5), false, workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(dayTwoReportDayEntry)), Map.of());
 
         final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(weekOneReportDay));
         final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of(weekTwoReportDay));

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportDayTest.java
@@ -45,7 +45,7 @@ class ReportDayTest {
         final ReportDayEntry reportDayEntry = new ReportDayEntry(null, batman, "hard work", from, to, true);
 
         final LocalDate reportDate = LocalDate.of(2024, 11, 13);
-        final ReportDay sut = new ReportDay(reportDate, Map.of(), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
+        final ReportDay sut = new ReportDay(reportDate, false, Map.of(), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
 
         final List<ReportDayEntry> reportDayEntries = sut.reportDayEntries();
         assertThat(reportDayEntries)
@@ -67,7 +67,7 @@ class ReportDayTest {
 
         final ReportDay sut = new ReportDay(
             reportDate,
-            Map.of(
+            false, Map.of(
                 batmanIdComposite, new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of()),
                 robinIdComposite, new WorkingTimeCalendar(Map.of(reportDate, new PlannedWorkingHours(Duration.ofHours(4))), Map.of())
             ),
@@ -88,7 +88,7 @@ class ReportDayTest {
 
         final ReportDay sut = new ReportDay(
             reportDate,
-            Map.of(
+            false, Map.of(
                 batmanIdComposite, new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of()),
                 robinIdComposite, new WorkingTimeCalendar(Map.of(reportDate, new PlannedWorkingHours(Duration.ofHours(4))), Map.of()),
                 // enforce empty optional value while calculating planned working hours
@@ -120,7 +120,7 @@ class ReportDayTest {
         final LocalDate reportDate = LocalDate.of(2021, 1, 4);
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of());
 
-        final ReportDay sut = new ReportDay(reportDate, Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
+        final ReportDay sut = new ReportDay(reportDate, false, Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of());
         assertThat(sut.workDuration().duration()).isEqualTo(Duration.ZERO);
     }
 
@@ -139,7 +139,7 @@ class ReportDayTest {
         final LocalDate reportDate = LocalDate.of(2021, 1, 4);
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of(reportDate, List.of(absence)));
 
-        final ReportDay sut = new ReportDay(reportDate, Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence))));
+        final ReportDay sut = new ReportDay(reportDate, false, Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence))));
         assertThat(sut.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ZERO));
     }
 
@@ -159,7 +159,7 @@ class ReportDayTest {
         final LocalDate reportDate = LocalDate.of(2021, 1, 4);
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(reportDate, PlannedWorkingHours.EIGHT), Map.of(reportDate, List.of(absence)));
 
-        final ReportDay sut = new ReportDay(LocalDate.of(2021, 1, 4), Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence))));
+        final ReportDay sut = new ReportDay(LocalDate.of(2021, 1, 4), false, Map.of(batmanIdComposite, workingTimeCalendar), Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, List.of(new ReportDayAbsence(batman, absence))));
         assertThat(sut.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ofHours(4)));
     }
 
@@ -192,7 +192,7 @@ class ReportDayTest {
                 Map.of(reportDate, List.of()))
         );
 
-        final ReportDay sut = new ReportDay(reportDate, plannedWorkingHoursByUser, entriesByUser, absencesByUser);
+        final ReportDay sut = new ReportDay(reportDate, false, plannedWorkingHoursByUser, entriesByUser, absencesByUser);
         assertThat(sut.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ofHours(4L)));
     }
 
@@ -225,7 +225,7 @@ class ReportDayTest {
                 Map.of(reportDate, List.of()))
         );
 
-        final ReportDay sut = new ReportDay(reportDate, plannedWorkingHoursByUser, entriesByUser, absencesByUser);
+        final ReportDay sut = new ReportDay(reportDate, false, plannedWorkingHoursByUser, entriesByUser, absencesByUser);
         assertThat(sut.shouldWorkingHours()).isEqualTo(new ShouldWorkingHours(Duration.ofHours(8L)));
     }
 

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
@@ -6,6 +6,7 @@ import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryDTO;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryDialogHelper;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryId;
+import de.focusshift.zeiterfassung.timeentry.TimeEntryLockService;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryService;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryViewHelper;
 import de.focusshift.zeiterfassung.user.DateFormatterImpl;
@@ -75,6 +76,8 @@ class ReportMonthControllerTest implements ControllerTest {
     @Mock
     private TimeEntryService timeEntryService;
     @Mock
+    private TimeEntryLockService timeEntryLockService;
+    @Mock
     private UserSettingsProvider userSettingsProvider;
     @Mock
     private UserManagementService userManagementService;
@@ -94,7 +97,7 @@ class ReportMonthControllerTest implements ControllerTest {
         dateFormatter = new DateFormatterImpl();
         dateRangeFormatter = new DateRangeFormatter(dateFormatter, messageSource);
         reportViewHelper = new ReportViewHelper(dateFormatter, dateRangeFormatter);
-        timeEntryViewHelper = new TimeEntryViewHelper(timeEntryService, userSettingsProvider);
+        timeEntryViewHelper = new TimeEntryViewHelper(timeEntryService, timeEntryLockService, userSettingsProvider);
         timeEntryDialogHelper = new TimeEntryDialogHelper(timeEntryService, timeEntryViewHelper, userSettingsProvider, userManagementService);
         sut = new ReportMonthController(reportService, reportPermissionService, dateFormatter, reportViewHelper, timeEntryDialogHelper, clock);
     }

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
@@ -568,13 +568,13 @@ class ReportMonthControllerTest implements ControllerTest {
             eightHoursDay(firstDateOfWeek.plusDays(4), user),
             new ReportDay(
                 firstDateOfWeek.plusDays(5),
-                Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(firstDateOfWeek.plusDays(5), PlannedWorkingHours.ZERO), Map.of(firstDateOfWeek.plusDays(5), List.of()))),
+                false, Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(firstDateOfWeek.plusDays(5), PlannedWorkingHours.ZERO), Map.of(firstDateOfWeek.plusDays(5), List.of()))),
                 Map.of(user.userIdComposite(), List.of()),
                 Map.of(user.userIdComposite(), List.of())
             ),
             new ReportDay(
                 firstDateOfWeek.plusDays(6),
-                Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(firstDateOfWeek.plusDays(6), PlannedWorkingHours.ZERO), Map.of(firstDateOfWeek.plusDays(6), List.of()))),
+                false, Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(firstDateOfWeek.plusDays(6), PlannedWorkingHours.ZERO), Map.of(firstDateOfWeek.plusDays(6), List.of()))),
                 Map.of(user.userIdComposite(), List.of()),
                 Map.of(user.userIdComposite(), List.of())
             ))
@@ -584,7 +584,7 @@ class ReportMonthControllerTest implements ControllerTest {
     private ReportDay eightHoursDay(LocalDate date, User user) {
         return new ReportDay(
             date,
-            Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(date, PlannedWorkingHours.EIGHT), Map.of(date, List.of()))),
+            false, Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(date, PlannedWorkingHours.EIGHT), Map.of(date, List.of()))),
             Map.of(user.userIdComposite(), List.of(reportDayEntry(user, date))),
             Map.of(user.userIdComposite(), List.of())
         );
@@ -593,7 +593,7 @@ class ReportMonthControllerTest implements ControllerTest {
     private ReportDay zeroHoursDay(LocalDate date, User user) {
         return new ReportDay(
             date,
-            Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(date, PlannedWorkingHours.ZERO), Map.of(date, List.of()))),
+            false, Map.of(user.userIdComposite(), new WorkingTimeCalendar(Map.of(date, PlannedWorkingHours.ZERO), Map.of(date, List.of()))),
             Map.of(user.userIdComposite(), List.of()),
             Map.of(user.userIdComposite(), List.of())
         );

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
@@ -98,7 +98,7 @@ class ReportMonthControllerTest implements ControllerTest {
         dateRangeFormatter = new DateRangeFormatter(dateFormatter, messageSource);
         reportViewHelper = new ReportViewHelper(dateFormatter, dateRangeFormatter);
         timeEntryViewHelper = new TimeEntryViewHelper(timeEntryService, timeEntryLockService, userSettingsProvider);
-        timeEntryDialogHelper = new TimeEntryDialogHelper(timeEntryService, timeEntryViewHelper, userSettingsProvider, userManagementService);
+        timeEntryDialogHelper = new TimeEntryDialogHelper(timeEntryService, timeEntryLockService, timeEntryViewHelper, userSettingsProvider, userManagementService);
         sut = new ReportMonthController(reportService, reportPermissionService, dateFormatter, reportViewHelper, timeEntryDialogHelper, clock);
     }
 

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthTest.java
@@ -75,20 +75,20 @@ class ReportMonthTest {
 
         return new ReportWeek(firstDateOfWeek, List.of(
             // january
-            new ReportDay(firstDateOfWeek, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(tuesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(firstDateOfWeek, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(tuesday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
             // february
-            new ReportDay(wednesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
+            new ReportDay(wednesday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
+            new ReportDay(thursday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
+            new ReportDay(friday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of())
+            new ReportDay(saturday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
     }
 
@@ -117,23 +117,23 @@ class ReportMonthTest {
         );
 
         return new ReportWeek(firstDateOfWeek, List.of(
-            new ReportDay(firstDateOfWeek, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
+            new ReportDay(firstDateOfWeek, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(firstDateOfWeek, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(firstDateOfWeek, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
+            new ReportDay(tuesday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(tuesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(tuesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(wednesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
+            new ReportDay(wednesday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
+            new ReportDay(thursday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
+            new ReportDay(friday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of())
+            new ReportDay(saturday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
     }
 
@@ -163,18 +163,18 @@ class ReportMonthTest {
 
         return new ReportWeek(firstDateOfWeek, List.of(
             // february
-            new ReportDay(firstDateOfWeek, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
+            new ReportDay(firstDateOfWeek, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
+            new ReportDay(tuesday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
             // march
-            new ReportDay(wednesday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(thursday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(friday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(saturday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of())
+            new ReportDay(wednesday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(thursday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(friday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(saturday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, false, workingTimeCalendarByUser, Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportServicePermissionAwareTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportServicePermissionAwareTest.java
@@ -1,5 +1,6 @@
 package de.focusshift.zeiterfassung.report;
 
+import de.focusshift.zeiterfassung.timeentry.TimeEntryLockService;
 import de.focusshift.zeiterfassung.user.UserDateService;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,10 +29,12 @@ class ReportServicePermissionAwareTest {
     private ReportServiceRaw reportServiceRaw;
     @Mock
     private UserDateService userDateService;
+    @Mock
+    private TimeEntryLockService timeEntryLockService;
 
     @BeforeEach
     void setUp() {
-        sut = new ReportServicePermissionAware(reportPermissionService, reportServiceRaw, userDateService);
+        sut = new ReportServicePermissionAware(reportPermissionService, reportServiceRaw, userDateService, timeEntryLockService);
     }
 
     @Test
@@ -51,13 +54,13 @@ class ReportServicePermissionAwareTest {
         assertThat(actual).isNotNull();
         assertThat(actual.firstDateOfWeek()).isEqualTo(LocalDate.of(2023, 2, 13));
         assertThat(actual.reportDays()).containsExactly(
-            new ReportDay(LocalDate.of(2023, 2, 13), Map.of(), Map.of(), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 14), Map.of(), Map.of(), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 15), Map.of(), Map.of(), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 16), Map.of(), Map.of(), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 17), Map.of(), Map.of(), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 18), Map.of(), Map.of(), Map.of()),
-            new ReportDay(LocalDate.of(2023, 2, 19), Map.of(), Map.of(), Map.of())
+            new ReportDay(LocalDate.of(2023, 2, 13), false, Map.of(), Map.of(), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 14), false, Map.of(), Map.of(), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 15), false, Map.of(), Map.of(), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 16), false, Map.of(), Map.of(), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 17), false, Map.of(), Map.of(), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 18), false, Map.of(), Map.of(), Map.of()),
+            new ReportDay(LocalDate.of(2023, 2, 19), false, Map.of(), Map.of(), Map.of())
         );
     }
 
@@ -83,65 +86,65 @@ class ReportServicePermissionAwareTest {
         assertThat(actual.weeks().get(0)).satisfies(week -> {
             assertThat(week.firstDateOfWeek()).isEqualTo(LocalDate.of(2023, 1, 30));
             assertThat(week.reportDays()).containsExactly(
-                new ReportDay(LocalDate.of(2023, 1, 30), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 1, 31), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 1), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 2), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 3), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 4), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 5), Map.of(), Map.of(), Map.of())
+                new ReportDay(LocalDate.of(2023, 1, 30), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 1, 31), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 1), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 2), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 3), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 4), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 5), false, Map.of(), Map.of(), Map.of())
             );
         });
 
         assertThat(actual.weeks().get(1)).satisfies(week -> {
             assertThat(week.firstDateOfWeek()).isEqualTo(LocalDate.of(2023, 2, 6));
             assertThat(week.reportDays()).containsExactly(
-                new ReportDay(LocalDate.of(2023, 2, 6), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 7), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 8), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 9), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 10), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 11), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 12), Map.of(), Map.of(), Map.of())
+                new ReportDay(LocalDate.of(2023, 2, 6), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 7), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 8), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 9), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 10), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 11), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 12), false, Map.of(), Map.of(), Map.of())
             );
         });
 
         assertThat(actual.weeks().get(2)).satisfies(week -> {
             assertThat(week.firstDateOfWeek()).isEqualTo(LocalDate.of(2023, 2, 13));
             assertThat(week.reportDays()).containsExactly(
-                new ReportDay(LocalDate.of(2023, 2, 13), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 14), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 15), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 16), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 17), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 18), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 19), Map.of(), Map.of(), Map.of())
+                new ReportDay(LocalDate.of(2023, 2, 13), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 14), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 15), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 16), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 17), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 18), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 19), false, Map.of(), Map.of(), Map.of())
             );
         });
 
         assertThat(actual.weeks().get(3)).satisfies(week -> {
             assertThat(week.firstDateOfWeek()).isEqualTo(LocalDate.of(2023, 2, 20));
             assertThat(week.reportDays()).containsExactly(
-                new ReportDay(LocalDate.of(2023, 2, 20), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 21), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 22), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 23), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 24), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 25), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 26), Map.of(), Map.of(), Map.of())
+                new ReportDay(LocalDate.of(2023, 2, 20), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 21), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 22), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 23), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 24), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 25), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 26), false, Map.of(), Map.of(), Map.of())
             );
         });
 
         assertThat(actual.weeks().get(4)).satisfies(week -> {
             assertThat(week.firstDateOfWeek()).isEqualTo(LocalDate.of(2023, 2, 27));
             assertThat(week.reportDays()).containsExactly(
-                new ReportDay(LocalDate.of(2023, 2, 27), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 2, 28), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 3, 1), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 3, 2), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 3, 3), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 3, 4), Map.of(), Map.of(), Map.of()),
-                new ReportDay(LocalDate.of(2023, 3, 5), Map.of(), Map.of(), Map.of())
+                new ReportDay(LocalDate.of(2023, 2, 27), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 2, 28), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 3, 1), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 3, 2), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 3, 3), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 3, 4), false, Map.of(), Map.of(), Map.of()),
+                new ReportDay(LocalDate.of(2023, 3, 5), false, Map.of(), Map.of(), Map.of())
             );
         });
     }

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportServiceRawTest.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.report;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.timeentry.TimeEntry;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryId;
+import de.focusshift.zeiterfassung.timeentry.TimeEntryLockService;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryService;
 import de.focusshift.zeiterfassung.user.UserDateService;
 import de.focusshift.zeiterfassung.user.UserId;
@@ -56,9 +57,12 @@ class ReportServiceRawTest {
     @Mock
     private WorkingTimeCalendarService workingTimeCalendarService;
 
+    @Mock
+    private TimeEntryLockService timeEntryLockService;
+
     @BeforeEach
     void setUp() {
-        sut = new ReportServiceRaw(timeEntryService, userManagementService, userDateService, workingTimeCalendarService);
+        sut = new ReportServiceRaw(timeEntryService, userManagementService, userDateService, workingTimeCalendarService, timeEntryLockService);
     }
 
     // ------------------------------------------------------------

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
@@ -135,13 +135,13 @@ class ReportWeekControllerTest implements ControllerTest {
             eightHoursDay(LocalDate.of(2023, 2, 3), user, workingTimeCalendar),
             new ReportDay(
                 LocalDate.of(2023, 2, 4),
-                Map.of(userIdComposite, workingTimeCalendar),
+                false, Map.of(userIdComposite, workingTimeCalendar),
                 Map.of(userIdComposite, List.of()),
                 Map.of(userIdComposite, List.of())
             ),
             new ReportDay(
                 LocalDate.of(2023, 2, 5),
-                Map.of(userIdComposite, workingTimeCalendar),
+                false, Map.of(userIdComposite, workingTimeCalendar),
                 Map.of(userIdComposite, List.of()),
                 Map.of(userIdComposite, List.of())
             )
@@ -206,7 +206,7 @@ class ReportWeekControllerTest implements ControllerTest {
         final ReportWeek reportWeek = new ReportWeek(LocalDate.of(2023, 1, 30), List.of(
             new ReportDay(
                 absenceDate,
-                Map.of(userIdComposite, workingTimeCalendar),
+                false, Map.of(userIdComposite, workingTimeCalendar),
                 Map.of(userIdComposite, List.of()),
                 Map.of(userIdComposite, List.of(
                     new ReportDayAbsence(user, absence)
@@ -222,7 +222,7 @@ class ReportWeekControllerTest implements ControllerTest {
             Date.from(ZonedDateTime.of(LocalDate.of(2023, 2,5), LocalTime.MIN, ZoneId.systemDefault()).toInstant()),
             5,
             List.of(
-                new DetailDayDto(true, "F", "Freitag", "03.02.2023", "00:00", "00:00", "00:00", false, List.of(),
+                new DetailDayDto(true, "F", "Freitag", "03.02.2023", false, "00:00", "00:00", "00:00", false, List.of(),
                     List.of(
                         new DetailDayAbsenceDto(
                             "Bruce Wayne",
@@ -547,7 +547,7 @@ class ReportWeekControllerTest implements ControllerTest {
     private ReportDay eightHoursDay(LocalDate date, User user, WorkingTimeCalendar workingTimeCalendar) {
         return new ReportDay(
             date,
-            Map.of(user.userIdComposite(), workingTimeCalendar),
+            false, Map.of(user.userIdComposite(), workingTimeCalendar),
             Map.of(user.userIdComposite(), List.of(reportDayEntry(user, date))),
             Map.of(user.userIdComposite(), List.of())
         );

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekTest.java
@@ -41,12 +41,12 @@ class ReportWeekTest {
 
         LocalDate date = LocalDate.of(2023, 2, 13);
         final ReportWeek sut = new ReportWeek(date, List.of(
-            new ReportDay(date, Map.of(userIdComposite, zeroHoursDay(date)), Map.of(userIdComposite, List.of()), Map.of()),
-            new ReportDay(date.plusDays(1), Map.of(userIdComposite, zeroHoursDay(date.plusDays(1))), Map.of(userIdComposite, List.of()), Map.of()),
-            new ReportDay(date.plusDays(2), Map.of(userIdComposite, zeroHoursDay(date.plusDays(2))), Map.of(userIdComposite, List.of()), Map.of()),
-            new ReportDay(date.plusDays(3), Map.of(userIdComposite, zeroHoursDay(date.plusDays(3))), Map.of(userIdComposite, List.of()), Map.of()),
-            new ReportDay(date.plusDays(4), Map.of(userIdComposite, zeroHoursDay(date.plusDays(4))), Map.of(userIdComposite, List.of()), Map.of()),
-            new ReportDay(date.plusDays(5), Map.of(userIdComposite, zeroHoursDay(date.plusDays(5))), Map.of(userIdComposite, List.of()), Map.of())
+            new ReportDay(date, false, Map.of(userIdComposite, zeroHoursDay(date)), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(date.plusDays(1), false, Map.of(userIdComposite, zeroHoursDay(date.plusDays(1))), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(date.plusDays(2), false, Map.of(userIdComposite, zeroHoursDay(date.plusDays(2))), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(date.plusDays(3), false, Map.of(userIdComposite, zeroHoursDay(date.plusDays(3))), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(date.plusDays(4), false, Map.of(userIdComposite, zeroHoursDay(date.plusDays(4))), Map.of(userIdComposite, List.of()), Map.of()),
+            new ReportDay(date.plusDays(5), false, Map.of(userIdComposite, zeroHoursDay(date.plusDays(5))), Map.of(userIdComposite, List.of()), Map.of())
         ));
 
         assertThat(sut.averageDayWorkDuration()).isEqualTo(WorkDuration.ZERO);
@@ -72,23 +72,23 @@ class ReportWeekTest {
         final LocalDate sunday = monday.plusDays(6);
 
         final ReportWeek sut = new ReportWeek(monday, List.of(
-            new ReportDay(monday, Map.of(user.userIdComposite(), eightHoursDay(monday)), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(monday, false, Map.of(user.userIdComposite(), eightHoursDay(monday)), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(monday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(monday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(tuesday, Map.of(user.userIdComposite(), eightHoursDay(tuesday)), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(tuesday, false, Map.of(user.userIdComposite(), eightHoursDay(tuesday)), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(tuesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(tuesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(wednesday, Map.of(user.userIdComposite(), eightHoursDay(wednesday)), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(wednesday, false, Map.of(user.userIdComposite(), eightHoursDay(wednesday)), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(wednesday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(wednesday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(thursday, Map.of(user.userIdComposite(), eightHoursDay(thursday)), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(thursday, false, Map.of(user.userIdComposite(), eightHoursDay(thursday)), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(thursday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(thursday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(friday, Map.of(user.userIdComposite(), eightHoursDay(friday)), Map.of(user.userIdComposite(), List.of(
+            new ReportDay(friday, false, Map.of(user.userIdComposite(), eightHoursDay(friday)), Map.of(user.userIdComposite(), List.of(
                 new ReportDayEntry(null, user, "", ZonedDateTime.of(LocalDateTime.of(friday, timeStart), UTC), ZonedDateTime.of(LocalDateTime.of(friday, timeEnd), UTC), false)
             )), Map.of()),
-            new ReportDay(saturday, Map.of(user.userIdComposite(), zeroHoursDay(saturday)), Map.of(user.userIdComposite(), List.of()), Map.of()),
-            new ReportDay(sunday, Map.of(user.userIdComposite(), zeroHoursDay(sunday)), Map.of(user.userIdComposite(), List.of()), Map.of())
+            new ReportDay(saturday, false, Map.of(user.userIdComposite(), zeroHoursDay(saturday)), Map.of(user.userIdComposite(), List.of()), Map.of()),
+            new ReportDay(sunday, false, Map.of(user.userIdComposite(), zeroHoursDay(sunday)), Map.of(user.userIdComposite(), List.of()), Map.of())
         ));
 
         final WorkDuration actual = sut.averageDayWorkDuration();

--- a/src/test/java/de/focusshift/zeiterfassung/settings/SettingsControllerSecurityIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/settings/SettingsControllerSecurityIT.java
@@ -1,0 +1,85 @@
+package de.focusshift.zeiterfassung.settings;
+
+import de.focusshift.zeiterfassung.ControllerTest;
+import de.focusshift.zeiterfassung.SingleTenantTestContainersBase;
+import de.focusshift.zeiterfassung.security.SecurityRole;
+import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
+import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_USER;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SettingsControllerSecurityIT extends SingleTenantTestContainersBase implements ControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @ParameterizedTest
+    @EnumSource(value = SecurityRole.class, names = {"ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL", "ZEITERFASSUNG_SETTINGS_GLOBAL"}, mode = EnumSource.Mode.EXCLUDE)
+    void ensureGetSettingsForbidden(SecurityRole role) throws Exception {
+
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserId userId = new UserId(UUID.randomUUID().toString());
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
+        mockMvc.perform(get("/settings").with(oidcSubject(userIdComposite, List.of(role))))
+            .andExpect(status().isForbidden());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SecurityRole.class, names = {"ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL", "ZEITERFASSUNG_SETTINGS_GLOBAL"}, mode = EnumSource.Mode.INCLUDE)
+    void ensureGetSettingsIsAllowed(SecurityRole role) throws Exception {
+
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserId userId = new UserId(UUID.randomUUID().toString());
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
+        mockMvc.perform(get("/settings").with(oidcSubject(userIdComposite, List.of(ZEITERFASSUNG_USER, role))))
+            .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SecurityRole.class, names = {"ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL", "ZEITERFASSUNG_SETTINGS_GLOBAL"}, mode = EnumSource.Mode.EXCLUDE)
+    void ensureUpdateSettingsForbidden(SecurityRole role) throws Exception {
+
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserId userId = new UserId(UUID.randomUUID().toString());
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
+        mockMvc.perform(post("/settings").with(oidcSubject(userIdComposite, List.of(role))))
+            .andExpect(status().isForbidden());
+    }
+
+    @Disabled("This returns 403 instead of 200. Why?")
+    @ParameterizedTest
+    @EnumSource(value = SecurityRole.class, names = {"ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL", "ZEITERFASSUNG_SETTINGS_GLOBAL"}, mode = EnumSource.Mode.INCLUDE)
+    void ensureUpdateSettingsIsAllowed(SecurityRole role) throws Exception {
+
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserId userId = new UserId(UUID.randomUUID().toString());
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+
+        mockMvc.perform(post("/settings").with(oidcSubject(userIdComposite, List.of(ZEITERFASSUNG_USER, role)))
+                .param("federalState", "NONE")
+                .param("worksOnPublicHoliday", "false")
+                .param("lockingIsActive", "false")
+                .param("lockTimeEntriesDaysInPast", "1")
+            )
+            .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/settings/SettingsControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/settings/SettingsControllerTest.java
@@ -1,0 +1,160 @@
+package de.focusshift.zeiterfassung.settings;
+
+import de.focusshift.zeiterfassung.ControllerTest;
+import de.focusshift.zeiterfassung.publicholiday.FederalState;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+@ExtendWith(MockitoExtension.class)
+class SettingsControllerTest implements ControllerTest {
+
+    private SettingsController sut;
+
+    @Mock
+    private SettingsService settingsService;
+
+    @BeforeEach
+    void setUp() {
+        sut = new SettingsController(settingsService);
+    }
+
+    @Test
+    void ensureGetSettingsForbidden() {
+
+        assertThatThrownBy(() -> {
+            perform(get("/settings"));
+        })
+            .isInstanceOf(ServletException.class)
+            .hasCauseInstanceOf(AccessDeniedException.class);
+
+        verifyNoMoreInteractions(settingsService);
+    }
+
+    @Test
+    void ensureGetSettings() throws Exception {
+
+        final FederalStateSettings federalStateSettings = new FederalStateSettings(FederalState.NONE, false);
+        final LockTimeEntriesSettings lockTimeEntriesSettings = new LockTimeEntriesSettings(true, 42);
+
+        when(settingsService.getFederalStateSettings()).thenReturn(federalStateSettings);
+        when(settingsService.getLockTimeEntriesSettings()).thenReturn(lockTimeEntriesSettings);
+
+        final SettingsDto expectedSettingsDto = new SettingsDto(FederalState.NONE, false, true, 42);
+
+        perform(get("/settings"))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("settings", expectedSettingsDto));
+    }
+
+    @Test
+    void ensureGetSettingsWithDisabledLockTimeEntriesSettings() throws Exception {
+
+        final FederalStateSettings federalStateSettings = new FederalStateSettings(FederalState.NONE, false);
+        final LockTimeEntriesSettings lockTimeEntriesSettings = new LockTimeEntriesSettings(false, -1);
+
+        when(settingsService.getFederalStateSettings()).thenReturn(federalStateSettings);
+        when(settingsService.getLockTimeEntriesSettings()).thenReturn(lockTimeEntriesSettings);
+
+        final SettingsDto expectedSettingsDto = new SettingsDto(FederalState.NONE, false, false, null);
+
+        perform(get("/settings"))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("settings", expectedSettingsDto));
+    }
+
+    @Test
+    void ensureUpdateSettingsRedirectsToSettings() throws Exception {
+
+        perform(post("/settings")
+            .param("federalState", "NONE")
+            .param("worksOnPublicHoliday", "false")
+            .param("lockingIsActive", "true")
+            .param("lockTimeEntriesDaysInPast", "42")
+        )
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/settings"));
+
+        verify(settingsService).updateFederalStateSettings(FederalState.NONE, false);
+        verify(settingsService).updateLockTimeEntriesSettings(true, 42);
+    }
+
+    @Test
+    void ensureUpdateSettingsValidatesLockTimeEntriesDaysInPastMustNotBeNegative() throws Exception {
+
+        perform(post("/settings")
+            .param("federalState", "NONE")
+            .param("worksOnPublicHoliday", "false")
+            .param("lockingIsActive", "true")
+            .param("lockTimeEntriesDaysInPast", "-1")
+        )
+            .andExpect(status().isOk())
+            .andExpect(view().name("settings/settings"))
+            .andExpect(model().attributeHasFieldErrorCode("settings", "lockTimeEntriesDaysInPast", "PositiveOrZero"));
+
+        verifyNoInteractions(settingsService);
+    }
+
+    @Test
+    void ensureUpdateLockTimeSettingsWithDisabledLockingAllowsEmptyDaysInPastInput() throws Exception {
+
+        perform(post("/settings")
+            .param("federalState", "NONE")
+            .param("worksOnPublicHoliday", "false")
+            .param("lockingIsActive", "false")
+        )
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/settings"));
+
+        verify(settingsService).updateFederalStateSettings(FederalState.NONE, false);
+        verify(settingsService).updateLockTimeEntriesSettings(false, -1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 1 })
+    void ensureUpdateLockTimeSettingsWithDisabledLockingAndZeroOrPositiveDaysInPast(int daysInPast) throws Exception {
+
+        perform(post("/settings")
+            .param("federalState", "NONE")
+            .param("worksOnPublicHoliday", "false")
+            .param("lockingIsActive", "false")
+            .param("lockTimeEntriesDaysInPast", String.valueOf(daysInPast))
+        )
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/settings"));
+
+        verify(settingsService).updateLockTimeEntriesSettings(false, daysInPast);
+    }
+
+    private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {
+        return standaloneSetup(sut)
+            .addFilters(new SecurityContextHolderFilter(new HttpSessionSecurityContextRepository()))
+            .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+            .build()
+            .perform(builder);
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/settings/SettingsServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/settings/SettingsServiceTest.java
@@ -1,0 +1,108 @@
+package de.focusshift.zeiterfassung.settings;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SettingsServiceTest {
+
+    private SettingsService sut;
+
+    @Mock
+    private FederalStateSettingsRepository federalStateSettingsRepository;
+    @Mock
+    private LockTimeEntriesSettingsRepository lockTimeEntriesSettingsRepository;
+
+    @BeforeEach
+    void setUp() {
+        sut = new SettingsService(federalStateSettingsRepository, lockTimeEntriesSettingsRepository);
+    }
+
+    @Nested
+    class LockTimeEntriesSettingsTest {
+
+        @Test
+        void ensureGetLockTimeEntriesSettings() {
+
+            final LockTimeEntriesSettingsEntity entity = new LockTimeEntriesSettingsEntity();
+            entity.setId(1L);
+            entity.setLockingIsActive(true);
+            entity.setLockTimeEntriesDaysInPast(7);
+
+            when(lockTimeEntriesSettingsRepository.findAll()).thenReturn(List.of(entity));
+
+            final LockTimeEntriesSettings actual = sut.getLockTimeEntriesSettings();
+            assertThat(actual.lockingIsActive()).isTrue();
+            assertThat(actual.lockTimeEntriesDaysInPast()).isEqualTo(7);
+        }
+
+        @Test
+        void ensureGetLockTimeEntriesSettingsReturnsDefaultSettings() {
+
+            when(lockTimeEntriesSettingsRepository.findAll()).thenReturn(List.of());
+
+            final LockTimeEntriesSettings actual = sut.getLockTimeEntriesSettings();
+            assertThat(actual.lockingIsActive()).isFalse();
+            assertThat(actual.lockTimeEntriesDaysInPast()).isEqualTo(2);
+        }
+
+        @Test
+        void ensureUpdateLockTimeEntriesSettings() {
+
+            final LockTimeEntriesSettingsEntity entity = new LockTimeEntriesSettingsEntity();
+            entity.setId(1L);
+            entity.setLockingIsActive(false);
+            entity.setLockTimeEntriesDaysInPast(1);
+
+            when(lockTimeEntriesSettingsRepository.findAll()).thenReturn(List.of(entity));
+            when(lockTimeEntriesSettingsRepository.save(any(LockTimeEntriesSettingsEntity.class))).thenAnswer(returnsFirstArg());
+
+            final LockTimeEntriesSettings actual = sut.updateLockTimeEntriesSettings(true, 42);
+
+            assertThat(actual.lockingIsActive()).isTrue();
+            assertThat(actual.lockTimeEntriesDaysInPast()).isEqualTo(42);
+
+            final ArgumentCaptor<LockTimeEntriesSettingsEntity> captor = ArgumentCaptor.forClass(LockTimeEntriesSettingsEntity.class);
+            verify(lockTimeEntriesSettingsRepository).save(captor.capture());
+
+            assertThat(captor.getValue()).isSameAs(entity);
+            assertThat(entity.getId()).isEqualTo(1L);
+            assertThat(entity.isLockingIsActive()).isTrue();
+            assertThat(entity.getLockTimeEntriesDaysInPast()).isEqualTo(42);
+        }
+
+        @Test
+        void ensureUpdateLockTimeEntriesSettingsCreatesNewEntity() {
+
+            when(lockTimeEntriesSettingsRepository.findAll()).thenReturn(List.of());
+            when(lockTimeEntriesSettingsRepository.save(any(LockTimeEntriesSettingsEntity.class))).thenAnswer(returnsFirstArg());
+
+            final LockTimeEntriesSettings actual = sut.updateLockTimeEntriesSettings(true, 42);
+
+            assertThat(actual.lockingIsActive()).isTrue();
+            assertThat(actual.lockTimeEntriesDaysInPast()).isEqualTo(42);
+
+            final ArgumentCaptor<LockTimeEntriesSettingsEntity> captor = ArgumentCaptor.forClass(LockTimeEntriesSettingsEntity.class);
+            verify(lockTimeEntriesSettingsRepository).save(captor.capture());
+
+            assertThat(captor.getValue()).satisfies(entity -> {
+                assertThat(entity.getId()).isNull(); // set by JPA
+                assertThat(entity.isLockingIsActive()).isTrue();
+                assertThat(entity.getLockTimeEntriesDaysInPast()).isEqualTo(42);
+            });
+        }
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/timeclock/TimeClockControllerAdviceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeclock/TimeClockControllerAdviceTest.java
@@ -1,5 +1,7 @@
 package de.focusshift.zeiterfassung.timeclock;
 
+import de.focusshift.zeiterfassung.security.oidc.CurrentOidcUser;
+import de.focusshift.zeiterfassung.timeentry.TimeEntryLockService;
 import de.focusshift.zeiterfassung.user.UserId;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +30,9 @@ class TimeClockControllerAdviceTest {
     @Mock
     private TimeClockService timeClockService;
 
+    @Mock
+    private TimeEntryLockService timeEntryLockService;
+
     static Stream<Arguments> timeClockArguments() {
         return Stream.of(
             Arguments.of(0, 0, 16, "00:00:16"),
@@ -48,7 +53,7 @@ class TimeClockControllerAdviceTest {
         final TimeClockControllerAdvice sut = createSut();
 
         final Model model = new BindingAwareModelMap();
-        final DefaultOidcUser principal = mock(DefaultOidcUser.class);
+        final CurrentOidcUser principal = mock(CurrentOidcUser.class);
 
         final OidcUserInfo oidcUserInfo = new OidcUserInfo(Map.of("sub", "batman"));
         when(principal.getUserInfo()).thenReturn(oidcUserInfo);
@@ -76,6 +81,6 @@ class TimeClockControllerAdviceTest {
     }
 
     private TimeClockControllerAdvice createSut() {
-        return new TimeClockControllerAdvice(timeClockService);
+        return new TimeClockControllerAdvice(timeClockService, timeEntryLockService);
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryControllerTest.java
@@ -82,14 +82,14 @@ class TimeEntryControllerTest implements ControllerTest {
     @BeforeEach
     void setUp() {
         timeEntryViewHelper = new TimeEntryViewHelper(timeEntryService, timeEntryLockService, userSettingsProvider);
-        sut = new TimeEntryController(timeEntryService, timeEntryLockService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
+        sut = new TimeEntryController(timeEntryService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
     }
 
     @Test
     void ensureTimeEntriesDefaultShowsCurrentWeek() throws Exception {
 
         clock = Clock.fixed(Instant.parse("2025-02-28T15:03:00.00Z"), ZoneOffset.UTC);
-        sut = new TimeEntryController(timeEntryService, timeEntryLockService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
+        sut = new TimeEntryController(timeEntryService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
 
         mockUserSettings(ZoneOffset.UTC);
 
@@ -448,7 +448,7 @@ class TimeEntryControllerTest implements ControllerTest {
     void ensureTimeEntriesForOtherUser() throws Exception {
 
         clock = Clock.fixed(Instant.parse("2025-03-18T10:04:00.00Z"), ZoneOffset.UTC);
-        sut = new TimeEntryController(timeEntryService, timeEntryLockService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
+        sut = new TimeEntryController(timeEntryService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
 
         final int year = 2025;
         final int weekOfYear = 12;

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryControllerTest.java
@@ -67,6 +67,8 @@ class TimeEntryControllerTest implements ControllerTest {
     @Mock
     private TimeEntryService timeEntryService;
     @Mock
+    private TimeEntryLockService timeEntryLockService;
+    @Mock
     private UserManagementService userManagementService;
     @Mock
     private UserSettingsProvider userSettingsProvider;
@@ -79,7 +81,7 @@ class TimeEntryControllerTest implements ControllerTest {
 
     @BeforeEach
     void setUp() {
-        timeEntryViewHelper = new TimeEntryViewHelper(timeEntryService, userSettingsProvider);
+        timeEntryViewHelper = new TimeEntryViewHelper(timeEntryService, timeEntryLockService, userSettingsProvider);
         sut = new TimeEntryController(timeEntryService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
     }
 

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryControllerTest.java
@@ -82,14 +82,14 @@ class TimeEntryControllerTest implements ControllerTest {
     @BeforeEach
     void setUp() {
         timeEntryViewHelper = new TimeEntryViewHelper(timeEntryService, timeEntryLockService, userSettingsProvider);
-        sut = new TimeEntryController(timeEntryService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
+        sut = new TimeEntryController(timeEntryService, timeEntryLockService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
     }
 
     @Test
     void ensureTimeEntriesDefaultShowsCurrentWeek() throws Exception {
 
         clock = Clock.fixed(Instant.parse("2025-02-28T15:03:00.00Z"), ZoneOffset.UTC);
-        sut = new TimeEntryController(timeEntryService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
+        sut = new TimeEntryController(timeEntryService, timeEntryLockService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
 
         mockUserSettings(ZoneOffset.UTC);
 
@@ -104,7 +104,7 @@ class TimeEntryControllerTest implements ControllerTest {
         final LocalDate timeEntryDate = LocalDate.parse("2025-02-28");
         final LocalDate firstDateOfWeek = LocalDate.parse("2025-02-24");
 
-        final TimeEntryDay timeEntryDay = new TimeEntryDay(timeEntryDate, PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());
+        final TimeEntryDay timeEntryDay = new TimeEntryDay(false, timeEntryDate, PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());
         final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(firstDateOfWeek, PlannedWorkingHours.EIGHT, List.of(timeEntryDay));
         final TimeEntryWeekPage timeEntryWeekPage = new TimeEntryWeekPage(timeEntryWeek, 1337);
         when(timeEntryService.getEntryWeekPage(userLocalId, 2025, 9)).thenReturn(timeEntryWeekPage);
@@ -178,9 +178,9 @@ class TimeEntryControllerTest implements ControllerTest {
         final Instant absenceEnd = ZonedDateTime.of(2025, 1, 3, 15, 0, 0, 0, zoneIdBerlin).toInstant();
         final Absence absence = new Absence(userId, absenceStart, absenceEnd, DayLength.FULL, locale -> "", YELLOW, HOLIDAY);
 
-        final TimeEntryDay timeEntryDay = new TimeEntryDay(LocalDate.of(2024, 12, 31), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());
-        final TimeEntryDay timeEntryDayWithAbsence = new TimeEntryDay(LocalDate.of(2025, 1, 2), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(), List.of(absence));
-        final TimeEntryDay timeEntryDayWithoutTimeEntriesAndWithoutAbsences = new TimeEntryDay(LocalDate.of(2025, 1, 3), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(), List.of());
+        final TimeEntryDay timeEntryDay = new TimeEntryDay(false, LocalDate.of(2024, 12, 31), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());
+        final TimeEntryDay timeEntryDayWithAbsence = new TimeEntryDay(false, LocalDate.of(2025, 1, 2), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(), List.of(absence));
+        final TimeEntryDay timeEntryDayWithoutTimeEntriesAndWithoutAbsences = new TimeEntryDay(false, LocalDate.of(2025, 1, 3), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(), List.of());
         final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(LocalDate.of(2024, 12, 30), PlannedWorkingHours.EIGHT, List.of(timeEntryDay, timeEntryDayWithAbsence, timeEntryDayWithoutTimeEntriesAndWithoutAbsences));
         final TimeEntryWeekPage timeEntryWeekPage = new TimeEntryWeekPage(timeEntryWeek, 1337);
         when(timeEntryService.getEntryWeekPage(userLocalId, 2025, 1)).thenReturn(timeEntryWeekPage);
@@ -264,7 +264,7 @@ class TimeEntryControllerTest implements ControllerTest {
         final ZonedDateTime expectedEnd = ZonedDateTime.of(2024, 12, 31, 15, 0, 0, 0, zoneIdBerlin);
         final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hack the planet", expectedStart, expectedEnd, false);
 
-        final TimeEntryDay timeEntryDay = new TimeEntryDay(LocalDate.of(2024, 12, 31), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());
+        final TimeEntryDay timeEntryDay = new TimeEntryDay(false, LocalDate.of(2024, 12, 31), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());
         final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(LocalDate.of(2024, 12, 30), PlannedWorkingHours.EIGHT, List.of(timeEntryDay));
         final TimeEntryWeekPage timeEntryWeekPage = new TimeEntryWeekPage(timeEntryWeek, 42);
         when(timeEntryService.getEntryWeekPage(userLocalId, 2025, 1)).thenReturn(timeEntryWeekPage);
@@ -448,7 +448,7 @@ class TimeEntryControllerTest implements ControllerTest {
     void ensureTimeEntriesForOtherUser() throws Exception {
 
         clock = Clock.fixed(Instant.parse("2025-03-18T10:04:00.00Z"), ZoneOffset.UTC);
-        sut = new TimeEntryController(timeEntryService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
+        sut = new TimeEntryController(timeEntryService, timeEntryLockService, userManagementService, userSettingsProvider, dateFormatter, timeEntryViewHelper, clock);
 
         final int year = 2025;
         final int weekOfYear = 12;
@@ -816,19 +816,19 @@ class TimeEntryControllerTest implements ControllerTest {
             new PlannedWorkingHours(Duration.ofHours(16)),
             List.of(
                 new TimeEntryDay(
+                    false,
                     LocalDate.of(2022, 9, 28),
                     PlannedWorkingHours.EIGHT,
                     ShouldWorkingHours.EIGHT,
                     List.of(timeEntryToEdit),
-                    List.of()
-                ),
+                    List.of()),
                 new TimeEntryDay(
+                    false,
                     LocalDate.of(2022, 9, 29),
                     PlannedWorkingHours.EIGHT,
                     ShouldWorkingHours.EIGHT,
                     List.of(timeEntryOtherDay),
-                    List.of()
-                )
+                    List.of())
             )
         );
 
@@ -939,7 +939,7 @@ class TimeEntryControllerTest implements ControllerTest {
 
         when(timeEntryService.findTimeEntry(new TimeEntryId(1337L))).thenReturn(Optional.of(timeEntry));
 
-        final TimeEntryDay timeEntryDay = new TimeEntryDay(LocalDate.of(2022, 9, 19), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());
+        final TimeEntryDay timeEntryDay = new TimeEntryDay(false, LocalDate.of(2022, 9, 19), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of());
         final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(LocalDate.of(2022, 9, 19), PlannedWorkingHours.EIGHT, List.of(timeEntryDay));
         final TimeEntryWeekPage timeEntryWeekPage = new TimeEntryWeekPage(timeEntryWeek, 1337);
         when(timeEntryService.getEntryWeekPage(userLocalId, 2021, 52)).thenReturn(timeEntryWeekPage);
@@ -1120,7 +1120,7 @@ class TimeEntryControllerTest implements ControllerTest {
 
         when(timeEntryService.findTimeEntry(new TimeEntryId(1L))).thenReturn(Optional.of(timeEntry));
 
-        final TimeEntryDay timeEntryDay = new TimeEntryDay(LocalDate.of(2022, 9, 28), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry2), List.of());
+        final TimeEntryDay timeEntryDay = new TimeEntryDay(false, LocalDate.of(2022, 9, 28), PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry2), List.of());
         final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(LocalDate.of(2022, 9, 26), PlannedWorkingHours.EIGHT, List.of(timeEntryDay));
         final TimeEntryWeekPage timeEntryWeekPage = new TimeEntryWeekPage(timeEntryWeek, 0);
         when(timeEntryService.getEntryWeekPage(userLocalId, 2022, 39)).thenReturn(timeEntryWeekPage);

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDialogHelperTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDialogHelperTest.java
@@ -47,6 +47,8 @@ class TimeEntryDialogHelperTest {
     @Mock
     private TimeEntryService timeEntryService;
     @Mock
+    private TimeEntryLockService timeEntryLockService;
+    @Mock
     private TimeEntryViewHelper timeEntryViewHelper;
     @Mock
     private UserSettingsProvider userSettingsProvider;
@@ -55,7 +57,7 @@ class TimeEntryDialogHelperTest {
 
     @BeforeEach
     void setUp() {
-        sut = new TimeEntryDialogHelper(timeEntryService, timeEntryViewHelper, userSettingsProvider, userManagementService);
+        sut = new TimeEntryDialogHelper(timeEntryService, timeEntryLockService, timeEntryViewHelper, userSettingsProvider, userManagementService);
     }
 
     @Nested

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDialogHelperTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDialogHelperTest.java
@@ -195,11 +195,11 @@ class TimeEntryDialogHelperTest {
 
             final Instant createdInstant = Instant.now();
             final EntityRevisionMetadata createdMetadata = new EntityRevisionMetadata(1, CREATED, createdInstant, Optional.of(user.userId()));
-            final TimeEntryHistoryItem createdHistoryItem = new TimeEntryHistoryItem(createdMetadata, createdTimeEntry, true, true, true, true);
+            final TimeEntryUpdatedHistoryItem createdHistoryItem = new TimeEntryUpdatedHistoryItem(createdMetadata, createdTimeEntry, true, true, true, true);
 
             final Instant modifiedInstant = Instant.now();
             final EntityRevisionMetadata modifiedMetadata = new EntityRevisionMetadata(2, UPDATED, modifiedInstant, Optional.of(otherUser.userId()));
-            final TimeEntryHistoryItem modifiedHistoryItem = new TimeEntryHistoryItem(modifiedMetadata, modifiedTimeEntry, true, false, false, false);
+            final TimeEntryUpdatedHistoryItem modifiedHistoryItem = new TimeEntryUpdatedHistoryItem(modifiedMetadata, modifiedTimeEntry, true, false, false, false);
 
             final TimeEntryHistory timeEntryHistory = new TimeEntryHistory(createdTimeEntry.id(), List.of(createdHistoryItem, modifiedHistoryItem));
             when(timeEntryService.findTimeEntryHistory(createdTimeEntry.id())).thenReturn(Optional.of(timeEntryHistory));

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockServiceImplTest.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.timeentry;
 import de.focusshift.zeiterfassung.security.SecurityRole;
 import de.focusshift.zeiterfassung.settings.LockTimeEntriesSettings;
 import de.focusshift.zeiterfassung.settings.LockTimeEntriesSettingsService;
+import de.focusshift.zeiterfassung.user.UserSettingsProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,13 +31,15 @@ class TimeEntryLockServiceImplTest {
 
     @Mock
     private LockTimeEntriesSettingsService lockTimeEntriesSettingsService;
+    @Mock
+    private UserSettingsProvider userSettingsProvider;
 
     private static final Clock clockFixed = Clock.fixed(Clock.systemUTC().instant(), UTC);
     private static final ZoneId ZONE_TOKYO = ZoneId.of("Asia/Tokyo");
 
     @BeforeEach
     void setUp() {
-        sut = new TimeEntryLockServiceImpl(lockTimeEntriesSettingsService, clockFixed);
+        sut = new TimeEntryLockServiceImpl(lockTimeEntriesSettingsService, userSettingsProvider, clockFixed);
     }
 
     @Nested

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryLockServiceImplTest.java
@@ -1,0 +1,154 @@
+package de.focusshift.zeiterfassung.timeentry;
+
+import de.focusshift.zeiterfassung.security.SecurityRole;
+import de.focusshift.zeiterfassung.settings.LockTimeEntriesSettings;
+import de.focusshift.zeiterfassung.settings.LockTimeEntriesSettingsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TimeEntryLockServiceImplTest {
+
+    private TimeEntryLockServiceImpl sut;
+
+    @Mock
+    private LockTimeEntriesSettingsService lockTimeEntriesSettingsService;
+
+    private static final Clock clockFixed = Clock.fixed(Clock.systemUTC().instant(), UTC);
+    private static final ZoneId ZONE_TOKYO = ZoneId.of("Asia/Tokyo");
+
+    @BeforeEach
+    void setUp() {
+        sut = new TimeEntryLockServiceImpl(lockTimeEntriesSettingsService, clockFixed);
+    }
+
+    @Nested
+    class IsTimespanLocked {
+
+        @Test
+        void ensureTimespanNotLockedForSameDay() {
+
+            mockSettings(new LockTimeEntriesSettings(true, 0));
+
+            final LocalDate today = LocalDate.now(clockFixed);
+
+            final boolean actual = sut.isTimespanLocked(today, today);
+            assertThat(actual).isFalse();
+        }
+
+        @Test
+        void ensureTimespanNotLockedForStartTodayEndOnBoundary() {
+
+            mockSettings(new LockTimeEntriesSettings(true, 1));
+
+            final LocalDate today = LocalDate.now(clockFixed);
+
+            final boolean actual = sut.isTimespanLocked(today, today.minusDays(1));
+            assertThat(actual).isFalse();
+        }
+
+        @Test
+        void ensureTimespanNotLockedForInBetween() {
+
+            mockSettings(new LockTimeEntriesSettings(true, 7));
+
+            final LocalDate yesterday = LocalDate.now(clockFixed).minusDays(1);
+
+            final boolean actual = sut.isTimespanLocked(yesterday, yesterday.minusDays(1));
+            assertThat(actual).isFalse();
+        }
+
+        @Test
+        void ensureTimespanNotLockedWhenSettingIsInactive() {
+
+            mockSettings(new LockTimeEntriesSettings(false, 0));
+
+            final LocalDate ooooold = LocalDate.now(clockFixed).minusYears(1);
+
+            final boolean actual = sut.isTimespanLocked(ooooold, ooooold);
+            assertThat(actual).isFalse();
+        }
+
+        @Test
+        void ensureIsTimespanLockedWhenStartIsToOld() {
+
+            mockSettings(new LockTimeEntriesSettings(true, 0));
+
+            final LocalDate yesterday = LocalDate.now(clockFixed).minusDays(1);
+
+            final boolean actual = sut.isTimespanLocked(yesterday, yesterday);
+            assertThat(actual).isTrue();
+        }
+
+        @Test
+        void ensureIsTimespanLockedWhenEndIsToOld() {
+
+            mockSettings(new LockTimeEntriesSettings(true, 0));
+
+            final LocalDate today = LocalDate.now(clockFixed);
+
+            final boolean actual = sut.isTimespanLocked(today, today.minusDays(42));
+            assertThat(actual).isTrue();
+        }
+
+        @Test
+        void ensureTimespanNotLockedForOtherTimeZone() {
+
+            mockSettings(new LockTimeEntriesSettings(true, 0));
+
+            final ZonedDateTime todayOtherTimeZone = ZonedDateTime.now(clockFixed).withZoneSameLocal(ZONE_TOKYO);
+
+            final boolean actual = sut.isTimespanLocked(todayOtherTimeZone, todayOtherTimeZone);
+            assertThat(actual).isFalse();
+        }
+
+        @Test
+        void ensureTimespanLockedForOtherTimeZone() {
+
+            mockSettings(new LockTimeEntriesSettings(true, 0));
+
+            final ZonedDateTime yesterdayOtherTimezone = ZonedDateTime.now(clockFixed).withZoneSameLocal(ZONE_TOKYO).minusDays(1);
+
+            final boolean actual = sut.isTimespanLocked(yesterdayOtherTimezone, yesterdayOtherTimezone);
+            assertThat(actual).isTrue();
+        }
+    }
+
+    @Nested
+    class IsUserAllowedToBypassLock {
+
+        @ParameterizedTest
+        @EnumSource(value = SecurityRole.class, names = {"ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL"}, mode = EnumSource.Mode.EXCLUDE)
+        void ensureIsUserAllowedToBypassLockReturnFalse(SecurityRole role) {
+            final boolean actual = sut.isUserAllowedToBypassLock(List.of(role));
+            assertThat(actual).isFalse();
+        }
+
+        @Test
+        void ensureIsUserAllowedToBypassLockReturnFalse() {
+            final boolean actual = sut.isUserAllowedToBypassLock(List.of(ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL));
+            assertThat(actual).isTrue();
+        }
+    }
+
+    private void mockSettings(LockTimeEntriesSettings settings) {
+        when(lockTimeEntriesSettingsService.getLockTimeEntriesSettings()).thenReturn(settings);
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
@@ -143,7 +143,7 @@ class TimeEntryServiceImplTest {
                 final ZonedDateTime endDateTime = ZonedDateTime.ofInstant(end, ZONE_ID_UTC);
 
                 final TimeEntry timeEntry = new TimeEntry(timeEntryId, userIdComposite, "Kickoff", startDateTime, endDateTime, false);
-                final TimeEntryHistoryItem historyItem = new TimeEntryHistoryItem(metadata, timeEntry, true, true, true, true);
+                final TimeEntryUpdatedHistoryItem historyItem = new TimeEntryUpdatedHistoryItem(metadata, timeEntry, true, true, true, true);
 
                 assertThat(history.revisions().getFirst()).isEqualTo(historyItem);
                 assertThat(history.revisions().getFirst().metadata()).isSameAs(metadata);

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
@@ -65,6 +65,8 @@ class TimeEntryServiceImplTest {
     @Mock
     private TimeEntryRepository timeEntryRepository;
     @Mock
+    private TimeEntryLockService timeEntryLockService;
+    @Mock
     private UserDateService userDateService;
     @Mock
     private WorkingTimeCalendarService workingTimeCalendarService;
@@ -79,8 +81,8 @@ class TimeEntryServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        sut = new TimeEntryServiceImpl(timeEntryRepository, userManagementService, workingTimeCalendarService,
-            userDateService, userSettingsProvider, entityRevisionMapper, clockFixed);
+        sut = new TimeEntryServiceImpl(timeEntryRepository, timeEntryLockService, userManagementService,
+            workingTimeCalendarService, userDateService, userSettingsProvider, entityRevisionMapper, clockFixed);
     }
 
     @Nested
@@ -1228,41 +1230,42 @@ class TimeEntryServiceImplTest {
                     new PlannedWorkingHours(Duration.ofHours(40)),
                     List.of(
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2022, 1, 9),
                             PlannedWorkingHours.ZERO,
                             ShouldWorkingHours.ZERO,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2022, 1, 8),
                             PlannedWorkingHours.ZERO,
                             ShouldWorkingHours.ZERO,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2022, 1, 7),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2022, 1, 6),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2022, 1, 5),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2022, 1, 4),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
@@ -1270,15 +1273,14 @@ class TimeEntryServiceImplTest {
                                 new TimeEntry(new TimeEntryId(1L), userIdComposite, "hack the planet!", timeEntryStart, timeEntryEnd, false),
                                 new TimeEntry(new TimeEntryId(2L), userIdComposite, "deserved break", timeEntryBreakStart, timeEntryBreakEnd, true)
                             ),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             firstDayOfWeek,
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        )
+                            List.of())
                     )
                 ),
                 3
@@ -1339,58 +1341,58 @@ class TimeEntryServiceImplTest {
                     new PlannedWorkingHours(Duration.ofHours(40)),
                     List.of(
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 2, 5),
                             PlannedWorkingHours.ZERO,
                             ShouldWorkingHours.ZERO,
                             List.of(
                                 new TimeEntry(new TimeEntryId(2L), userIdComposite, "hack the planet, second time!", lastDayOfWeekTimeEntryStart, lastDayOfWeekTimeEntryEnd, false)
                             ),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 2, 4),
                             PlannedWorkingHours.ZERO,
                             ShouldWorkingHours.ZERO,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 2, 3),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 2, 2),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 2, 1),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 1, 31),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             firstDateOfWeek,
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(
                                 new TimeEntry(new TimeEntryId(1L), userIdComposite, "hack the planet!", firstDayOfWeekTimeEntryStart, firstDayOfWeekTimeEntryEnd, false)
                             ),
-                            List.of()
-                        )
+                            List.of())
                     )
                 ),
                 6
@@ -1442,54 +1444,54 @@ class TimeEntryServiceImplTest {
                     new PlannedWorkingHours(Duration.ofHours(40)),
                     List.of(
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 6, 18),
                             PlannedWorkingHours.ZERO,
                             ShouldWorkingHours.ZERO,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 6, 17),
                             PlannedWorkingHours.ZERO,
                             ShouldWorkingHours.ZERO,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 6, 16),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 6, 15),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 6, 14),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 6, 13),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        ),
+                            List.of()),
                         new TimeEntryDay(
+                            false,
                             LocalDate.of(2023, 6, 12),
                             PlannedWorkingHours.EIGHT,
                             ShouldWorkingHours.EIGHT,
                             List.of(),
-                            List.of()
-                        )
+                            List.of())
                     )
                 ),
                 6

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryViewHelperTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryViewHelperTest.java
@@ -53,11 +53,13 @@ class TimeEntryViewHelperTest {
     @Mock
     private TimeEntryService timeEntryService;
     @Mock
+    private TimeEntryLockService timeEntryLockService;
+    @Mock
     private UserSettingsProvider userSettingsProvider;
 
     @BeforeEach
     void setUp() {
-        sut = new TimeEntryViewHelper(timeEntryService, userSettingsProvider);
+        sut = new TimeEntryViewHelper(timeEntryService, timeEntryLockService, userSettingsProvider);
     }
 
     @Test
@@ -169,6 +171,8 @@ class TimeEntryViewHelperTest {
             final UserLocalId userLocalId = new UserLocalId(1L);
             when(userSettingsProvider.zoneId()).thenReturn(UTC);
 
+            final CurrentOidcUser currentUser = anyCurrentOidcUser(userLocalId);
+
             final TimeEntryDTO timeEntryDTO = new TimeEntryDTO();
             timeEntryDTO.setUserLocalId(userLocalId.value());
             timeEntryDTO.setId(null);
@@ -178,7 +182,9 @@ class TimeEntryViewHelperTest {
             timeEntryDTO.setComment("comment");
             timeEntryDTO.setBreak(false);
 
-            sut.createTimeEntry(timeEntryDTO);
+            final BindingResult bindingResult = mock(BindingResult.class);
+
+            sut.createTimeEntry(timeEntryDTO, bindingResult, currentUser);
 
             final ZonedDateTime start = ZonedDateTime.parse("2025-02-16T09:00:00Z");
             final ZonedDateTime end = ZonedDateTime.parse("2025-02-16T17:00:00Z");
@@ -192,6 +198,8 @@ class TimeEntryViewHelperTest {
             final UserLocalId userLocalId = new UserLocalId(1L);
             when(userSettingsProvider.zoneId()).thenReturn(UTC);
 
+            final CurrentOidcUser currentUser = anyCurrentOidcUser(userLocalId);
+
             final TimeEntryDTO timeEntryDTO = new TimeEntryDTO();
             timeEntryDTO.setUserLocalId(userLocalId.value());
             timeEntryDTO.setId(null);
@@ -200,7 +208,9 @@ class TimeEntryViewHelperTest {
             timeEntryDTO.setDuration(duration);
             timeEntryDTO.setBreak(false);
 
-            sut.createTimeEntry(timeEntryDTO);
+            final BindingResult bindingResult = mock(BindingResult.class);
+
+            sut.createTimeEntry(timeEntryDTO, bindingResult, currentUser);
 
             final ZonedDateTime start = ZonedDateTime.parse("2025-02-16T09:00:00Z");
             final ZonedDateTime end = ZonedDateTime.parse("2025-02-16T17:00:00Z");
@@ -214,6 +224,8 @@ class TimeEntryViewHelperTest {
             final UserLocalId userLocalId = new UserLocalId(1L);
             when(userSettingsProvider.zoneId()).thenReturn(UTC);
 
+            final CurrentOidcUser currentUser = anyCurrentOidcUser(userLocalId);
+
             final TimeEntryDTO timeEntryDTO = new TimeEntryDTO();
             timeEntryDTO.setUserLocalId(userLocalId.value());
             timeEntryDTO.setId(null);
@@ -222,7 +234,9 @@ class TimeEntryViewHelperTest {
             timeEntryDTO.setDuration(duration);
             timeEntryDTO.setBreak(false);
 
-            sut.createTimeEntry(timeEntryDTO);
+            final BindingResult bindingResult = mock(BindingResult.class);
+
+            sut.createTimeEntry(timeEntryDTO, bindingResult, currentUser);
 
             final ZonedDateTime start = ZonedDateTime.parse("2025-02-16T09:00:00Z");
             final ZonedDateTime end = ZonedDateTime.parse("2025-02-16T17:00:00Z");

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryWeekTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryWeekTest.java
@@ -38,7 +38,7 @@ class TimeEntryWeekTest {
         final ZonedDateTime secondEnd = ZonedDateTime.of(LocalDateTime.of(2022, 1, 5, 17, 30, 0), ZONE_ID_BERLIN);
         final TimeEntry secondTimeEntry = new TimeEntry(new TimeEntryId(2L), userIdComposite, "hard work second day", secondStart, secondEnd, false);
 
-        final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(startOfWeek, PlannedWorkingHours.EIGHT, List.of(new TimeEntryDay(startOfWeek, PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(firstTimeEntry, secondTimeEntry), List.of())));
+        final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(startOfWeek, PlannedWorkingHours.EIGHT, List.of(new TimeEntryDay(false, startOfWeek, PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(firstTimeEntry, secondTimeEntry), List.of())));
 
         final Duration actualDuration = timeEntryWeek.workDuration().duration();
         assertThat(actualDuration).isEqualTo(Duration.ofHours(2).plusMinutes(45));
@@ -58,7 +58,7 @@ class TimeEntryWeekTest {
 
         final TimeEntry timeEntry = new TimeEntry(new TimeEntryId(1L), userIdComposite, "hard work in the night", start, end, false);
 
-        final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(startOfWeek, PlannedWorkingHours.EIGHT, List.of(new TimeEntryDay(startOfWeek, PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of())));
+        final TimeEntryWeek timeEntryWeek = new TimeEntryWeek(startOfWeek, PlannedWorkingHours.EIGHT, List.of(new TimeEntryDay(false, startOfWeek, PlannedWorkingHours.EIGHT, ShouldWorkingHours.EIGHT, List.of(timeEntry), List.of())));
 
         final Duration actualDuration = timeEntryWeek.workDuration().duration();
         assertThat(actualDuration).isEqualTo(Duration.ofHours(3));

--- a/src/test/java/de/focusshift/zeiterfassung/usermanagement/PermissionsControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/usermanagement/PermissionsControllerTest.java
@@ -106,8 +106,8 @@ class PermissionsControllerTest implements ControllerTest {
         final PermissionsDto workingTimeAllPermissionDto = new PermissionsDto();
         workingTimeAllPermissionDto.setWorkingTimeEditAll(true);
 
-        final PermissionsDto workingTimeGlobalPermissionDto = new PermissionsDto();
-        workingTimeGlobalPermissionDto.setWorkingTimeEditGlobal(true);
+        final PermissionsDto settingsGlobalPermissionsDto = new PermissionsDto();
+        settingsGlobalPermissionsDto.setGlobalSettings(true);
 
         final PermissionsDto overtimePermissionDto = new PermissionsDto();
         overtimePermissionDto.setOvertimeEditAll(true);
@@ -121,7 +121,8 @@ class PermissionsControllerTest implements ControllerTest {
         return Stream.of(
             Arguments.of(SecurityRole.ZEITERFASSUNG_VIEW_REPORT_ALL, reportPermissionDto),
             Arguments.of(SecurityRole.ZEITERFASSUNG_WORKING_TIME_EDIT_ALL, workingTimeAllPermissionDto),
-            Arguments.of(SecurityRole.ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL, workingTimeGlobalPermissionDto),
+            Arguments.of(SecurityRole.ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL, settingsGlobalPermissionsDto),
+            Arguments.of(SecurityRole.ZEITERFASSUNG_SETTINGS_GLOBAL, settingsGlobalPermissionsDto),
             Arguments.of(SecurityRole.ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL, overtimePermissionDto),
             Arguments.of(ZEITERFASSUNG_PERMISSIONS_EDIT_ALL, permissionsPermissionDto),
             Arguments.of(ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL, editTimeEntryPermissionDto)
@@ -294,12 +295,13 @@ class PermissionsControllerTest implements ControllerTest {
 
     @ParameterizedTest
     @CsvSource({
-        "ZEITERFASSUNG_VIEW_REPORT_ALL,true,false,false,false",
-        "ZEITERFASSUNG_WORKING_TIME_EDIT_ALL,false,true,false,false",
-        "ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL,false,false,true,false",
-        "ZEITERFASSUNG_PERMISSIONS_EDIT_ALL,false,false,false,true"
+        "ZEITERFASSUNG_VIEW_REPORT_ALL,true,false,false,false,false",
+        "ZEITERFASSUNG_WORKING_TIME_EDIT_ALL,false,true,false,false,false",
+        "ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL,false,false,true,false,false",
+        "ZEITERFASSUNG_PERMISSIONS_EDIT_ALL,false,false,false,true,false",
+        "ZEITERFASSUNG_SETTINGS_GLOBAL,false,false,false,false,true",
     })
-    void ensurePost(String roleName, boolean viewReportAll, boolean workingTimeEditAll, boolean overtimeEditAll, boolean permissionsEditAll) throws Exception {
+    void ensurePost(String roleName, boolean viewReportAll, boolean workingTimeEditAll, boolean overtimeEditAll, boolean permissionsEditAll, boolean globalSettings) throws Exception {
 
         final SecurityRole securityRole = SecurityRole.valueOf(roleName);
 
@@ -316,6 +318,7 @@ class PermissionsControllerTest implements ControllerTest {
                 .param("workingTimeEditAll", String.valueOf(workingTimeEditAll))
                 .param("overtimeEditAll", String.valueOf(overtimeEditAll))
                 .param("permissionsEditAll", String.valueOf(permissionsEditAll))
+                .param("globalSettings", String.valueOf(globalSettings))
         )
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/users/1337/permissions"));

--- a/src/test/resources/docker/keycloak/export/zeiterfassung-realm-realm.json
+++ b/src/test/resources/docker/keycloak/export/zeiterfassung-realm-realm.json
@@ -109,6 +109,14 @@
       "containerId" : "zeiterfassung-realm",
       "attributes" : { }
     }, {
+      "id" : "5ff04ece-718e-4c73-959e-96656c6c4789",
+      "name" : "zeiterfassung_settings_global",
+      "description" : "",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "zeiterfassung-realm",
+      "attributes" : { }
+    }, {
       "id" : "d0fcc3dd-7e1e-46fa-89ce-f7727e1a46f3",
       "name" : "zeiterfassung_overtime_account_edit_all",
       "description" : "",
@@ -409,6 +417,7 @@
       "zeiterfassung_view_report_all",
       "zeiterfassung_working_time_edit_all",
       "zeiterfassung_working_time_edit_global",
+      "zeiterfassung_settings_global",
       "zeiterfassung_overtime_account_edit_all",
       "zeiterfassung_permissions_edit_all",
       "zeiterfassung_time_entry_edit_all"


### PR DESCRIPTION
closes #1252

Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
