### PR TITLE
Fix find working time for last day of not most recent working time

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkTimeServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkTimeServiceImpl.java
@@ -197,10 +197,10 @@ class WorkTimeServiceImpl implements WorkingTimeService {
                 final LocalDate validFrom = workingTime.validFrom().get();
                 return validFrom.isBefore(toExclusive);
             } else {
-                // not the very first working-time
+                // not the very first working-time and not the most recent working-time entry
                 final LocalDate validFrom = workingTime.validFrom().get();
                 final LocalDate validTo = workingTime.validTo().get();
-                return validFrom.isBefore(toExclusive) && validTo.isAfter(from);
+                return validFrom.isBefore(toExclusive) && (validTo.isEqual(from) || validTo.isAfter(from));
             }
         };
     }

--- a/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkTimeServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkTimeServiceImplTest.java
@@ -503,6 +503,78 @@ class WorkTimeServiceImplTest {
         }
 
         @Test
+        void ensureGetWorkingTimeByUsersWithWorkingTimeEndingOnSameDayAsDateRangeReturningWorkingTime() {
+
+            final UUID workingTimeId1 = UUID.randomUUID();
+            final WorkingTimeEntity workingTimeEntity1 = anyWorkingTimeEntity(workingTimeId1, 1L, null);
+            workingTimeEntity1.setFederalState(FederalState.NONE);
+            workingTimeEntity1.setWorksOnPublicHoliday(false);
+            workingTimeEntity1.setMonday("PT1H");
+            workingTimeEntity1.setTuesday("PT2H");
+            workingTimeEntity1.setWednesday("PT3H");
+            workingTimeEntity1.setThursday("PT4H");
+            workingTimeEntity1.setFriday("PT5H");
+            workingTimeEntity1.setSaturday("PT6H");
+            workingTimeEntity1.setSunday("PT7H");
+
+            final UUID workingTimeId2 = UUID.randomUUID();
+            final WorkingTimeEntity workingTimeEntity2 = anyWorkingTimeEntity(workingTimeId2, 2L, null);
+
+            final UUID workingTimeId3 = UUID.randomUUID();
+            final WorkingTimeEntity workingTimeEntity3 = anyWorkingTimeEntity(workingTimeId3, 2L, LocalDate.parse("2026-01-01"));
+            workingTimeEntity3.setFederalState(GERMANY_BADEN_WUERTTEMBERG);
+            workingTimeEntity3.setWorksOnPublicHoliday(true);
+            workingTimeEntity3.setMonday("PT7H");
+            workingTimeEntity3.setTuesday("PT6H");
+            workingTimeEntity3.setWednesday("PT5H");
+            workingTimeEntity3.setThursday("PT4H");
+            workingTimeEntity3.setFriday("PT3H");
+            workingTimeEntity3.setSaturday("PT2H");
+            workingTimeEntity3.setSunday("PT1H");
+
+            final UUID workingTimeId4 = UUID.randomUUID();
+            final WorkingTimeEntity workingTimeEntity4 = anyWorkingTimeEntity(workingTimeId4, 2L, LocalDate.parse("2026-05-01"));
+            workingTimeEntity4.setFederalState(GERMANY_BADEN_WUERTTEMBERG);
+            workingTimeEntity4.setWorksOnPublicHoliday(true);
+            workingTimeEntity4.setMonday("PT7H");
+            workingTimeEntity4.setTuesday("PT6H");
+            workingTimeEntity4.setWednesday("PT5H");
+            workingTimeEntity4.setThursday("PT4H");
+            workingTimeEntity4.setFriday("PT3H");
+            workingTimeEntity4.setSaturday("PT2H");
+            workingTimeEntity4.setSunday("PT1H");
+
+            when(workingTimeRepository.findAllByUserIdIsIn(List.of(1L, 2L))).thenReturn(List.of(workingTimeEntity1, workingTimeEntity2, workingTimeEntity3, workingTimeEntity4));
+
+            final UserId userId_1 = new UserId("uuid-1");
+            final UserLocalId userLocalId_1 = new UserLocalId(1L);
+            final UserIdComposite userIdComposite_1 = new UserIdComposite(userId_1, userLocalId_1);
+            final User user_1 = new User(userIdComposite_1, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+            final UserId userId_2 = new UserId("uuid-2");
+            final UserLocalId userLocalId_2 = new UserLocalId(2L);
+            final UserIdComposite userIdComposite_2 = new UserIdComposite(userId_2, userLocalId_2);
+            final User user_2 = new User(userIdComposite_2, "Clark", "Kent", new EMailAddress(""), Set.of());
+
+            when(userManagementService.findAllUsersByLocalIds(List.of(userLocalId_1, userLocalId_2)))
+                .thenReturn(List.of(user_1, user_2));
+
+            final LocalDate date = LocalDate.parse("2026-04-30");
+            final Map<UserIdComposite, List<WorkingTime>> actual = sut.getWorkingTimesByUsers(date, date, List.of(new UserLocalId(1L), new UserLocalId(2L)));
+
+            assertThat(actual)
+                .hasEntrySatisfying(userIdComposite_2, workingTimes -> {
+                    assertThat(workingTimes).hasSize(1);
+                    assertThat(workingTimes.getFirst()).satisfies(workingTime -> {
+                        assertThat(workingTime.userIdComposite()).isEqualTo(userIdComposite_2);
+                        assertThat(workingTime.id()).isEqualTo(new WorkingTimeId(workingTimeId3));
+                        assertThat(workingTime.validFrom()).hasValue(LocalDate.parse("2026-01-01"));
+                        assertThat(workingTime.validTo()).hasValue(LocalDate.parse("2026-04-30"));
+                    });
+                });
+        }
+
+        @Test
         void ensureGetWorkingTimeByUsersAddsDefaultWorkingTimeForUsersWithoutExplicitOne() {
 
             when(workingTimeRepository.findAllByUserIdIsIn(List.of(1L))).thenReturn(List.of());


### PR DESCRIPTION
If a user has multiple working times for intermediate working times the find method can not select the correct working time for the last day of this working time.

fix #1983


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
