### PR TITLE
enable locking of time entries by default

### DIFF
--- a/src/main/resources/db/changelog/changelog-2.23.4-locking-time-entries-default-to-true.xml
+++ b/src/main/resources/db/changelog/changelog-2.23.4-locking-time-entries-default-to-true.xml
@@ -1,0 +1,23 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd">
+
+  <changeSet author="schneider" id="locking-time-entries-default-to-true">
+    <preConditions>
+      <tableExists tableName="settings_locking_time_entries"/>
+      <columnExists tableName="settings_locking_time_entries" columnName="locking_is_active"/>
+    </preConditions>
+
+    <dropDefaultValue
+      tableName="settings_locking_time_entries"
+      columnName="locking_is_active"
+      columnDataType="BOOLEAN" />
+
+    <addDefaultValue
+      tableName="settings_locking_time_entries"
+      columnName="locking_is_active"
+      columnDataType="BOOLEAN"
+      defaultValueBoolean="true" />
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-main.xml
+++ b/src/main/resources/db/changelog/db.changelog-main.xml
@@ -36,4 +36,5 @@
   <include relativeToChangelogFile="true" file="changelog-2.22.0-update-tenant-user-uuid-length.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.22.0-add-absence-overtime-hours.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.22.0-add-shedlock.xml"/>
+  <include relativeToChangelogFile="true" file="changelog-2.23.4-locking-time-entries-default-to-true.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
closes #1464


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
