### PR TITLE
ui test: ensure user search should only use one LoginPage

### DIFF
--- a/src/test/java/de/focusshift/zeiterfassung/ui/UserSearchUIIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/ui/UserSearchUIIT.java
@@ -5,7 +5,6 @@ import de.focusshift.zeiterfassung.SingleTenantPostgreSQLContainer;
 import de.focusshift.zeiterfassung.TestKeycloakContainer;
 import de.focusshift.zeiterfassung.ui.extension.UiTest;
 import de.focusshift.zeiterfassung.ui.pages.LoginPage;
-import de.focusshift.zeiterfassung.ui.pages.LoginPage.Credentials;
 import de.focusshift.zeiterfassung.ui.pages.NavigationPage;
 import de.focusshift.zeiterfassung.ui.pages.ReportPage;
 import de.focusshift.zeiterfassung.ui.pages.TimeEntryPage;
@@ -19,6 +18,9 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static de.focusshift.zeiterfassung.ui.pages.LoginPage.Credentials.BOSS;
+import static de.focusshift.zeiterfassung.ui.pages.LoginPage.Credentials.OFFICE;
+import static de.focusshift.zeiterfassung.ui.pages.LoginPage.Credentials.USER;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -42,27 +44,30 @@ class UserSearchUIIT {
 
     @Test
     void ensureUserSearch(Page page) {
+        final LoginPage loginPage = new LoginPage(page, port);
+        final NavigationPage navigationPage = new NavigationPage(page);
 
         // log in with different users first, otherwise they don't exist in the application
-        final Page bossPage = page.context().browser().newContext().newPage();
-        new LoginPage(bossPage, port).login(Credentials.BOSS);
+        loginPage.login(BOSS);
+        navigationPage.logout();
 
-        final Page userPage = page.context().browser().newContext().newPage();
-        new LoginPage(userPage, port).login(Credentials.USER);
+        loginPage.login(USER);
+        navigationPage.logout();
 
         // then ensure user search for OFFICE
-        new LoginPage(page, port).login(Credentials.OFFICE);
+        loginPage.login(OFFICE);
 
-        final NavigationPage navigationPage = new NavigationPage(page);
         final UserSearchPage userSearchPage = new UserSearchPage(page);
 
         ensureTimeEntriesUserSearch(page, navigationPage, userSearchPage);
         ensureReportsUserSearch(page, navigationPage, userSearchPage);
         ensureUserSettingsUserSearch(page, navigationPage, userSearchPage);
         ensureSettingsUserSearch(page, navigationPage, userSearchPage);
+        navigationPage.logout();
 
         // USER is not allowed to search for other users
-        new UserSearchPage(userPage).isNotPresent();
+        loginPage.login(USER);
+        userSearchPage.isNotPresent();
     }
 
     private void ensureTimeEntriesUserSearch(Page page, NavigationPage navigationPage, UserSearchPage userSearchPage) {

--- a/src/test/java/de/focusshift/zeiterfassung/ui/pages/NavigationPage.java
+++ b/src/test/java/de/focusshift/zeiterfassung/ui/pages/NavigationPage.java
@@ -70,7 +70,7 @@ public class NavigationPage {
             page.getByTestId("avatar").click();
             final Locator logout = page.getByTestId("logout");
             logout.waitFor(new Locator.WaitForOptions().setState(VISIBLE));
-            logout.click();
+            page.waitForResponse(Response::ok, logout::click);
 
             page.context().clearCookies();
             page.context().clearPermissions();

--- a/src/test/java/de/focusshift/zeiterfassung/ui/pages/UserSearchPage.java
+++ b/src/test/java/de/focusshift/zeiterfassung/ui/pages/UserSearchPage.java
@@ -33,7 +33,9 @@ public class UserSearchPage {
     }
 
     public void selectSuggestion(String name) {
-        userSuggestionsLocator().getByRole(LINK, new Locator.GetByRoleOptions().setName(name)).click();
+        final Locator suggestion = userSuggestionsLocator().getByRole(LINK, new Locator.GetByRoleOptions().setName(name));
+        assertThat(suggestion).isVisible();
+        suggestion.click();
     }
 
     public void selectSuggestionTimeEntries(String name) {


### PR DESCRIPTION
Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
