### PR TITLE
Feature/api timeentries

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,35 @@
+# Zeiterfassung REST API
+
+## Übersicht
+
+Die Zeiterfassung REST API ermöglicht es Nutzern, ihre Arbeitszeiteinträge programmatisch zu verwalten.
+
+## Authentifizierung
+
+Die API verwendet API-Keys zur Authentifizierung. Jeder Request muss einen gültigen API-Key im `Authorization` Header enthalten:
+
+```
+Authorization: Bearer zf_<your-api-key>
+```
+
+### API-Key erstellen
+
+1. Navigiere zu `/apikeys` in der Web-Oberfläche
+2. Erstelle einen neuen API-Key mit einer Beschreibung
+3. Kopiere den generierten Key - er wird nur einmal angezeigt!
+
+**Hinweis:** Die Permission `ZEITERFASSUNG_API_ACCESS` muss für den Nutzer aktiviert sein.
+
+## Basis-URL
+
+```
+https://your-zeiterfassung-instance/api
+```
+
+## Endpoint Dokumentation
+
+Die vollständige interaktive OpenAPI-Dokumentation ist verfügbar unter:
+
+```
+https://your-zeiterfassung-instance/swagger-ui/index.html
+```

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,13 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- API Documentation -->
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>2.7.0</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/de/focusshift/zeiterfassung/api/config/OpenApiConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/api/config/OpenApiConfiguration.java
@@ -14,7 +14,7 @@ public class OpenApiConfiguration {
     @Bean
     public OpenAPI zeiterfassungOpenAPI() {
         final String securitySchemeName = "bearerAuth";
-        
+
         return new OpenAPI()
             .info(new Info()
                 .title("Zeiterfassung API")

--- a/src/main/java/de/focusshift/zeiterfassung/api/config/OpenApiConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/api/config/OpenApiConfiguration.java
@@ -1,0 +1,32 @@
+package de.focusshift.zeiterfassung.api.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfiguration {
+
+    @Bean
+    public OpenAPI zeiterfassungOpenAPI() {
+        final String securitySchemeName = "bearerAuth";
+        
+        return new OpenAPI()
+            .info(new Info()
+                .title("Zeiterfassung API")
+                .description("REST API für die Zeiterfassung")
+                .version("1.0"))
+            .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+            .components(new Components()
+                .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                    .name(securitySchemeName)
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("API-Key")
+                    .description("API-Key zur Authentifizierung (Format: zf_...)")));
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/api/timeentry/TimeEntryApiController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/api/timeentry/TimeEntryApiController.java
@@ -1,0 +1,137 @@
+package de.focusshift.zeiterfassung.api.timeentry;
+
+import de.focusshift.zeiterfassung.security.oidc.CurrentOidcUser;
+import de.focusshift.zeiterfassung.timeentry.TimeEntry;
+import de.focusshift.zeiterfassung.timeentry.TimeEntryId;
+import de.focusshift.zeiterfassung.timeentry.TimeEntryService;
+import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/timeentries")
+@PreAuthorize("hasAuthority('ZEITERFASSUNG_API_ACCESS')")
+public class TimeEntryApiController {
+
+    private final TimeEntryService timeEntryService;
+
+    public TimeEntryApiController(TimeEntryService timeEntryService) {
+        this.timeEntryService = timeEntryService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TimeEntryApiResponse>> getTimeEntries(
+        @RequestParam(required = false) LocalDate from,
+        @RequestParam(required = false) LocalDate to,
+        @AuthenticationPrincipal CurrentOidcUser currentUser
+    ) {
+        final UserLocalId userLocalId = currentUser.getUserIdComposite().localId();
+        final LocalDate queryFrom = from != null ? from : LocalDate.now().minusMonths(1);
+        final LocalDate queryTo = to != null ? to : LocalDate.now().plusDays(1);
+
+        final List<TimeEntry> entries = timeEntryService.getEntries(queryFrom, queryTo, userLocalId);
+        final List<TimeEntryApiResponse> responses = entries.stream()
+            .map(this::toApiResponse)
+            .toList();
+
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<TimeEntryApiResponse> getTimeEntry(
+        @PathVariable Long id,
+        @AuthenticationPrincipal CurrentOidcUser currentUser
+    ) {
+        final TimeEntryId timeEntryId = new TimeEntryId(id);
+        return timeEntryService.findTimeEntry(timeEntryId)
+            .filter(te -> te.userIdComposite().equals(currentUser.getUserIdComposite()))
+            .map(this::toApiResponse)
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<TimeEntryApiResponse> createTimeEntry(
+        @Valid @RequestBody TimeEntryApiRequest request,
+        @AuthenticationPrincipal CurrentOidcUser currentUser
+    ) {
+        final UserLocalId userLocalId = currentUser.getUserIdComposite().localId();
+        final TimeEntry created = timeEntryService.createTimeEntry(
+            userLocalId,
+            request.comment(),
+            request.start(),
+            request.end(),
+            request.isBreak()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(toApiResponse(created));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<TimeEntryApiResponse> updateTimeEntry(
+        @PathVariable Long id,
+        @Valid @RequestBody TimeEntryApiRequest request,
+        @AuthenticationPrincipal CurrentOidcUser currentUser
+    ) {
+        final TimeEntryId timeEntryId = new TimeEntryId(id);
+        return timeEntryService.findTimeEntry(timeEntryId)
+            .filter(te -> te.userIdComposite().equals(currentUser.getUserIdComposite()))
+            .map(timeEntry -> {
+                try {
+                    final TimeEntry updated = timeEntryService.updateTimeEntry(
+                        timeEntryId,
+                        request.comment(),
+                        request.start(),
+                        request.end(),
+                        null,
+                        request.isBreak()
+                    );
+                    return ResponseEntity.ok(toApiResponse(updated));
+                } catch (Exception e) {
+                    return ResponseEntity.<TimeEntryApiResponse>badRequest().build();
+                }
+            })
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTimeEntry(
+        @PathVariable Long id,
+        @AuthenticationPrincipal CurrentOidcUser currentUser
+    ) {
+        final TimeEntryId timeEntryId = new TimeEntryId(id);
+        return timeEntryService.findTimeEntry(timeEntryId)
+            .filter(te -> te.userIdComposite().equals(currentUser.getUserIdComposite()))
+            .map(timeEntry -> {
+                timeEntryService.deleteTimeEntry(timeEntryId);
+                return ResponseEntity.<Void>noContent().build();
+            })
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    private TimeEntryApiResponse toApiResponse(TimeEntry timeEntry) {
+        return new TimeEntryApiResponse(
+            timeEntry.id().value(),
+            timeEntry.start(),
+            timeEntry.end(),
+            timeEntry.workDuration().duration(),
+            timeEntry.comment(),
+            timeEntry.isBreak()
+        );
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/api/timeentry/TimeEntryApiRequest.java
+++ b/src/main/java/de/focusshift/zeiterfassung/api/timeentry/TimeEntryApiRequest.java
@@ -1,0 +1,13 @@
+package de.focusshift.zeiterfassung.api.timeentry;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.ZonedDateTime;
+
+public record TimeEntryApiRequest(
+    @NotNull ZonedDateTime start,
+    @NotNull ZonedDateTime end,
+    String comment,
+    boolean isBreak
+) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/api/timeentry/TimeEntryApiResponse.java
+++ b/src/main/java/de/focusshift/zeiterfassung/api/timeentry/TimeEntryApiResponse.java
@@ -1,0 +1,14 @@
+package de.focusshift.zeiterfassung.api.timeentry;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+
+public record TimeEntryApiResponse(
+    Long id,
+    ZonedDateTime start,
+    ZonedDateTime end,
+    Duration duration,
+    String comment,
+    boolean isBreak
+) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKey.java
+++ b/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKey.java
@@ -1,0 +1,19 @@
+package de.focusshift.zeiterfassung.apikey;
+
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
+import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ApiKey(
+    Long id,
+    TenantId tenantId,
+    UserLocalId userId,
+    String label,
+    Instant createdAt,
+    Instant lastUsedAt,
+    Instant expiresAt,
+    boolean active
+) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyController.java
@@ -1,0 +1,74 @@
+package de.focusshift.zeiterfassung.apikey;
+
+import de.focus_shift.launchpad.api.HasLaunchpad;
+import de.focusshift.zeiterfassung.security.CurrentUser;
+import de.focusshift.zeiterfassung.security.oidc.CurrentOidcUser;
+import de.focusshift.zeiterfassung.timeclock.HasTimeClock;
+import de.focusshift.zeiterfassung.usermanagement.User;
+import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
+import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/apikeys")
+@PreAuthorize("hasAuthority('ZEITERFASSUNG_API_ACCESS')")
+public class ApiKeyController implements HasLaunchpad, HasTimeClock {
+
+    private final ApiKeyService apiKeyService;
+    private final UserManagementService userManagementService;
+
+    public ApiKeyController(ApiKeyService apiKeyService, UserManagementService userManagementService) {
+        this.apiKeyService = apiKeyService;
+        this.userManagementService = userManagementService;
+    }
+
+    @GetMapping
+    public String index(@CurrentUser CurrentOidcUser currentUser, Model model) {
+        final User user = userManagementService.findUserByLocalId(currentUser.getUserIdComposite().localId())
+            .orElseThrow();
+
+        final List<ApiKey> apiKeys = apiKeyService.findApiKeysByUser(currentUser.getUserIdComposite().localId());
+
+        model.addAttribute("apiKeys", apiKeys);
+        model.addAttribute("user", user);
+
+        return "apikeys/index";
+    }
+
+    @PostMapping
+    public String create(@CurrentUser CurrentOidcUser currentUser,
+                        @RequestParam String label,
+                        RedirectAttributes redirectAttributes) {
+        final User user = userManagementService.findUserByLocalId(currentUser.getUserIdComposite().localId())
+            .orElseThrow();
+
+        final ApiKeyCreationResult result = apiKeyService.createApiKey(user, label);
+
+        redirectAttributes.addFlashAttribute("createdApiKey", result.rawKey());
+        redirectAttributes.addFlashAttribute("createdApiKeyLabel", label);
+
+        return "redirect:/apikeys";
+    }
+
+    @PostMapping("/{id}/delete")
+    public String delete(@PathVariable Long id, @CurrentUser CurrentOidcUser currentUser) {
+        apiKeyService.deleteApiKey(id);
+        return "redirect:/apikeys";
+    }
+
+    @PostMapping("/{id}/toggle")
+    public String toggle(@PathVariable Long id, @CurrentUser CurrentOidcUser currentUser) {
+        apiKeyService.toggleApiKeyStatus(id);
+        return "redirect:/apikeys";
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyCreationResult.java
+++ b/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyCreationResult.java
@@ -1,0 +1,4 @@
+package de.focusshift.zeiterfassung.apikey;
+
+public record ApiKeyCreationResult(ApiKey apiKey, String rawKey) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyEntity.java
+++ b/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyEntity.java
@@ -1,0 +1,152 @@
+package de.focusshift.zeiterfassung.apikey;
+
+import de.focusshift.zeiterfassung.tenancy.tenant.AbstractTenantAwareEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
+import java.util.Objects;
+
+@Entity
+@Table(name = "api_key")
+public class ApiKeyEntity extends AbstractTenantAwareEntity {
+
+    @Id
+    @Column(name = "id", unique = true, nullable = false, updatable = false)
+    @SequenceGenerator(name = "api_key_seq", sequenceName = "api_key_seq")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "api_key_seq")
+    protected Long id;
+
+    @Column(name = "user_id", nullable = false)
+    @NotNull
+    private Long userId;
+
+    @Column(name = "key_hash", nullable = false, unique = true)
+    @NotNull
+    @Size(max = 255)
+    private String keyHash;
+
+    @Column(name = "label", nullable = false)
+    @NotNull
+    @Size(max = 255)
+    private String label;
+
+    @Column(name = "created_at", nullable = false)
+    @NotNull
+    private Instant createdAt;
+
+    @Column(name = "last_used_at")
+    private Instant lastUsedAt;
+
+    @Column(name = "expires_at")
+    private Instant expiresAt;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active = true;
+
+    protected ApiKeyEntity() {
+        super(null);
+    }
+
+    public ApiKeyEntity(String tenantId, Long userId, String keyHash, String label, Instant createdAt) {
+        super(tenantId);
+        this.userId = userId;
+        this.keyHash = keyHash;
+        this.label = label;
+        this.createdAt = createdAt;
+        this.active = true;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getKeyHash() {
+        return keyHash;
+    }
+
+    public void setKeyHash(String keyHash) {
+        this.keyHash = keyHash;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getLastUsedAt() {
+        return lastUsedAt;
+    }
+
+    public void setLastUsedAt(Instant lastUsedAt) {
+        this.lastUsedAt = lastUsedAt;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Instant expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApiKeyEntity that = (ApiKeyEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "ApiKeyEntity{" +
+            "id=" + id +
+            ", userId=" + userId +
+            ", label='" + label + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyRepository.java
+++ b/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyRepository.java
@@ -1,0 +1,21 @@
+package de.focusshift.zeiterfassung.apikey;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+interface ApiKeyRepository extends JpaRepository<ApiKeyEntity, Long> {
+
+    Optional<ApiKeyEntity> findByKeyHash(String keyHash);
+
+    List<ApiKeyEntity> findByUserId(Long userId);
+
+    @Modifying
+    @Query("UPDATE ApiKeyEntity a SET a.lastUsedAt = :lastUsedAt WHERE a.id = :id")
+    void updateLastUsedAt(@Param("id") Long id, @Param("lastUsedAt") Instant lastUsedAt);
+}

--- a/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyService.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.apikey;
 import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,11 +24,13 @@ public class ApiKeyService {
     private final ApiKeyRepository repository;
     private final PasswordEncoder passwordEncoder;
     private final Clock clock;
+    private final UserManagementService userManagementService;
 
-    public ApiKeyService(ApiKeyRepository repository, PasswordEncoder passwordEncoder, Clock clock) {
+    public ApiKeyService(ApiKeyRepository repository, PasswordEncoder passwordEncoder, Clock clock, UserManagementService userManagementService) {
         this.repository = repository;
         this.passwordEncoder = passwordEncoder;
         this.clock = clock;
+        this.userManagementService = userManagementService;
     }
 
     @Transactional
@@ -75,7 +78,7 @@ public class ApiKeyService {
                 }
 
                 repository.updateLastUsedAt(entity.getId(), clock.instant());
-                return Optional.empty(); // TODO: load user from entity.getUserId()
+                return userManagementService.findUserByLocalId(new UserLocalId(entity.getUserId()));
             }
         }
 

--- a/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/apikey/ApiKeyService.java
@@ -1,0 +1,117 @@
+package de.focusshift.zeiterfassung.apikey;
+
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
+import de.focusshift.zeiterfassung.usermanagement.User;
+import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ApiKeyService {
+
+    private static final int API_KEY_LENGTH = 32;
+    private static final String API_KEY_PREFIX = "zf_";
+
+    private final ApiKeyRepository repository;
+    private final PasswordEncoder passwordEncoder;
+    private final Clock clock;
+
+    public ApiKeyService(ApiKeyRepository repository, PasswordEncoder passwordEncoder, Clock clock) {
+        this.repository = repository;
+        this.passwordEncoder = passwordEncoder;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public ApiKeyCreationResult createApiKey(User user, String label) {
+        final String rawKey = generateApiKey();
+        final String keyHash = passwordEncoder.encode(rawKey);
+
+        final ApiKeyEntity entity = new ApiKeyEntity(
+            user.userIdComposite().tenantId().value(),
+            user.userIdComposite().localId().value(),
+            keyHash,
+            label,
+            clock.instant()
+        );
+
+        repository.save(entity);
+
+        final ApiKey apiKey = toApiKey(entity);
+        return new ApiKeyCreationResult(apiKey, rawKey);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApiKey> findApiKeysByUser(UserLocalId userId) {
+        return repository.findByUserId(userId.value()).stream()
+            .map(this::toApiKey)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ApiKey> findApiKeyById(Long id) {
+        return repository.findById(id).map(this::toApiKey);
+    }
+
+    @Transactional
+    public Optional<User> validateApiKey(String rawKey) {
+        if (!rawKey.startsWith(API_KEY_PREFIX)) {
+            return Optional.empty();
+        }
+
+        final List<ApiKeyEntity> allKeys = repository.findAll();
+        for (ApiKeyEntity entity : allKeys) {
+            if (entity.isActive() && passwordEncoder.matches(rawKey, entity.getKeyHash())) {
+                if (entity.getExpiresAt() != null && entity.getExpiresAt().isBefore(clock.instant())) {
+                    return Optional.empty();
+                }
+
+                repository.updateLastUsedAt(entity.getId(), clock.instant());
+                return Optional.empty(); // TODO: load user from entity.getUserId()
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Transactional
+    public void deleteApiKey(Long id) {
+        repository.deleteById(id);
+    }
+
+    @Transactional
+    public void toggleApiKeyStatus(Long id) {
+        repository.findById(id).ifPresent(entity -> {
+            entity.setActive(!entity.isActive());
+            repository.save(entity);
+        });
+    }
+
+    private String generateApiKey() {
+        final SecureRandom random = new SecureRandom();
+        final byte[] bytes = new byte[API_KEY_LENGTH];
+        random.nextBytes(bytes);
+        return API_KEY_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private ApiKey toApiKey(ApiKeyEntity entity) {
+        return new ApiKey(
+            entity.getId(),
+            new TenantId(entity.getTenantId()),
+            new UserLocalId(entity.getUserId()),
+            entity.getLabel(),
+            entity.getCreatedAt(),
+            entity.getLastUsedAt(),
+            entity.getExpiresAt(),
+            entity.isActive()
+        );
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/security/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/ApiKeyAuthenticationFilter.java
@@ -41,16 +41,11 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
         if (header != null && header.startsWith(BEARER_PREFIX)) {
             final String apiKey = header.substring(BEARER_PREFIX.length());
 
-            // Validiere API-Key und lade User
-            // TODO: ApiKeyService muss User zurückgeben
-            // Optional<User> userOpt = apiKeyService.validateApiKey(apiKey);
-            //
-            // userOpt.ifPresent(user -> {
-            //     CurrentOidcUser oidcUser = createOidcUser(user);
-            //     UsernamePasswordAuthenticationToken authentication =
-            //         new UsernamePasswordAuthenticationToken(oidcUser, null, oidcUser.getAuthorities());
-            //     SecurityContextHolder.getContext().setAuthentication(authentication);
-            // });
+            apiKeyService.validateApiKey(apiKey).ifPresent(user -> {
+                final UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(user, null, user.grantedAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            });
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/de/focusshift/zeiterfassung/security/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/ApiKeyAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package de.focusshift.zeiterfassung.security;
+
+import de.focusshift.zeiterfassung.apikey.ApiKeyService;
+import de.focusshift.zeiterfassung.security.oidc.CurrentOidcUser;
+import de.focusshift.zeiterfassung.usermanagement.User;
+import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final ApiKeyService apiKeyService;
+    private final UserManagementService userManagementService;
+
+    public ApiKeyAuthenticationFilter(ApiKeyService apiKeyService, UserManagementService userManagementService) {
+        this.apiKeyService = apiKeyService;
+        this.userManagementService = userManagementService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        @NonNull HttpServletRequest request,
+        @NonNull HttpServletResponse response,
+        @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        final String header = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            final String apiKey = header.substring(BEARER_PREFIX.length());
+
+            // Validiere API-Key und lade User
+            // TODO: ApiKeyService muss User zurückgeben
+            // Optional<User> userOpt = apiKeyService.validateApiKey(apiKey);
+            //
+            // userOpt.ifPresent(user -> {
+            //     CurrentOidcUser oidcUser = createOidcUser(user);
+            //     UsernamePasswordAuthenticationToken authentication =
+            //         new UsernamePasswordAuthenticationToken(oidcUser, null, oidcUser.getAuthorities());
+            //     SecurityContextHolder.getContext().setAuthentication(authentication);
+            // });
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
+        return !request.getRequestURI().startsWith("/api/");
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/security/SecurityRole.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/SecurityRole.java
@@ -43,7 +43,11 @@ public enum SecurityRole {
     /**
      * Allowed to edit permissions of all persons.
      */
-    ZEITERFASSUNG_PERMISSIONS_EDIT_ALL;
+    ZEITERFASSUNG_PERMISSIONS_EDIT_ALL,
+    /**
+     * Allowed to use the REST API.
+     */
+    ZEITERFASSUNG_API_ACCESS;
 
     public static final Set<SecurityRole> DEFAULT_USER_ROLES = Set.of(ZEITERFASSUNG_USER);
     public static final Set<SecurityRole> INITIAL_USER_ROLES = Set.of(ZEITERFASSUNG_USER, ZEITERFASSUNG_PERMISSIONS_EDIT_ALL);

--- a/src/main/java/de/focusshift/zeiterfassung/security/SecurityWebConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/SecurityWebConfiguration.java
@@ -1,5 +1,6 @@
 package de.focusshift.zeiterfassung.security;
 
+import de.focusshift.zeiterfassung.apikey.ApiKeyService;
 import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +32,7 @@ public class SecurityWebConfiguration {
     private final ClientRegistrationRepository clientRegistrationRepository;
     private final SessionService sessionService;
     private final UserManagementService userManagementService;
+    private final ApiKeyService apiKeyService;
 
     @Autowired
     SecurityWebConfiguration(
@@ -38,13 +40,15 @@ public class SecurityWebConfiguration {
         OidcClientInitiatedLogoutSuccessHandler oidcClientInitiatedLogoutSuccessHandler,
         ClientRegistrationRepository clientRegistrationRepository,
         SessionService sessionService,
-        UserManagementService userManagementService
+        UserManagementService userManagementService,
+        ApiKeyService apiKeyService
     ) {
         this.authenticationEntryPoint = authenticationEntryPoint;
         this.oidcClientInitiatedLogoutSuccessHandler = oidcClientInitiatedLogoutSuccessHandler;
         this.clientRegistrationRepository = clientRegistrationRepository;
         this.sessionService = sessionService;
         this.userManagementService = userManagementService;
+        this.apiKeyService = apiKeyService;
     }
 
     @Bean
@@ -86,6 +90,7 @@ public class SecurityWebConfiguration {
         );
 
         http.securityContext(securityContext -> securityContext.securityContextRepository(securityContextRepository));
+        http.addFilterBefore(new ApiKeyAuthenticationFilter(apiKeyService, userManagementService), BasicAuthenticationFilter.class);
         http.addFilterAfter(new ReloadAuthenticationAuthoritiesFilter(userManagementService, sessionService, securityContextRepository, tenantContextHolder), BasicAuthenticationFilter.class);
 
         //@formatter:on

--- a/src/main/java/de/focusshift/zeiterfassung/security/SecurityWebConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/SecurityWebConfiguration.java
@@ -59,6 +59,8 @@ public class SecurityWebConfiguration {
                 .requestMatchers("/favicons/**").permitAll()
                 .requestMatchers("/browserconfig.xml").permitAll()
                 .requestMatchers("/site.webmanifest").permitAll()
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .requestMatchers("/api/**").authenticated()
                 .requestMatchers("/", "/**").hasAuthority(ZEITERFASSUNG_USER.name())
                 .anyRequest().authenticated()
             );
@@ -69,8 +71,8 @@ public class SecurityWebConfiguration {
             )
         );
 
-        // exclude /actuator from csrf protection
-        http.securityMatcher(request -> !request.getRequestURI().startsWith("/actuator"))
+        // exclude /actuator and /api from csrf protection
+        http.securityMatcher(request -> !request.getRequestURI().startsWith("/actuator") && !request.getRequestURI().startsWith("/api"))
             .csrf(csrfConfigurer -> csrfConfigurer.csrfTokenRepository(new HttpSessionCsrfTokenRepository()));
 
         // maybe we can remove the authenticationEntryPoint customization, because

--- a/src/main/java/de/focusshift/zeiterfassung/tenancy/configuration/multi/TenantAwareDatabaseConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/tenancy/configuration/multi/TenantAwareDatabaseConfiguration.java
@@ -3,6 +3,7 @@ package de.focusshift.zeiterfassung.tenancy.configuration.multi;
 import com.zaxxer.hikari.HikariDataSource;
 import de.focusshift.zeiterfassung.absence.AbsenceTypeEntity;
 import de.focusshift.zeiterfassung.absence.AbsenceWriteEntity;
+import de.focusshift.zeiterfassung.apikey.ApiKeyEntity;
 import de.focusshift.zeiterfassung.companyvacation.CompanyVacationEntity;
 import de.focusshift.zeiterfassung.settings.FederalStateSettingsEntity;
 import de.focusshift.zeiterfassung.tenancy.tenant.TenantAwareRevisionEntity;
@@ -40,6 +41,7 @@ import static org.hibernate.cfg.AvailableSettings.BEAN_CONTAINER;
     basePackageClasses = {
         AbsenceWriteEntity.class,
         AbsenceTypeEntity.class,
+        ApiKeyEntity.class,
         TimeEntryEntity.class,
         TimeClockEntity.class,
         TenantUserEntity.class,

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/PermissionsController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/PermissionsController.java
@@ -129,6 +129,7 @@ class PermissionsController implements HasLaunchpad, HasTimeClock {
                 case ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL -> permissionsDto.setOvertimeEditAll(true);
                 case ZEITERFASSUNG_PERMISSIONS_EDIT_ALL -> permissionsDto.setPermissionsEditAll(true);
                 case ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL -> permissionsDto.setTimeEntryEditAll(true);
+                case ZEITERFASSUNG_API_ACCESS -> permissionsDto.setApiAccess(true);
                 case ZEITERFASSUNG_OPERATOR, ZEITERFASSUNG_USER -> { /* ok */ }
             }
         }
@@ -154,6 +155,7 @@ class PermissionsController implements HasLaunchpad, HasTimeClock {
                 case ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL -> adder.accept(permissionsDto::isOvertimeEditAll, role);
                 case ZEITERFASSUNG_PERMISSIONS_EDIT_ALL -> adder.accept(permissionsDto::isPermissionsEditAll, role);
                 case ZEITERFASSUNG_TIME_ENTRY_EDIT_ALL -> adder.accept(permissionsDto::isTimeEntryEditAll, role);
+                case ZEITERFASSUNG_API_ACCESS -> adder.accept(permissionsDto::isApiAccess, role);
                 case ZEITERFASSUNG_OPERATOR, ZEITERFASSUNG_USER -> { /* ok */ }
             }
         }

--- a/src/main/java/de/focusshift/zeiterfassung/usermanagement/PermissionsDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/usermanagement/PermissionsDto.java
@@ -8,6 +8,7 @@ class PermissionsDto {
     private boolean permissionsEditAll;
     private boolean timeEntryEditAll;
     private boolean globalSettings;
+    private boolean apiAccess;
 
     public boolean isViewReportAll() {
         return viewReportAll;
@@ -57,6 +58,14 @@ class PermissionsDto {
         this.globalSettings = globalSettings;
     }
 
+    public boolean isApiAccess() {
+        return apiAccess;
+    }
+
+    public void setApiAccess(boolean apiAccess) {
+        this.apiAccess = apiAccess;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
@@ -67,7 +76,8 @@ class PermissionsDto {
             && overtimeEditAll == that.overtimeEditAll
             && permissionsEditAll == that.permissionsEditAll
             && timeEntryEditAll == that.timeEntryEditAll
-            && globalSettings == that.globalSettings;
+            && globalSettings == that.globalSettings
+            && apiAccess == that.apiAccess;
     }
 
     @Override
@@ -78,6 +88,7 @@ class PermissionsDto {
         result = 31 * result + Boolean.hashCode(permissionsEditAll);
         result = 31 * result + Boolean.hashCode(timeEntryEditAll);
         result = 31 * result + Boolean.hashCode(globalSettings);
+        result = 31 * result + Boolean.hashCode(apiAccess);
         return result;
     }
 
@@ -90,6 +101,7 @@ class PermissionsDto {
             ", permissionsEditAll=" + permissionsEditAll +
             ", timeEntryEditAll=" + timeEntryEditAll +
             ", globalSettings=" + globalSettings +
+            ", apiAccess=" + apiAccess +
             '}';
     }
 }

--- a/src/main/resources/db/changelog/changelog-2.26.0-add-api-key.xml
+++ b/src/main/resources/db/changelog/changelog-2.26.0-add-api-key.xml
@@ -1,0 +1,69 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd">
+
+  <changeSet author="automated" id="add-api-key-table">
+
+    <preConditions>
+      <not>
+        <tableExists tableName="api_key"/>
+      </not>
+    </preConditions>
+
+    <createSequence sequenceName="api_key_seq" incrementBy="50"/>
+
+    <createTable tableName="api_key">
+      <column name="id" type="BIGINT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="PK_API_KEY"/>
+      </column>
+      <column name="tenant_id" type="VARCHAR(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="user_id" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="key_hash" type="VARCHAR(255)">
+        <constraints nullable="false" unique="true" uniqueConstraintName="UC_API_KEY_HASH"/>
+      </column>
+      <column name="label" type="VARCHAR(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="created_at" type="TIMESTAMP WITH TIME ZONE">
+        <constraints nullable="false"/>
+      </column>
+      <column name="last_used_at" type="TIMESTAMP WITH TIME ZONE"/>
+      <column name="expires_at" type="TIMESTAMP WITH TIME ZONE"/>
+      <column name="is_active" type="BOOLEAN" defaultValueBoolean="true">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <addForeignKeyConstraint baseColumnNames="tenant_id" baseTableName="api_key"
+                             constraintName="FK_API_KEY_TENANT_ID"
+                             deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION"
+                             referencedColumnNames="tenant_id" referencedTableName="tenant"/>
+
+    <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="api_key"
+                             constraintName="FK_API_KEY_TENANT_USER_ID"
+                             deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION"
+                             referencedColumnNames="id" referencedTableName="tenant_user"/>
+
+    <sql>
+      ALTER TABLE api_key ENABLE ROW LEVEL SECURITY;
+      DROP POLICY IF EXISTS api_key_tenant_isolation_policy ON api_key;
+      CREATE POLICY api_key_tenant_isolation_policy ON api_key
+      USING (tenant_id = current_setting('app.tenant_id', true)::VARCHAR);
+    </sql>
+
+    <createIndex tableName="api_key" indexName="IDX_API_KEY_USER_ID">
+      <column name="user_id"/>
+    </createIndex>
+
+    <createIndex tableName="api_key" indexName="IDX_API_KEY_TENANT_ID">
+      <column name="tenant_id"/>
+    </createIndex>
+
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-main.xml
+++ b/src/main/resources/db/changelog/db.changelog-main.xml
@@ -39,4 +39,5 @@
   <include relativeToChangelogFile="true" file="changelog-2.23.4-locking-time-entries-default-to-true.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.24.0-subtract-break-from-timeentry.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.25.0-add-company-vacation.xml"/>
+  <include relativeToChangelogFile="true" file="changelog-2.26.0-add-api-key.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
## feat: Add REST API with API-Key authentication and management

Here are some things you should have thought about:
**Multi-Tenancy**
- [x] Extended new entities with `AbstractTenantAwareEntity`?
- [x] New entity added to `TenantAwareDatabaseConfiguration`?
- [x] Tested with `dev-multitenant` profile?

# Features
- **REST API für Arbeitszeiteinträge**: CRUD-Operationen (GET, POST, PUT, DELETE)
- **API-Key Authentication**: Sichere Authentifizierung mittels gehashter API-Keys
- **API-Key Management**: Web-Interface zum Erstellen, Deaktivieren und Löschen von API-Keys
- **OpenAPI/Swagger Dokumentation**: Interaktive API-Dokumentation unter `/swagger-ui`
- **Permission Management**: Neue `ZEITERFASSUNG_API_ACCESS` Permission zur Kontrolle der API-Nutzung

# Endpoints
GET /api/timeentries - Alle Zeiteinträge mit optionalen Datumfiltern
GET /api/timeentries/{id} - Einzelnen Zeiteintrag abrufen
POST /api/timeentries - Neuen Zeiteintrag erstellen
PUT /api/timeentries/{id} - Zeiteintrag aktualisieren
DELETE /api/timeentries/{id} - Zeiteintrag löschen
GET /apikeys - API-Keys des Users verwalten
POST /apikeys - Neuen API-Key erstellen


# Documentation
- API-Dokumentation: [docs/api.md](docs/api.md)
- Swagger-UI: `/swagger-ui/index.html`

# Issues:
- #99 