### PR TITLE
add working time revision history

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkTimeServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkTimeServiceImpl.java
@@ -144,6 +144,8 @@ class WorkTimeServiceImpl implements WorkingTimeService {
         final User user = findUser(userLocalId);
 
         final WorkingTimeEntity saved = repository.save(entity);
+        LOG.info("Updated WorkingTime id={}", saved.getId());
+
         final List<WorkingTimeEntity> allEntitiesSorted = findAllWorkingTimeEntitiesSorted(userLocalId);
 
         applicationEventPublisher.publishEvent(new WorkingTimeUpdatedEvent(

--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeEntity.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import org.hibernate.envers.Audited;
 
 import java.time.LocalDate;
 import java.util.Objects;
@@ -15,7 +16,7 @@ import java.util.UUID;
 
 import static jakarta.persistence.EnumType.STRING;
 
-
+@Audited(withModifiedFlag = true)
 @Entity(name = "working_time")
 public class WorkingTimeEntity extends AbstractTenantAwareEntity {
 

--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeRepository.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeRepository.java
@@ -1,12 +1,13 @@
 package de.focusshift.zeiterfassung.workingtime;
 
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.history.RevisionRepository;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
-interface WorkingTimeRepository extends CrudRepository<WorkingTimeEntity, UUID> {
+interface WorkingTimeRepository extends CrudRepository<WorkingTimeEntity, UUID>, RevisionRepository<WorkingTimeEntity, UUID, Long> {
 
     List<WorkingTimeEntity> findAllByUserId(Long userId);
 

--- a/src/main/resources/db/changelog/changelog-2.26.0-add-working-time-versioning.xml
+++ b/src/main/resources/db/changelog/changelog-2.26.0-add-working-time-versioning.xml
@@ -1,0 +1,94 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+
+  <changeSet author="seber" id="add-working-time--audit-table">
+    <preConditions>
+      <not>
+        <tableExists tableName="working_time_aud"/>
+      </not>
+    </preConditions>
+
+    <createSequence sequenceName="working_time_aud_seq" incrementBy="50" />
+
+    <createTable tableName="working_time_aud">
+      <column name="id" type="BIGINT" />
+      <column name="tenant_id" type="VARCHAR(255)"/>
+      <column name="user_id" type="BIGINT" />
+      <column name="monday" type="VARCHAR" />
+      <column name="tuesday" type="VARCHAR" />
+      <column name="wednesday" type="VARCHAR" />
+      <column name="thursday" type="VARCHAR" />
+      <column name="friday" type="VARCHAR" />
+      <column name="saturday" type="VARCHAR" />
+      <column name="sunday" type="VARCHAR" />
+      <column name="federal_state" type="VARCHAR" />
+      <column name="valid_from" type="DATE" />
+      <column name="works_on_public_holiday" type="BOOLEAN" defaultValue="false" />
+
+      <!-- Add audit-specific columns -->
+      <column name="rev" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="revtype" type="TINYINT">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <addPrimaryKey tableName="working_time_aud" columnNames="id,rev" constraintName="PK_WORKING_TIME_AUD"/>
+
+    <!-- omit foreign key constraint to working_time.id so we have access to the history. -->
+    <!-- we may introduce a feature to delete the history as well by an authenticated person? -->
+    <!-- however, application has to delete the history on person delete! -->
+
+    <addForeignKeyConstraint baseTableName="working_time_aud"
+                             baseColumnNames="rev"
+                             referencedTableName="revinfo"
+                             referencedColumnNames="id"
+                             constraintName="FK_WORKING_TIME_AUD_REV"/>
+
+    <addForeignKeyConstraint baseTableName="working_time_aud"
+                             baseColumnNames="user_id"
+                             referencedTableName="tenant_user"
+                             referencedColumnNames="id"
+                             constraintName="FK_WORKING_TIME_AUD_OWNER"/>
+  </changeSet>
+
+  <changeSet author="seber" id="migrate-existing-working-time-to-audit">
+    <sql>
+      -- create the first revtype=INSERT audit item
+      -- for every working-time not existing in the _aud table yet
+      --
+      with new_rev as (
+        select nextval('revinfo_seq') as id,
+               extract(epoch from w.updated_at) * 1000 as timestamp,
+               w.tenant_id,
+               -- null owner since we don't know who created this working-time :(
+               null,
+               w.id as working_time_id
+        from working_time w
+        where w.id not in (select id from working_time_aud)
+      ),
+      insert_revinfo as (
+        -- first create the revinfo entry, to be able to reference the id in the _aud table
+        insert into revinfo (id, timestamp, tenant_id, updated_by)
+        select r.id, r.timestamp, r.tenant_id, r.updated_by from new_rev r
+      )
+      -- then create the final revtype=INSERT _aud entry
+      insert into working_time_aud (
+        id, tenant_id, user_id, monday, monday_mod, tuesday, tuesday_mod, wednesday, wednesday_mod, thursday,
+        thursday_mod, friday, friday_mod, saturday, saturday_mod, sunday, sunday_mod, valid_from, valid_from_mod,
+        works_on_public_holiday, works_on_public_holiday_mod, rev, revtype
+      )
+      select
+        -- tenant_id == null since tenant id is not set in future modification inserts anyway
+        -- tenant_id exists in the revinfo metadata.
+        w.id, null, w.user_id, true,
+        w.monday, true, w.tuesday, true, w.wednesday, true, w.thursday, true, w.friday, true, w.saturday, true,
+        w.sunday, true, w.valid_from, true, w.works_on_public_holiday, true, r.id, 0
+      from working_timne w
+      join new_rev r on r.working_time_id = w.id
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-main.xml
+++ b/src/main/resources/db/changelog/db.changelog-main.xml
@@ -39,4 +39,5 @@
   <include relativeToChangelogFile="true" file="changelog-2.23.4-locking-time-entries-default-to-true.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.24.0-subtract-break-from-timeentry.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.25.0-add-company-vacation.xml"/>
+  <include relativeToChangelogFile="true" file="changelog-2.26.0-add-working-time-versioning.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
closes #1817

Todos:
* [ ] siehe inline Kommentare
* [ ] `WorkingTimeEntity`
  * erweitern mit
    * [ ] `updatedAt` wann wurde die entity bearbeitet/erstellt
      * --> unsicher ob wir das brauchen? die Historie hat einen `timestamp` aus welchem die information auch geholt werden kann 
    * [ ] `updatedBy` von wem
      * --> auch das hier steht in der `revinfo` tabelle (wie `timestamp`) 
  * [ ] und diese Felder beim anlegen / bearbeiten schreiben, sofern die Felder benötigt werden
* [ ] testen

Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
