### PR TITLE
configure jvm max metaspace for docker image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,9 @@
             <name>
               ${docker-publish-registry}/${docker-publish-registry-path}/${project.artifactId}:${project.version}
             </name>
+            <env>
+              <BPE_DEFAULT_BPL_JVM_CLASS_ADJUSTMENT>120%</BPE_DEFAULT_BPL_JVM_CLASS_ADJUSTMENT>
+            </env>
           </image>
           <docker>
             <publishRegistry>


### PR DESCRIPTION
Set JVM class adjustment for Docker image to 120% to prevent OOM errors

details see https://github.com/urlaubsverwaltung/urlaubsverwaltung/issues/4593


closes #1873

Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
