### PR TITLE
Substract breaks from working times

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDay.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDay.java
@@ -1,11 +1,19 @@
 package de.focusshift.zeiterfassung.timeentry;
 
+
 import de.focusshift.zeiterfassung.absence.Absence;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
+import static java.time.Duration.between;
+import static java.util.Comparator.comparing;
+import static java.util.function.Predicate.not;
 
 /**
  * @param locked              whether this day is locked or not.
@@ -33,9 +41,66 @@ record TimeEntryDay(
     }
 
     public WorkDuration workDuration() {
-        return timeEntries
-            .stream()
-            .map(TimeEntry::workDuration)
-            .reduce(WorkDuration.ZERO, WorkDuration::plus);
+        // Merge work intervals
+        final List<TimeRange> workIntervals = timeEntries.stream()
+            .filter(not(TimeEntry::isBreak))
+            .map(e -> new TimeRange(e.start(), e.end()))
+            .sorted(comparing(TimeRange::start))
+            .toList();
+        final List<TimeRange> mergedWork = mergeIntervals(workIntervals);
+
+        // Merge break intervals
+        final List<TimeRange> breakIntervals = timeEntries.stream()
+            .filter(TimeEntry::isBreak)
+            .map(e -> new TimeRange(e.start(), e.end()))
+            .sorted(comparing(TimeRange::start))
+            .toList();
+        final List<TimeRange> mergedBreaks = mergeIntervals(breakIntervals);
+
+        // Collect overlaps between work and break using streams
+        final List<TimeRange> overlaps = mergedWork.stream()
+            .flatMap(work -> mergedBreaks.stream()
+                .map(brk -> {
+                    final ZonedDateTime start = work.start().isAfter(brk.start()) ? work.start() : brk.start();
+                    final ZonedDateTime end = work.end().isBefore(brk.end()) ? work.end() : brk.end();
+                    return end.isAfter(start) ? new TimeRange(start, end) : null;
+                })
+                .filter(Objects::nonNull)
+            )
+            .sorted(comparing(TimeRange::start))
+            .toList();
+
+        // Merge overlaps
+        final List<TimeRange> mergedOverlaps = mergeIntervals(overlaps);
+
+        // Calculate work time using streams
+        final Duration totalWork = mergedWork.stream()
+            .map(work -> between(work.start(), work.end()))
+            .reduce(Duration.ZERO, Duration::plus);
+
+        // Subtract break time using streams
+        final Duration totalBreak = mergedOverlaps.stream()
+            .map(interval -> between(interval.start(), interval.end()))
+            .reduce(Duration.ZERO, Duration::plus);
+
+        return new WorkDuration(totalWork.minus(totalBreak));
+    }
+
+    private static List<TimeRange> mergeIntervals(List<TimeRange> intervals) {
+        final List<TimeRange> merged = new ArrayList<>();
+        for (final TimeRange interval : intervals) {
+            if (merged.isEmpty() || merged.getLast().end().isBefore(interval.start())) {
+                merged.add(interval);
+            } else {
+                final TimeRange last = merged.removeLast();
+                final ZonedDateTime newStart = last.start();
+                final ZonedDateTime newEnd = last.end().isAfter(interval.end()) ? last.end() : interval.end();
+                merged.add(new TimeRange(newStart, newEnd));
+            }
+        }
+        return merged;
+    }
+
+    private record TimeRange(ZonedDateTime start, ZonedDateTime end) {
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryWeek.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryWeek.java
@@ -46,7 +46,6 @@ record TimeEntryWeek(
             .stream()
             .map(TimeEntryDay::timeEntries)
             .flatMap(Collection::stream)
-            .filter(not(TimeEntry::isBreak))
             .map(TimeEntry::workDuration)
             .reduce(WorkDuration.ZERO, WorkDuration::plus);
     }

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDayTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryDayTest.java
@@ -1,0 +1,82 @@
+package de.focusshift.zeiterfassung.timeentry;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TimeEntryDayTest {
+
+    @Test
+    void workDurationForTimeEntriesOnly() {
+        final TimeEntry e1 = entry("2025-09-26T08:00:00Z", "2025-09-26T09:00:00Z", false);
+        final TimeEntry e2 = entry("2025-09-26T09:00:00Z", "2025-09-26T10:00:00Z", false);
+        final List<TimeEntry> timeEntries = List.of(e1, e2);
+        final TimeEntryDay day = new TimeEntryDay(false, LocalDate.now(), null, null, timeEntries, null);
+        assertThat(day.workDuration().durationInMinutes()).isEqualTo(Duration.ofHours(2));
+    }
+
+    @Test
+    void workDurationForTimeEntriesOnlyWithOverlap() {
+        final TimeEntry e1 = entry("2025-09-26T08:00:00Z", "2025-09-26T09:00:00Z", false);
+        final TimeEntry e2 = entry("2025-09-26T08:30:00Z", "2025-09-26T09:30:00Z", false);
+        final List<TimeEntry> timeEntries = List.of(e1, e2);
+        final TimeEntryDay day = new TimeEntryDay(false, LocalDate.now(), null, null, timeEntries, null);
+        assertThat(day.workDuration().durationInMinutes()).isEqualTo(Duration.ofMinutes(90));
+    }
+
+    @Test
+    void workDurationForTimeEntryWithOverlappingBreak() {
+        final TimeEntry timeEntry = entry("2025-09-26T08:00:00Z", "2025-09-26T17:00:00Z", false);
+        final TimeEntry breakEntry = entry("2025-09-26T12:00:00Z", "2025-09-26T13:00:00Z", true);
+        final List<TimeEntry> timeEntries = List.of(timeEntry, breakEntry);
+        final TimeEntryDay day = new TimeEntryDay(false, LocalDate.now(), null, null, timeEntries, null);
+        assertThat(day.workDuration().durationInMinutes()).isEqualTo(Duration.ofHours(8));
+    }
+
+    @Test
+    void workDurationForTimeEntryWithOverlappingBreakAtStart() {
+        final TimeEntry timeEntry = entry("2025-09-26T08:00:00Z", "2025-09-26T17:00:00Z", false);
+        final TimeEntry breakEntry = entry("2025-09-26T07:00:00Z", "2025-09-26T09:00:00Z", true);
+        final List<TimeEntry> timeEntries = List.of(timeEntry, breakEntry);
+        final TimeEntryDay day = new TimeEntryDay(false, LocalDate.now(), null, null, timeEntries, null);
+        assertThat(day.workDuration().durationInMinutes()).isEqualTo(Duration.ofHours(8));
+    }
+
+    @Test
+    void workDurationForTimeEntryWithOverlappingBreakAtEnd() {
+        final TimeEntry timeEntry = entry("2025-09-26T08:00:00Z", "2025-09-26T17:00:00Z", false);
+        final TimeEntry breakEntry = entry("2025-09-26T16:00:00Z", "2025-09-26T18:00:00Z", true);
+        final List<TimeEntry> timeEntries = List.of(timeEntry, breakEntry);
+        final TimeEntryDay day = new TimeEntryDay(false, LocalDate.now(), null, null, timeEntries, null);
+        assertThat(day.workDuration().durationInMinutes()).isEqualTo(Duration.ofHours(8));
+    }
+
+    @Test
+    void workDurationForTimeEntriesWithOverlappingBreak() {
+        final TimeEntry e1 = entry("2025-09-26T08:00:00Z", "2025-09-26T12:15:00Z", false);
+        final TimeEntry e2 = entry("2025-09-26T12:45:00Z", "2025-09-26T17:00:00Z", false);
+        final TimeEntry breakEntry = entry("2025-09-26T12:00:00Z", "2025-09-26T13:00:00Z", true);
+        final List<TimeEntry> timeEntries = List.of(e1, e2, breakEntry);
+        final TimeEntryDay day = new TimeEntryDay(false, LocalDate.now(), null, null, timeEntries, null);
+        assertThat(day.workDuration().durationInMinutes()).isEqualTo(Duration.ofHours(8));
+    }
+
+    @Test
+    void workDurationForTimeEntriesWithMultipleOverlappingBreak() {
+        final TimeEntry timeEntry = entry("2025-09-26T08:00:00Z", "2025-09-26T17:00:00Z", false);
+        final TimeEntry b1 = entry("2025-09-26T12:00:00Z", "2025-09-26T13:00:00Z", true);
+        final TimeEntry b2 = entry("2025-09-26T12:30:00Z", "2025-09-26T13:30:00Z", true);
+        final List<TimeEntry> timeEntries = List.of(timeEntry, b1, b2);
+        final TimeEntryDay day = new TimeEntryDay(false, LocalDate.now(), null, null, timeEntries, null);
+        assertThat(day.workDuration().durationInMinutes()).isEqualTo(Duration.ofHours(7).plusMinutes(30));
+    }
+
+    private static TimeEntry entry(String start, String end, boolean isBreak) {
+        return new TimeEntry(null, null, "", ZonedDateTime.parse(start), ZonedDateTime.parse(end), isBreak);
+    }
+}


### PR DESCRIPTION
Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

closes #268 268

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
