### PR TITLE
fix timeclock edit with validation errors

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/timeclock/TimeClockDtoPastOrPresentValidator.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeclock/TimeClockDtoPastOrPresentValidator.java
@@ -35,27 +35,18 @@ public class TimeClockDtoPastOrPresentValidator implements ConstraintValidator<P
         final boolean valid;
 
         if (date.isAfter(now.toLocalDate())) {
-            // given date is in the future.
-            // -> `date` AND `time` are both invalid
             context
                 .buildConstraintViolationWithTemplate(message)
                 .addPropertyNode("date").addConstraintViolation();
-            context
-                .buildConstraintViolationWithTemplate(message)
-                .addPropertyNode("time").addConstraintViolation();
             valid = false;
         }
         else if (date.isEqual(now.toLocalDate()) && time.isAfter(now.toLocalTime())) {
-            // given date is today. given time is in the future.
-            // -> `time` is invalid
             context
                 .buildConstraintViolationWithTemplate(message)
                 .addPropertyNode("time").addConstraintViolation();
             valid = false;
         }
         else {
-            // given date is in the past. time cannot be in the future anymore.
-            // -> everything is fine
             valid = true;
         }
 

--- a/src/main/javascript/components/time-clock/index.ts
+++ b/src/main/javascript/components/time-clock/index.ts
@@ -1,1 +1,2 @@
 import "./TimeClockDuration";
+import "./timeclock-dialog";

--- a/src/main/javascript/components/time-clock/timeclock-dialog.ts
+++ b/src/main/javascript/components/time-clock/timeclock-dialog.ts
@@ -1,0 +1,25 @@
+import { FetchResponse } from "@hotwired/turbo";
+import { morphWithoutTouchingValueOfActiveElement } from "../../morph";
+
+const frameSelector = "#frame-nav-time-clock-edit";
+
+let fetchResponse: FetchResponse;
+
+document.addEventListener("turbo:before-fetch-response", function (event) {
+  fetchResponse = event.detail.fetchResponse;
+});
+
+document.addEventListener("turbo:before-frame-render", function (event) {
+  if (
+    event.detail.newFrame.matches(frameSelector) &&
+    fetchResponse.statusCode === 422
+  ) {
+    // update the popover children only. otherwise there is undefined behavior with the popover element.
+    event.detail.render = function (current, next) {
+      morphWithoutTouchingValueOfActiveElement(
+        current.querySelector("form")!,
+        next.querySelector("form")!,
+      );
+    };
+  }
+});

--- a/src/main/resources/templates/_top.html
+++ b/src/main/resources/templates/_top.html
@@ -18,6 +18,7 @@
         <button
           type="submit"
           class="button-primary button-primary-icon pl-3 pr-4 py-1 text-lg rounded-full"
+          data-testid="time-clock-start-button"
         >
           <svg th:replace="~{icons/play::svg(className='w-6 h-6 mr-1.5')}" />
           <span th:text="#{timeclock.start}"> Start </span>
@@ -30,6 +31,7 @@
             type="button"
             popovertarget="time-clock-popover"
             class="flex items-center gap-1"
+            data-testid="time-clock-edit-button"
           >
             <span
               class="sr-only"
@@ -67,6 +69,7 @@
           <button
             type="submit"
             class="bg-red-700 text-white py-1 pl-2 pr-3 text-lg font-medium rounded-full flex items-center gap-1.5 hover:bg-red-600 transition-colors"
+            data-testid="time-clock-stop-button"
           >
             <svg
               th:replace="~{icons/stop::svg(className='text-red-100 w-6 h-6')}"

--- a/src/main/resources/templates/timeclock/timeclock-edit-form.html
+++ b/src/main/resources/templates/timeclock/timeclock-edit-form.html
@@ -60,6 +60,7 @@
               th:classappend="${hasDateError ? 'border-red-300' : ''}"
               th:aria-invalid="${hasDateError ?: 'true'}"
               th:aria-describedBy="${hasDateError ?: 'errors-time-clock-date'}"
+              data-testid="time-clock-date-input"
             />
           </div>
           <div class="flex flex-col gap-0.5">
@@ -80,6 +81,7 @@
               th:classappend="${hasTimeError ? 'border-red-300' : ''}"
               th:aria-invalid="${hasTimeError ?: 'true'}"
               th:aria-describedBy="${hasTimeError ?: 'errors-time-clock-time'}"
+              data-testid="time-clock-time-input"
             />
           </div>
           <div class="flex flex-col gap-0.5 checkbox-switch">
@@ -96,6 +98,7 @@
               name="break"
               th:checked="${timeClock.isBreak}"
               class="border border-gray-200"
+              data-testid="time-clock-is-break-input"
             />
           </div>
         </div>
@@ -131,6 +134,7 @@
             name="comment"
             th:classappend="${hasCommentError ? 'border-red-300' : ''}"
             th:text="${timeClock.comment}"
+            data-testid="time-clock-comment-input"
           ></textarea>
           <p
             th:if="${hasCommentError}"
@@ -144,6 +148,7 @@
           type="submit"
           class="w-full text-center bg-blue-600 text-blue-50 rounded-sm px-4 py-2 whitespace-nowrap border border-blue-600"
           th:text="#{timeclock.edit.submit}"
+          data-testid="time-clock-update-button"
         >
           Aktualisieren
         </button>

--- a/src/test/java/de/focusshift/zeiterfassung/timeclock/TimeClockDtoValidationTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeclock/TimeClockDtoValidationTest.java
@@ -88,11 +88,7 @@ class TimeClockDtoValidationTest {
             final Set<ConstraintViolation<TimeClockDto>> violations = validator.validate(timeClockDto);
 
             assertThat(violations)
-                .hasSize(3) // +1 item -> class level violation is reported somehow
-                .anySatisfy(violation -> {
-                    assertThat(violation.getPropertyPath()).hasToString("time");
-                    assertThat(violation.getMessageTemplate()).isEqualTo("{timeclock.edit.startAt.error.past-or-present}");
-                })
+                .hasSize(2) // +1 item -> class level violation is reported somehow
                 .anySatisfy(violation -> {
                     assertThat(violation.getPropertyPath()).hasToString("date");
                     assertThat(violation.getMessageTemplate()).isEqualTo("{timeclock.edit.startAt.error.past-or-present}");

--- a/src/test/java/de/focusshift/zeiterfassung/ui/TimeClockUIIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/ui/TimeClockUIIT.java
@@ -1,0 +1,201 @@
+package de.focusshift.zeiterfassung.ui;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import de.focusshift.zeiterfassung.SingleTenantPostgreSQLContainer;
+import de.focusshift.zeiterfassung.TestKeycloakContainer;
+import de.focusshift.zeiterfassung.ui.extension.UiTest;
+import de.focusshift.zeiterfassung.ui.pages.LoginPage;
+import de.focusshift.zeiterfassung.user.UserSettingsProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static de.focusshift.zeiterfassung.ui.pages.LoginPage.Credentials.OFFICE;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@UiTest
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@Testcontainers(parallel = true)
+class TimeClockUIIT {
+
+    private static final ZoneId USER_ZONE_ID = ZoneId.of("Europe/Berlin");
+
+    @Autowired
+    private Clock clock;
+
+    @LocalServerPort
+    private int port;
+
+    @Container
+    private static final SingleTenantPostgreSQLContainer postgre = new SingleTenantPostgreSQLContainer();
+    @Container
+    private static final TestKeycloakContainer keycloak = new TestKeycloakContainer();
+
+    @DynamicPropertySource
+    static void containerProperties(DynamicPropertyRegistry registry) {
+        postgre.configureSpringDataSource(registry);
+        keycloak.configureSpringDataSource(registry);
+    }
+
+    @MockitoBean
+    private UserSettingsProvider userSettingsProvider;
+
+    @BeforeEach
+    void setUp() {
+        when(userSettingsProvider.zoneId()).thenReturn(USER_ZONE_ID);
+        when(userSettingsProvider.firstDayOfWeek()).thenReturn(DayOfWeek.MONDAY);
+    }
+
+    @Test
+    void ensureTimeClock(Page page) {
+        final LoginPage loginPage = new LoginPage(page, port);
+        final TimeClockPage timeClockPage = new TimeClockPage(page);
+
+        final LocalDateTime now = LocalDateTime.now(clock.withZone(USER_ZONE_ID));
+
+        loginPage.login(OFFICE);
+
+        timeClockPage.ensureTimeClockNotRunning();
+
+        timeClockPage.startTimeClock();
+        timeClockPage.ensureTimeClockRunning();
+
+        timeClockPage.openEditForm();
+        timeClockPage.hasDate(now.toLocalDate());
+        timeClockPage.hasTime(now.toLocalTime());
+
+        // future date not allowed
+        timeClockPage.setDate(now.toLocalDate().plusDays(1));
+        timeClockPage.submit();
+        timeClockPage.hasDateError();
+
+        // future time now allowed
+        timeClockPage.setDate(now.toLocalDate());
+        timeClockPage.setTime(now.toLocalTime().plusHours(1));
+        timeClockPage.submit();
+        timeClockPage.hasTimeError();
+
+        // valid edit
+        timeClockPage.setDate(now.toLocalDate());
+        timeClockPage.setTime(now.toLocalTime().minusHours(1));
+        timeClockPage.setComment("most awesome comment");
+        timeClockPage.submit();
+        timeClockPage.ensurePopoverHidden();
+
+        timeClockPage.openEditForm();
+        timeClockPage.hasDate(now.toLocalDate());
+        timeClockPage.hasTime(now.toLocalTime().minusHours(1));
+        timeClockPage.hasComment("most awesome comment");
+
+        timeClockPage.stopTimeClock();
+        timeClockPage.ensureTimeClockNotRunning();
+    }
+
+    private static class TimeClockPage {
+        private final Locator startButton;
+        private final Locator stopButton;
+        private final Locator editButton;
+        private final Locator updateButton;
+        private final Locator dateInput;
+        private final Locator timeInput;
+        private final Locator commentInput;
+
+        private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+
+        private TimeClockPage(Page page) {
+            this.startButton = page.getByTestId("time-clock-start-button");
+            this.stopButton = page.getByTestId("time-clock-stop-button");
+            this.editButton = page.getByTestId("time-clock-edit-button");
+            this.updateButton = page.getByTestId("time-clock-update-button");
+            this.dateInput = page.getByTestId("time-clock-date-input");
+            this.timeInput = page.getByTestId("time-clock-time-input");
+            this.commentInput = page.getByTestId("time-clock-comment-input");
+        }
+
+        public void startTimeClock() {
+            startButton.click();
+        }
+
+        public void stopTimeClock() {
+            stopButton.click();
+        }
+
+        public void openEditForm() {
+            editButton.click();
+        }
+
+        public void setDate(LocalDate date) {
+            dateInput.fill(dateFormatter.format(date));
+        }
+
+        public void setTime(LocalTime time) {
+            timeInput.fill(timeFormatter.format(time));
+        }
+
+        public void setComment(String comment) {
+            commentInput.fill(comment);
+        }
+
+        public void hasDate(LocalDate date) {
+            assertThat(dateInput).hasValue(dateFormatter.format(date));
+        }
+
+        public void hasTime(LocalTime time) {
+            assertThat(timeInput).hasValue(timeFormatter.format(time));
+        }
+
+        public void hasComment(String comment) {
+            assertThat(commentInput).hasValue(comment);
+        }
+
+        public void submit() {
+            updateButton.click();
+        }
+
+        public void ensureTimeClockNotRunning() {
+            assertThat(startButton).isVisible();
+            assertThat(stopButton).not().isVisible();
+            assertThat(editButton).not().isVisible();
+        }
+
+        public void ensureTimeClockRunning() {
+            assertThat(startButton).not().isVisible();
+            assertThat(stopButton).isVisible();
+            assertThat(editButton).isVisible();
+        }
+
+        public void ensurePopoverHidden() {
+            assertThat(updateButton).not().isVisible();
+            assertThat(dateInput).not().isVisible();
+            assertThat(timeInput).not().isVisible();
+            assertThat(commentInput).not().isVisible();
+        }
+
+        public void hasDateError() {
+            assertThat(dateInput).hasAttribute("aria-invalid", "true");
+        }
+
+        public void hasTimeError() {
+            assertThat(timeInput).hasAttribute("aria-invalid", "true");
+        }
+    }
+}


### PR DESCRIPTION
closes #1947

Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
