### PR TITLE
fix running tests late night breaks them

### DIFF
--- a/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/absence/AbsenceServiceImplTest.java
@@ -135,13 +135,13 @@ class AbsenceServiceImplTest {
             final Map<LocalDate, List<Absence>> actual = sut.findAllAbsences(new UserId("user"), startDate, endDateExclusive);
             assertThat(actual)
                 .hasSize(7)
-                .containsEntry(LocalDate.ofInstant(today, UTC), List.of())
-                .containsEntry(LocalDate.ofInstant(today.plus(1, DAYS), UTC), List.of(expectedAbsence_1))
-                .containsEntry(LocalDate.ofInstant(today.plus(2, DAYS), UTC), List.of(expectedAbsence_1))
-                .containsEntry(LocalDate.ofInstant(today.plus(3, DAYS), UTC), List.of())
-                .containsEntry(LocalDate.ofInstant(today.plus(4, DAYS), UTC), List.of(expectedAbsence_2))
-                .containsEntry(LocalDate.ofInstant(today.plus(5, DAYS), UTC), List.of())
-                .containsEntry(LocalDate.ofInstant(today.plus(6, DAYS), UTC), List.of());
+                .containsEntry(LocalDate.ofInstant(today, berlin), List.of())
+                .containsEntry(LocalDate.ofInstant(today.plus(1, DAYS), berlin), List.of(expectedAbsence_1))
+                .containsEntry(LocalDate.ofInstant(today.plus(2, DAYS), berlin), List.of(expectedAbsence_1))
+                .containsEntry(LocalDate.ofInstant(today.plus(3, DAYS), berlin), List.of())
+                .containsEntry(LocalDate.ofInstant(today.plus(4, DAYS), berlin), List.of(expectedAbsence_2))
+                .containsEntry(LocalDate.ofInstant(today.plus(5, DAYS), berlin), List.of())
+                .containsEntry(LocalDate.ofInstant(today.plus(6, DAYS), berlin), List.of());
         }
 
         @ParameterizedTest
@@ -240,13 +240,13 @@ class AbsenceServiceImplTest {
 
             assertThat(actual)
                 .hasSize(7)
-                .containsEntry(LocalDate.ofInstant(today, UTC), List.of())
-                .containsEntry(LocalDate.ofInstant(today.plus(1, DAYS), UTC), List.of(expectedAbsence))
-                .containsEntry(LocalDate.ofInstant(today.plus(2, DAYS), UTC), List.of(expectedAbsence))
-                .containsEntry(LocalDate.ofInstant(today.plus(3, DAYS), UTC), List.of())
-                .containsEntry(LocalDate.ofInstant(today.plus(4, DAYS), UTC), List.of())
-                .containsEntry(LocalDate.ofInstant(today.plus(5, DAYS), UTC), List.of())
-                .containsEntry(LocalDate.ofInstant(today.plus(6, DAYS), UTC), List.of());
+                .containsEntry(LocalDate.ofInstant(today, berlin), List.of())
+                .containsEntry(LocalDate.ofInstant(today.plus(1, DAYS), berlin), List.of(expectedAbsence))
+                .containsEntry(LocalDate.ofInstant(today.plus(2, DAYS), berlin), List.of(expectedAbsence))
+                .containsEntry(LocalDate.ofInstant(today.plus(3, DAYS), berlin), List.of())
+                .containsEntry(LocalDate.ofInstant(today.plus(4, DAYS), berlin), List.of())
+                .containsEntry(LocalDate.ofInstant(today.plus(5, DAYS), berlin), List.of())
+                .containsEntry(LocalDate.ofInstant(today.plus(6, DAYS), berlin), List.of());
         }
     }
 

--- a/src/test/java/de/focusshift/zeiterfassung/settings/SettingsControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/settings/SettingsControllerTest.java
@@ -66,7 +66,8 @@ class SettingsControllerTest implements ControllerTest {
         final LockTimeEntriesSettings lockTimeEntriesSettings = new LockTimeEntriesSettings(true, 42);
 
         final Instant subtractBreakFeatureTimestamp = Instant.now();
-        final LocalDate subtractBreakFeatureDate = subtractBreakFeatureTimestamp.atZone(UTC).toLocalDate();
+        final ZoneId berlin = ZoneId.of("Europe/Berlin");
+        final LocalDate subtractBreakFeatureDate = subtractBreakFeatureTimestamp.atZone(berlin).toLocalDate();
         final SubtractBreakFromTimeEntrySettings subtractBreakFromTimeEntrySettings =
             new SubtractBreakFromTimeEntrySettings(true, Optional.of(subtractBreakFeatureTimestamp));
 


### PR DESCRIPTION
The tests used UTC to convert Instant.now() to LocalDate in assertions, while the production code uses the user's timezone (Europe/Berlin, UTC+1). When tests run after 23:00 UTC, Berlin is already the next calendar day, causing a date mismatch.


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
