### PR TITLE
Fix fetching time-entries considering timezone

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImpl.java
@@ -462,8 +462,10 @@ class TimeEntryServiceImpl implements TimeEntryService {
         return new TimeEntry(new TimeEntryId(entity.getId()), userIdComposite, entity.getComment(), startDateTime, endDateTime, entity.isBreak());
     }
 
-    private static Instant toInstant(LocalDate localDate) {
-        return localDate.atStartOfDay(UTC).toInstant();
+    private Instant toInstant(LocalDate localDate) {
+        // this must actually be the invoker point of view.
+        // this does not necessarily have to be the logged-in user!
+        return localDate.atStartOfDay().atZone(userSettingsProvider.zoneId()).toInstant();
     }
 
     private <T> boolean hasBeenModified(Supplier<T> a, Supplier<T> b) {

--- a/src/main/java/de/focusshift/zeiterfassung/user/UserSettingsProviderImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/user/UserSettingsProviderImpl.java
@@ -20,6 +20,7 @@ class UserSettingsProviderImpl implements UserSettingsProvider {
         // once this value becomes dynamic,
         // we need to consider handling of DayLockedEvent and publishing OvertimeRabbitEvent.
         // whether a day is locked or not depends on the zoneId. a date can be locked in Berlin, but not in Los Angeles yet.
+        // furthermore check current usage and maybe refactor method signatures since zoneId point ov view is not correct anymore.
         return EUROPE_BERLIN;
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceIT.java
@@ -1,0 +1,79 @@
+package de.focusshift.zeiterfassung.timeentry;
+
+import de.focusshift.zeiterfassung.SingleTenantTestContainersBase;
+import de.focusshift.zeiterfassung.security.SecurityRole;
+import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
+import de.focusshift.zeiterfassung.tenancy.user.TenantUser;
+import de.focusshift.zeiterfassung.tenancy.user.TenantUserService;
+import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
+import de.focusshift.zeiterfassung.usermanagement.User;
+import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class TimeEntryServiceIT extends SingleTenantTestContainersBase {
+
+    @Autowired
+    private TimeEntryService timeEntryService;
+    @Autowired
+    private UserManagementService userManagementService;
+    @Autowired
+    private TenantUserService tenantUserService;
+    @Autowired
+    private TimeEntryRepository repository;
+
+    @Test
+    void ensureGetTimeEntriesConsideringTimeZones() {
+
+        final User user = createAnyUser();
+
+        final ZonedDateTime start1 = ZonedDateTime.parse("2025-06-04T23:00:00+00:00[UTC]");
+        final ZonedDateTime end1 = ZonedDateTime.parse("2025-06-05T01:00:00+00:00[UTC]");
+        final TimeEntry timeEntry1Valid = timeEntryService.createTimeEntry(user.userLocalId(), "comment", start1, end1, false);
+
+        final ZonedDateTime start2 = ZonedDateTime.parse("2025-06-05T23:00:00+00:00[UTC]");
+        final ZonedDateTime end2 = ZonedDateTime.parse("2025-06-06T03:00:00+00:00[UTC]");
+        final TimeEntry timeEntry2Valid = timeEntryService.createTimeEntry(user.userLocalId(), "comment", start2, end2, false);
+
+        final ZonedDateTime startUtc = ZonedDateTime.parse("2025-06-06T21:10:00+00:00[UTC]");
+        final ZonedDateTime endUtc = ZonedDateTime.parse("2025-06-06T23:40:00+00:00[UTC]");
+        final TimeEntry timeEntry3ValidUtc = timeEntryService.createTimeEntry(user.userLocalId(), "comment", startUtc, endUtc, false);
+
+        final ZonedDateTime startInvalid = ZonedDateTime.parse("2025-06-06T23:00:00+00:00[UTC]");
+        final ZonedDateTime endInvalid = ZonedDateTime.parse("2025-06-07T01:00:00+00:00[UTC]");
+        timeEntryService.createTimeEntry(user.userLocalId(), "comment", startInvalid, endInvalid, false);
+
+        // timeEntryService uses the Clock from configuration which is UTC.
+        // and it has to return the created Europe/Berlin since it touches the requested date.
+        final LocalDate requestedStart = LocalDate.parse("2025-06-05");
+        final LocalDate requestedEndExclusive = LocalDate.parse("2025-06-07");
+        final Map<UserIdComposite, List<TimeEntry>> actual = timeEntryService.getEntriesForAllUsers(requestedStart, requestedEndExclusive);
+
+        assertThat(actual).contains(Map.entry(user.userIdComposite(), List.of(timeEntry3ValidUtc, timeEntry2Valid, timeEntry1Valid)));
+
+        // just ensure timeEntries exist
+        assertThat(repository.findAll()).hasSize(4);
+    }
+
+    private User createAnyUser() {
+        final String userUuid = UUID.randomUUID().toString();
+        final EMailAddress userEmail = new EMailAddress("bruce@example.org");
+        final List<SecurityRole> userRoles = List.of(ZEITERFASSUNG_USER);
+        final TenantUser tenantUser = tenantUserService.createNewUser(userUuid, "Bruce", "Wayne", userEmail, userRoles);
+        return userManagementService.findUserById(new UserId(tenantUser.id())).orElseThrow();
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryServiceImplTest.java
@@ -1094,6 +1094,9 @@ class TimeEntryServiceImplTest {
     @Test
     void ensureGetEntriesForAllUsers() {
 
+        final ZoneId userZoneId = ZoneId.of("Europe/Berlin");
+        when(userSettingsProvider.zoneId()).thenReturn(userZoneId);
+
         final Instant now = Instant.now();
         final LocalDate from = LocalDate.of(2023, 1, 1);
         final LocalDate toExclusive = LocalDate.of(2023, 2, 1);
@@ -1106,7 +1109,7 @@ class TimeEntryServiceImplTest {
         final LocalDateTime entryBreakEnd = LocalDateTime.of(toExclusive, LocalTime.of(13, 0, 0));
         final TimeEntryEntity timeEntryBreakEntity = new TimeEntryEntity(2L, "pinguin", "deserved break", entryBreakStart.toInstant(UTC), ZONE_ID_UTC, entryBreakEnd.toInstant(UTC), ZONE_ID_UTC, now, true);
 
-        when(timeEntryRepository.findAllByStartGreaterThanEqualAndStartLessThanOrderByStartDesc(from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
+        when(timeEntryRepository.findAllByStartGreaterThanEqualAndStartLessThanOrderByStartDesc(from.atStartOfDay().atZone(userZoneId).toInstant(), toExclusive.atStartOfDay().atZone(userZoneId).toInstant()))
             .thenReturn(List.of(timeEntryEntity, timeEntryBreakEntity));
 
         final UserId batmanId = new UserId("batman");
@@ -1146,6 +1149,9 @@ class TimeEntryServiceImplTest {
     @Test
     void ensureGetEntries() {
 
+        final ZoneId userZoneId = ZoneId.of("Europe/Berlin");
+        when(userSettingsProvider.zoneId()).thenReturn(userZoneId);
+
         final UserId batmanId = new UserId("uuid-1");
         final UserLocalId batmanLocalId = new UserLocalId(1L);
         final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
@@ -1171,7 +1177,7 @@ class TimeEntryServiceImplTest {
         final LocalDateTime entryBreakEnd = LocalDateTime.of(toExclusive, LocalTime.of(13, 0, 0));
         final TimeEntryEntity timeEntryBreakEntity = new TimeEntryEntity(2L, "uuid-2", "deserved break", entryBreakStart.toInstant(UTC), ZONE_ID_UTC, entryBreakEnd.toInstant(UTC), ZONE_ID_UTC, now, true);
 
-        when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(List.of("uuid-1", "uuid-2"), from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
+        when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(List.of("uuid-1", "uuid-2"), from.atStartOfDay().atZone(userZoneId).toInstant(), toExclusive.atStartOfDay().atZone(userZoneId).toInstant()))
             .thenReturn(List.of(timeEntryEntity, timeEntryBreakEntity));
 
         final Map<UserIdComposite, List<TimeEntry>> actual = sut.getEntries(from, toExclusive, List.of(batmanLocalId, robinLocalId));
@@ -1199,6 +1205,9 @@ class TimeEntryServiceImplTest {
     @Test
     void ensureGetEntriesByUserLocalIdsReturnsValuesForEveryAskedUserLocalId() {
 
+        final ZoneId userZoneId = ZoneId.of("Europe/Berlin");
+        when(userSettingsProvider.zoneId()).thenReturn(userZoneId);
+
         final UserId userId = new UserId("batman");
         final UserLocalId userLocalId = new UserLocalId(1L);
         final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
@@ -1208,7 +1217,7 @@ class TimeEntryServiceImplTest {
         final LocalDate from = LocalDate.of(2023, 1, 1);
         final LocalDate toExclusive = LocalDate.of(2023, 2, 1);
 
-        when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(List.of("batman"), from.atStartOfDay(UTC).toInstant(), toExclusive.atStartOfDay(UTC).toInstant()))
+        when(timeEntryRepository.findAllByOwnerIsInAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc(List.of("batman"), from.atStartOfDay().atZone(userZoneId).toInstant(), toExclusive.atStartOfDay().atZone(userZoneId).toInstant()))
             .thenReturn(List.of());
 
         final Map<UserIdComposite, List<TimeEntry>> actual = sut.getEntries(from, toExclusive, List.of(userLocalId));
@@ -1222,6 +1231,9 @@ class TimeEntryServiceImplTest {
 
     @Test
     void ensureGetEntriesSortedByStart_NewestFirst() {
+
+        final ZoneId userZoneId = ZoneId.of("Europe/Berlin");
+        when(userSettingsProvider.zoneId()).thenReturn(userZoneId);
 
         final LocalDate periodFrom = LocalDate.of(2022, 1, 3);
         final LocalDate periodToExclusive = LocalDate.of(2022, 1, 10);
@@ -1238,8 +1250,8 @@ class TimeEntryServiceImplTest {
         final LocalDateTime entryEnd2 = LocalDateTime.of(periodToExclusive, LocalTime.of(8, 30, 0));
         final TimeEntryEntity timeEntryEntity2 = new TimeEntryEntity(3L, "batman", "waking up *zzzz", entryStart2.toInstant(UTC), ZoneId.of("UTC"), entryEnd2.toInstant(UTC), ZoneId.of("UTC"), Instant.now(), false);
 
-        final Instant periodStartInstant = periodFrom.atStartOfDay(UTC).toInstant();
-        final Instant periodEndInstant = periodToExclusive.atStartOfDay(UTC).toInstant();
+        final Instant periodStartInstant = periodFrom.atStartOfDay().atZone(userZoneId).toInstant();
+        final Instant periodEndInstant = periodToExclusive.atStartOfDay().atZone(userZoneId).toInstant();
         when(timeEntryRepository.findAllByOwnerAndStartGreaterThanEqualAndStartLessThanOrderByStartDesc("batman", periodStartInstant, periodEndInstant))
             .thenReturn(List.of(timeEntryEntity, timeEntryBreakEntity, timeEntryEntity2));
 


### PR DESCRIPTION
Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
