### PR TITLE
Consume applications of overtime reductions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>de.focus-shift.urlaubsverwaltung.extension.api</groupId>
       <artifactId>model-events</artifactId>
-      <version>2.1.0</version>
+      <version>2.2.0</version>
     </dependency>
 
     <!-- PUBLIC HOLIDAYS INFORMATION -->

--- a/src/main/java/de/focusshift/zeiterfassung/absence/Absence.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/Absence.java
@@ -6,7 +6,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 
 /**

--- a/src/main/java/de/focusshift/zeiterfassung/absence/Absence.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/Absence.java
@@ -2,9 +2,11 @@ package de.focusshift.zeiterfassung.absence;
 
 import de.focusshift.zeiterfassung.user.UserId;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -25,8 +27,19 @@ public record Absence(
     DayLength dayLength,
     Function<Locale, String> label,
     AbsenceColor color,
-    AbsenceTypeCategory absenceTypeCategory
+    AbsenceTypeCategory absenceTypeCategory,
+    Duration overtimeHours
 ) {
+
+    public Absence(UserId userId,
+                   Instant startDate,
+                   Instant endDate,
+                   DayLength dayLength,
+                   Function<Locale, String> label,
+                   AbsenceColor color,
+                   AbsenceTypeCategory absenceTypeCategory) {
+        this(userId, startDate, endDate, dayLength, label, color, absenceTypeCategory, null);
+    }
 
     public String label(Locale locale) {
         return label.apply(locale);
@@ -42,11 +55,12 @@ public record Absence(
             && dayLength == absence.dayLength
             && Objects.equals(endDate, absence.endDate)
             && Objects.equals(startDate, absence.startDate)
-            && Objects.equals(absenceTypeCategory, absence.absenceTypeCategory);
+            && Objects.equals(absenceTypeCategory, absence.absenceTypeCategory)
+            && Objects.equals(overtimeHours, absence.overtimeHours);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId, startDate, endDate, dayLength, color, absenceTypeCategory);
+        return Objects.hash(userId, startDate, endDate, dayLength, color, absenceTypeCategory, overtimeHours);
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceServiceImpl.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -190,8 +191,19 @@ class AbsenceServiceImpl implements AbsenceService {
         final DayLength dayLength = entity.getDayLength();
         final Function<Locale, String> label = getAbsenceTypeLabelWithDayLength(dayLength, absenceType);
 
-        return Optional.of(
-            new Absence(
+        if (entity.getOvertimeHours().isPresent()) {
+            return Optional.of(new Absence(
+                new UserId(entity.getUserId()),
+                entity.getStartDate(),
+                entity.getEndDate(),
+                dayLength,
+                label,
+                absenceType.color(),
+                absenceType.category(),
+                entity.getOvertimeHours().get()
+            ));
+        } else {
+            return Optional.of(new Absence(
                 new UserId(entity.getUserId()),
                 entity.getStartDate(),
                 entity.getEndDate(),
@@ -199,8 +211,8 @@ class AbsenceServiceImpl implements AbsenceService {
                 label,
                 absenceType.color(),
                 absenceType.category()
-            )
-        );
+            ));
+        }
     }
 
     private Function<Locale, String> getAbsenceTypeLabelWithDayLength(DayLength dayLength, AbsenceType absenceType) {

--- a/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceTypeCategory.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceTypeCategory.java
@@ -5,6 +5,7 @@ public enum AbsenceTypeCategory {
     HOLIDAY,
     SPECIALLEAVE,
     UNPAIDLEAVE,
+    OVERTIME,
     OTHER,
     SICK,
 }

--- a/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceWrite.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceWrite.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.absence;
 import de.focusshift.zeiterfassung.user.UserId;
 import jakarta.annotation.Nullable;
 
+import java.time.Duration;
 import java.time.Instant;
 
 /**
@@ -14,6 +15,7 @@ import java.time.Instant;
  * @param endDate
  * @param dayLength
  * @param absenceTypeCategory
+ * @param overtimeHours
  * @param absenceTypeSourceId absence type source id or {@code null} for {@linkplain AbsenceTypeCategory#SICK}
  */
 public record AbsenceWrite(
@@ -22,6 +24,7 @@ public record AbsenceWrite(
     Instant startDate,
     Instant endDate,
     DayLength dayLength,
+    @Nullable Duration overtimeHours,
     AbsenceTypeCategory absenceTypeCategory,
     @Nullable AbsenceTypeSourceId absenceTypeSourceId
 ) {
@@ -34,9 +37,10 @@ public record AbsenceWrite(
      * @param startDate
      * @param endDate
      * @param dayLength
+     * @param overtimeHours
      * @param absenceTypeCategory
      */
-    public AbsenceWrite(Long sourceId, UserId userId, Instant startDate, Instant endDate, DayLength dayLength, AbsenceTypeCategory absenceTypeCategory) {
-        this(sourceId, userId, startDate, endDate, dayLength, absenceTypeCategory, null);
+    public AbsenceWrite(Long sourceId, UserId userId, Instant startDate, Instant endDate, DayLength dayLength, Duration overtimeHours, AbsenceTypeCategory absenceTypeCategory) {
+        this(sourceId, userId, startDate, endDate, dayLength, overtimeHours, absenceTypeCategory, null);
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceWriteEntity.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceWriteEntity.java
@@ -11,8 +11,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 
 import static jakarta.persistence.EnumType.STRING;
 
@@ -26,21 +28,24 @@ public class AbsenceWriteEntity extends AbstractTenantAwareEntity {
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "absence_seq")
     private Long id;
 
-    @Column(name="source_id", nullable = false)
+    @Column(name = "source_id", nullable = false)
     private Long sourceId;
 
-    @Column(name="user_id", nullable = false)
+    @Column(name = "user_id", nullable = false)
     private String userId;
 
-    @Column(name="start_date", nullable = false)
+    @Column(name = "start_date", nullable = false)
     private Instant startDate;
 
-    @Column(name="end_date", nullable = false)
+    @Column(name = "end_date", nullable = false)
     private Instant endDate;
 
-    @Column(name="day_length", nullable = false)
+    @Column(name = "day_length", nullable = false)
     @Enumerated(STRING)
     private DayLength dayLength;
+
+    @Column(name = "overtime_hours", nullable = true)
+    private Long overtimeHours;
 
     @Embedded
     private AbsenceTypeEntityEmbeddable type;
@@ -103,6 +108,14 @@ public class AbsenceWriteEntity extends AbstractTenantAwareEntity {
 
     public void setType(AbsenceTypeEntityEmbeddable type) {
         this.type = type;
+    }
+
+    public Optional<Duration> getOvertimeHours() {
+        return overtimeHours == null ? Optional.empty() : Optional.of(Duration.ofSeconds(overtimeHours));
+    }
+
+    public void setOvertimeHours(Duration overtimeHours) {
+        this.overtimeHours = overtimeHours == null ? null : overtimeHours.getSeconds();
     }
 
     @Override

--- a/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceWriteServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/absence/AbsenceWriteServiceImpl.java
@@ -86,6 +86,7 @@ class AbsenceWriteServiceImpl implements AbsenceWriteService {
         entity.setEndDate(absence.endDate());
         entity.setDayLength(absence.dayLength());
         entity.setType(setTypeEntityFields(absence));
+        entity.setOvertimeHours(absence.overtimeHours());
     }
 
     private static AbsenceTypeEntityEmbeddable setTypeEntityFields(AbsenceWrite absence) {

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationEventDtoAdapter.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationEventDtoAdapter.java
@@ -8,6 +8,9 @@ import de.focus_shift.urlaubsverwaltung.extension.api.application.ApplicationPer
 import de.focus_shift.urlaubsverwaltung.extension.api.application.ApplicationUpdatedEventDTO;
 import de.focus_shift.urlaubsverwaltung.extension.api.application.VacationTypeDTO;
 
+import java.time.Duration;
+import java.util.Optional;
+
 /**
  * Common interface of urlaubsverwaltung (vacation)application events to provide minimal information required by Zeiterfassung.
  */
@@ -17,12 +20,14 @@ class ApplicationEventDtoAdapter {
     private final ApplicationPersonDTO person;
     private final VacationTypeDTO vacationType;
     private final ApplicationPeriodDTO period;
+    private final Duration overtimeHours;
 
     ApplicationEventDtoAdapter(ApplicationAllowedEventDTO event) {
         this.sourceId = event.getSourceId();
         this.person = event.getPerson();
         this.vacationType = event.getVacationType();
         this.period = event.getPeriod();
+        this.overtimeHours = event.getHours();
     }
 
     ApplicationEventDtoAdapter(ApplicationCancelledEventDTO event) {
@@ -30,6 +35,7 @@ class ApplicationEventDtoAdapter {
         this.person = event.getPerson();
         this.vacationType = event.getVacationType();
         this.period = event.getPeriod();
+        this.overtimeHours = event.getHours();
     }
 
     ApplicationEventDtoAdapter(ApplicationUpdatedEventDTO event) {
@@ -37,6 +43,7 @@ class ApplicationEventDtoAdapter {
         this.person = event.getPerson();
         this.vacationType = event.getVacationType();
         this.period = event.getPeriod();
+        this.overtimeHours = event.getHours();
     }
 
     ApplicationEventDtoAdapter(ApplicationCreatedFromSickNoteEventDTO event) {
@@ -44,6 +51,7 @@ class ApplicationEventDtoAdapter {
         this.person = event.getPerson();
         this.vacationType = event.getVacationType();
         this.period = event.getPeriod();
+        this.overtimeHours = null;
     }
 
     public Long getSourceId() {
@@ -60,5 +68,9 @@ class ApplicationEventDtoAdapter {
 
     public ApplicationPeriodDTO getPeriod() {
         return period;
+    }
+
+    public Optional<Duration> getOvertimeHours() {
+        return Optional.ofNullable(overtimeHours);
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationEventHandlerRabbitmq.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationEventHandlerRabbitmq.java
@@ -53,6 +53,7 @@ public class ApplicationEventHandlerRabbitmq extends RabbitMessageConsumer {
             event.getPeriod().getStartDate(),
             event.getPeriod().getEndDate(),
             maybeDayLength.get(),
+            event.getOvertimeHours().orElse(null),
             maybeAbsenceTypeCategory.get(),
             absenceTypeSourceId
         ));

--- a/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmq.java
+++ b/src/main/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmq.java
@@ -107,6 +107,7 @@ public class SickNoteEventHandlerRabbitmq extends RabbitMessageConsumer {
                 event.getPeriod().getStartDate(),
                 event.getPeriod().getEndDate(),
                 dayLength,
+                null,
                 AbsenceTypeCategory.SICK
             ));
     }

--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendar.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendar.java
@@ -70,6 +70,9 @@ public final class WorkingTimeCalendar {
 
         for (Absence absence : absences) {
             if (absence.absenceTypeCategory() == AbsenceTypeCategory.OVERTIME) {
+                // TODO: That's not correct for application for overtime reduction which are longer than one day
+                // Here we need to some additional implementation to distribute evenly overtimeHours by working day of
+                // ZE user
                 absenceDuration = absenceDuration.plus(absence.overtimeHours());
             } else {
                 // application for leave or sicknote

--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendar.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendar.java
@@ -7,18 +7,12 @@ import de.focusshift.zeiterfassung.usermanagement.User;
 
 import java.time.Duration;
 import java.time.LocalDate;
-import java.time.Period;
 import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static java.time.temporal.ChronoUnit.DAYS;
 import static org.apache.commons.lang3.compare.ComparableUtils.max;
 
 /**

--- a/src/main/resources/db/changelog/changelog-2.22.0-add-absence-overtime-hours.xml
+++ b/src/main/resources/db/changelog/changelog-2.22.0-add-absence-overtime-hours.xml
@@ -8,7 +8,9 @@
       <tableExists tableName="absence"/>
     </preConditions>
     <addColumn tableName="absence">
-      <column name="overtime_hours" type="BIGINT"/>
+      <column name="overtime_hours" type="BIGINT">
+        <constraints nullable="true"/>
+      </column>
     </addColumn>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-2.22.0-add-absence-overtime-hours.xml
+++ b/src/main/resources/db/changelog/changelog-2.22.0-add-absence-overtime-hours.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd">
+
+  <changeSet author="honnel" id="add-absence-overtime-hours">
+    <preConditions>
+      <tableExists tableName="absence"/>
+    </preConditions>
+    <addColumn tableName="absence">
+      <column name="overtime_hours" type="BIGINT"/>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-main.xml
+++ b/src/main/resources/db/changelog/db.changelog-main.xml
@@ -34,5 +34,5 @@
   <include relativeToChangelogFile="true" file="changelog-2.18.0-add-missing-indices.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.20.0-add-setting-for-locking-time-entries.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.22.0-update-tenant-user-uuid-length.xml"/>
-
+  <include relativeToChangelogFile="true" file="changelog-2.22.0-add-absence-overtime-hours.xml"/>
 </databaseChangeLog>

--- a/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceWriteServiceImplIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceWriteServiceImplIT.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -55,6 +56,7 @@ class AbsenceWriteServiceImplIT extends SingleTenantTestContainersBase {
             startDate,
             endDate,
             DayLength.FULL,
+            Duration.ZERO,
             HOLIDAY
         );
 

--- a/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceWriteServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceWriteServiceImplTest.java
@@ -8,6 +8,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -45,6 +46,7 @@ class AbsenceWriteServiceImplTest {
             startDate,
             endDate,
             DayLength.FULL,
+            Duration.ZERO,
             SPECIALLEAVE
         );
 
@@ -78,6 +80,7 @@ class AbsenceWriteServiceImplTest {
             startDate,
             endDate,
             DayLength.FULL,
+            Duration.ZERO,
             SPECIALLEAVE
         );
 

--- a/src/test/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationEventHandlerRabbitmqTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/application/ApplicationEventHandlerRabbitmqTest.java
@@ -24,10 +24,12 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
 
 import static de.focusshift.zeiterfassung.absence.AbsenceTypeCategory.HOLIDAY;
+import static de.focusshift.zeiterfassung.absence.AbsenceTypeCategory.OVERTIME;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,9 +58,10 @@ class ApplicationEventHandlerRabbitmqTest {
                 .sourceId(1L)
                 .person(ApplicationPersonDTO.builder().personId(2L).username("userId").build())
                 .period(ApplicationPeriodDTO.builder().startDate(Instant.ofEpochMilli(0L)).endDate(Instant.ofEpochMilli(1L)).dayLength(de.focus_shift.urlaubsverwaltung.extension.api.application.DayLength.FULL).build())
-                .vacationType(VacationTypeDTO.builder().category("HOLIDAY").sourceId(1000L).color("CYAN").build())
+                .vacationType(VacationTypeDTO.builder().category("OVERTIME").sourceId(4242L).color("CYAN").build())
                 .createdAt(Instant.ofEpochMilli(0L))
                 .status("status")
+                .hours(Duration.ofHours(6))
                 .build();
 
         sut.on(event);
@@ -69,8 +72,9 @@ class ApplicationEventHandlerRabbitmqTest {
             Instant.ofEpochMilli(0L),
             Instant.ofEpochMilli(1L),
             DayLength.FULL,
-            HOLIDAY,
-            new AbsenceTypeSourceId(1000L)
+            Duration.ofHours(6),
+            OVERTIME,
+            new AbsenceTypeSourceId(4242L)
         );
         verify(absenceWriteService).addAbsence(absence);
 
@@ -101,6 +105,7 @@ class ApplicationEventHandlerRabbitmqTest {
             Instant.ofEpochMilli(0L),
             Instant.ofEpochMilli(1L),
             DayLength.FULL,
+            null,
             HOLIDAY,
             new AbsenceTypeSourceId(1000L)
         );
@@ -133,6 +138,7 @@ class ApplicationEventHandlerRabbitmqTest {
             Instant.ofEpochMilli(0L),
             Instant.ofEpochMilli(1L),
             DayLength.FULL,
+            null,
             HOLIDAY,
             new AbsenceTypeSourceId(1000L)
         );
@@ -165,6 +171,7 @@ class ApplicationEventHandlerRabbitmqTest {
             Instant.ofEpochMilli(0L),
             Instant.ofEpochMilli(1L),
             DayLength.FULL,
+            null,
             HOLIDAY,
             new AbsenceTypeSourceId(1000L)
         );

--- a/src/test/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmqIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/integration/urlaubsverwaltung/sicknote/SickNoteEventHandlerRabbitmqIT.java
@@ -27,6 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -193,7 +194,7 @@ class SickNoteEventHandlerRabbitmqIT extends SingleTenantTestContainersBase {
         final TenantId tenantId = new TenantId(TENANT_ID);
         when(tenantContextHolder.getCurrentTenantId()).thenReturn(Optional.of(tenantId));
 
-        final AbsenceWrite absence = new AbsenceWrite(1L, userId, startOfDay, startOfDay, FULL, SICK);
+        final AbsenceWrite absence = new AbsenceWrite(1L, userId, startOfDay, startOfDay, FULL, Duration.ZERO, SICK);
         absenceWriteService.addAbsence(absence);
 
         // CANCEL sick note absence

--- a/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarTest.java
@@ -22,7 +22,6 @@ import static de.focusshift.zeiterfassung.absence.AbsenceTypeCategory.OVERTIME;
 import static de.focusshift.zeiterfassung.absence.DayLength.FULL;
 import static de.focusshift.zeiterfassung.absence.DayLength.MORNING;
 import static de.focusshift.zeiterfassung.absence.DayLength.NOON;
-import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class WorkingTimeCalendarTest {

--- a/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarTest.java
@@ -1,15 +1,28 @@
 package de.focusshift.zeiterfassung.workingtime;
 
+import de.focusshift.zeiterfassung.absence.Absence;
+import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
+import de.focusshift.zeiterfassung.user.UserId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static de.focusshift.zeiterfassung.absence.AbsenceColor.PINK;
+import static de.focusshift.zeiterfassung.absence.AbsenceTypeCategory.HOLIDAY;
+import static de.focusshift.zeiterfassung.absence.AbsenceTypeCategory.OVERTIME;
+import static de.focusshift.zeiterfassung.absence.DayLength.FULL;
+import static de.focusshift.zeiterfassung.absence.DayLength.MORNING;
+import static de.focusshift.zeiterfassung.absence.DayLength.NOON;
+import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class WorkingTimeCalendarTest {
@@ -53,5 +66,139 @@ class WorkingTimeCalendarTest {
 
         final PlannedWorkingHours actual = sut.plannedWorkingHours(now, now.plusDays(2));
         assertThat(actual).isEqualTo(new PlannedWorkingHours(Duration.ofHours(16)));
+    }
+
+    @Test
+    void ensureShouldHoursForOvertimeReduction() {
+        final LocalDate today = LocalDate.now();
+        final Instant date = today.atStartOfDay().toInstant(ZoneOffset.UTC);
+
+        final Absence applicationOvertimeReduction = new Absence(
+            new UserId("user"),
+            date,
+            date,
+            FULL,
+            locale -> "de",
+            PINK,
+            OVERTIME,
+            Duration.ofHours(6L)
+        );
+
+        final WorkingTimeCalendar sut = new WorkingTimeCalendar(Map.of(
+            today, PlannedWorkingHours.EIGHT
+        ), Map.of(today, List.of(applicationOvertimeReduction)));
+
+        assertThat(sut.shouldWorkingHours(today)).hasValue(new ShouldWorkingHours(Duration.ofHours(2)));
+    }
+
+    @Test
+    void ensureShouldHoursForOvertimeReductionAtMorningAndApplicationForLeaveAtNoon() {
+        final LocalDate today = LocalDate.now();
+        final Instant date = today.atStartOfDay().toInstant(ZoneOffset.UTC);
+
+        final Absence applicationOvertimeReduction = new Absence(
+            new UserId("user"),
+            date,
+            date,
+            MORNING,
+            locale -> "de",
+            PINK,
+            OVERTIME,
+            Duration.ofHours(4L)
+        );
+
+        final Absence applicationForLeave = new Absence(
+            new UserId("user"),
+            date,
+            date,
+            NOON,
+            locale -> "de",
+            PINK,
+            HOLIDAY
+        );
+
+        final WorkingTimeCalendar sut = new WorkingTimeCalendar(Map.of(
+            today, PlannedWorkingHours.EIGHT
+        ), Map.of(today, List.of(applicationOvertimeReduction, applicationForLeave)));
+
+        assertThat(sut.shouldWorkingHours(today)).hasValue(ShouldWorkingHours.ZERO);
+    }
+
+    @Test
+    void ensureShouldHoursZeroForTwoApplicationForLeave() {
+        final LocalDate today = LocalDate.now();
+        final Instant date = today.atStartOfDay().toInstant(ZoneOffset.UTC);
+
+        final Absence morning = new Absence(
+            new UserId("user"),
+            date,
+            date,
+            MORNING,
+            locale -> "de",
+            PINK,
+            HOLIDAY
+        );
+
+        final Absence noon = new Absence(
+            new UserId("user"),
+            date,
+            date,
+            NOON,
+            locale -> "de",
+            PINK,
+            HOLIDAY
+        );
+
+        final WorkingTimeCalendar sut = new WorkingTimeCalendar(Map.of(
+            today, PlannedWorkingHours.EIGHT
+        ), Map.of(today, List.of(morning, noon)));
+
+        assertThat(sut.shouldWorkingHours(today)).hasValue(ShouldWorkingHours.ZERO);
+    }
+
+    @Test
+    void ensureShouldHoursAreZeroForOvertimeReductionWithMoreThanPlannedWorkingHours() {
+        final LocalDate today = LocalDate.now();
+        final Instant date = today.atStartOfDay().toInstant(ZoneOffset.UTC);
+
+        final Absence applicationOvertimeReduction = new Absence(
+            new UserId("user"),
+            date,
+            date,
+            MORNING,
+            locale -> "de",
+            PINK,
+            OVERTIME,
+            Duration.ofHours(10L)
+        );
+
+        final WorkingTimeCalendar sut = new WorkingTimeCalendar(Map.of(
+            today, PlannedWorkingHours.EIGHT
+        ), Map.of(today, List.of(applicationOvertimeReduction)));
+
+        assertThat(sut.shouldWorkingHours(today)).hasValue(ShouldWorkingHours.ZERO);
+    }
+
+    @Test
+    void ensureShouldHoursAreZeroForFullDayApplicationForLeave() {
+        final LocalDate today = LocalDate.now();
+        final Instant date = today.atStartOfDay().toInstant(ZoneOffset.UTC);
+
+        final Absence applicationOvertimeReduction = new Absence(
+            new UserId("user"),
+            date,
+            date,
+            FULL,
+            locale -> "de",
+            PINK,
+            HOLIDAY,
+            Duration.ofHours(10L)
+        );
+
+        final WorkingTimeCalendar sut = new WorkingTimeCalendar(Map.of(
+            today, PlannedWorkingHours.EIGHT
+        ), Map.of(today, List.of(applicationOvertimeReduction)));
+
+        assertThat(sut.shouldWorkingHours(today)).hasValue(ShouldWorkingHours.ZERO);
     }
 }


### PR DESCRIPTION
#1290

- [x] Anteilige Abbildung in der ZE bei Abwesenheit über mehrere Tage

Here are some things you should have thought about:

**Multi-Tenancy**
- [x] Extended new entities with `AbstractTenantAwareEntity`?
- [x] New entity added to `TenantAwareDatabaseConfiguration`?
- [x] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
