### PR TITLE
Fix application startup for local multitenant environment

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/tenancy/registration/property/TenantRegistryFromOAuthPropertiesImporterService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/tenancy/registration/property/TenantRegistryFromOAuthPropertiesImporterService.java
@@ -3,8 +3,10 @@ package de.focusshift.zeiterfassung.tenancy.registration.property;
 import de.focusshift.zeiterfassung.tenancy.registration.TenantRegistration;
 import de.focusshift.zeiterfassung.tenancy.registration.TenantRegistrationService;
 import org.slf4j.Logger;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -19,6 +21,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 @ConditionalOnBean(TenantRegistrationService.class)
 @ConditionalOnProperty(value = "zeiterfassung.tenant.registration.property.oauth.enabled", havingValue = "true")
 @EnableConfigurationProperties(TenantRegistryFromOAuthConfigurationProperties.class)
+@AutoConfiguration(after = {OAuth2ClientAutoConfiguration.class})
 class TenantRegistryFromOAuthPropertiesImporterService {
 
     private static final Logger LOG = getLogger(lookup().lookupClass());


### PR DESCRIPTION
Since spring boot 3.5 auto configuration of OAuth2ClientProperties is done by OAuth2ClientAutoConfiguration


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
