### PR TITLE
fix wrongly visible overtime reduction entries

### DIFF
--- a/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImplTest.java
@@ -639,12 +639,20 @@ class WorkingTimeCalendarServiceImplTest {
 
             // just check absences (shouldWorkingHours calculation is covered by WorkingTimeCalendar test)
             // calendar must contain absences outside requested interval
-            assertThat(calendar.absence(LocalDate.of(2025, 12, 24))).hasValue(List.of(overtimeAbsence, christmasEve));
-            assertThat(calendar.absence(LocalDate.of(2025, 12, 25))).hasValue(List.of(overtimeAbsence, publicHoliday1));
-            assertThat(calendar.absence(LocalDate.of(2025, 12, 26))).hasValue(List.of(overtimeAbsence, publicHoliday2));
-            assertThat(calendar.absence(LocalDate.of(2025, 12, 31))).hasValue(List.of(overtimeAbsence, silvester));
-            assertThat(calendar.absence(LocalDate.of(2026, 1, 1))).hasValue(List.of(overtimeAbsence, publicHoliday3));
-            assertThat(calendar.absence(LocalDate.of(2026, 1, 6))).hasValue(List.of(overtimeAbsence, publicHoliday4));
+            assertThat(calendar.absence(LocalDate.of(2025, 12, 24))).hasValue(List.of(christmasEve));
+            assertThat(calendar.absence(LocalDate.of(2025, 12, 25))).hasValue(List.of(publicHoliday1));
+            assertThat(calendar.absence(LocalDate.of(2025, 12, 26))).hasValue(List.of(publicHoliday2));
+            assertThat(calendar.absence(LocalDate.of(2025, 12, 27))).hasValue(List.of()); // saturday
+            assertThat(calendar.absence(LocalDate.of(2025, 12, 28))).hasValue(List.of()); // sunday
+            assertThat(calendar.absence(LocalDate.of(2025, 12, 29))).hasValue(List.of(overtimeAbsence));
+            assertThat(calendar.absence(LocalDate.of(2025, 12, 30))).hasValue(List.of(overtimeAbsence));
+            assertThat(calendar.absence(LocalDate.of(2025, 12, 31))).hasValue(List.of(silvester));
+            assertThat(calendar.absence(LocalDate.of(2026, 1, 1))).hasValue(List.of(publicHoliday3));
+            assertThat(calendar.absence(LocalDate.of(2026, 1, 2))).hasValue(List.of()); // friday - no workday
+            assertThat(calendar.absence(LocalDate.of(2026, 1, 3))).hasValue(List.of()); // saturday
+            assertThat(calendar.absence(LocalDate.of(2026, 1, 4))).hasValue(List.of()); // sunday
+            assertThat(calendar.absence(LocalDate.of(2026, 1, 5))).hasValue(List.of(overtimeAbsence));
+            assertThat(calendar.absence(LocalDate.of(2026, 1, 6))).hasValue(List.of(publicHoliday4));
 
             // just peeking...
             // zero -> overtime reduction


### PR DESCRIPTION
closes #1756


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
