### PR TITLE
fix bean name collision with HeaderScriptConfiguration

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/web/FrameDataProviderConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/web/FrameDataProviderConfiguration.java
@@ -9,12 +9,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 class FrameDataProviderConfiguration {
 
     @Bean
-    FrameDataProvider headerScriptControllerAdvice(MenuProperties menuProperties) {
+    FrameDataProvider frameDataProvider(MenuProperties menuProperties) {
         return new FrameDataProvider(menuProperties);
     }
 
     @Bean
-    WebMvcConfigurer headerScriptWebMvcConfigurer(FrameDataProvider frameDataProvider) {
+    WebMvcConfigurer frameDataProviderWebMvcConfigurer(FrameDataProvider frameDataProvider) {
         return new FrameDataProviderWebMvcConfigurer(frameDataProvider);
     }
 


### PR DESCRIPTION
## Summary

- Rename the two `@Bean` methods in `FrameDataProviderConfiguration` so the bean names match what they actually return:
  - `headerScriptControllerAdvice` → `frameDataProvider`
  - `headerScriptWebMvcConfigurer` → `frameDataProviderWebMvcConfigurer`

## Why

The two `@Bean` methods were copy-pasted from `HeaderScriptConfiguration` and only the method bodies were adjusted — the method names (which Spring uses as bean names) were left unchanged. So `FrameDataProviderConfiguration` was registering a `FrameDataProvider` under the name `headerScriptControllerAdvice` and a `WebMvcConfigurer` under `headerScriptWebMvcConfigurer`.

This stayed dormant as long as `HeaderScriptConfiguration` was inactive — it is gated by `@ConditionalOnProperty("zeiterfassung.header-script.enabled", havingValue = "true")`.

On the labs demo system that property has been enabled, both configs activate, both try to register a bean called `headerScriptControllerAdvice`, and Spring fails startup because `spring.main.allow-bean-definition-overriding` defaults to `false`:

```
The bean 'headerScriptControllerAdvice', defined in class path resource
[.../HeaderScriptConfiguration.class], could not be registered. A bean
with that name has already been defined in class path resource
[.../FrameDataProviderConfiguration.class] and overriding is disabled.
```

Renaming restores unique bean names and the two configs coexist again. No qualifier-by-name lookups for the old names existed (verified by grep), so this change is safe.

## Test plan

- [x] Production code compiles (`./mvnw compile`)
- [ ] Deploy to labs demo with `zeiterfassung.header-script.enabled=true` and confirm the pod starts cleanly