### PR TITLE
navigation collapsable

### DIFF
--- a/src/main/css/bundles/1-base.css
+++ b/src/main/css/bundles/1-base.css
@@ -1,6 +1,15 @@
 @import "../config.css";
 
+/* width of the navigation column on desktop; animatable so collapse/expand transitions smoothly */
+@property --nav-width {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 300px;
+}
+
 :root {
+  --nav-width: 300px;
+
   /* tooltips shown on pointer hover should always be on top */
   --z-index-tooltip: 99999;
   --z-index-overlay: 300;
@@ -122,11 +131,23 @@ body {
 @variant desktop {
   body {
     grid-template-rows: auto auto 1fr;
-    grid-template-columns: minmax(300px, auto) 1fr auto auto;
+    grid-template-columns: var(--nav-width) 1fr auto auto;
     grid-template-areas:
       "banner banner banner banner"
       "launchpad-app search timeclock avatar"
       "navigation content content content";
+  }
+
+  html {
+    transition: --nav-width 200ms ease;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+  }
+
+  html[data-nav-collapsed] {
+    --nav-width: 5rem;
   }
 }
 

--- a/src/main/css/bundles/2-components.css
+++ b/src/main/css/bundles/2-components.css
@@ -8,6 +8,7 @@
 @import "../components/feedback-heart.css" layer(components);
 @import "../components/navigation.css" layer(components);
 @import "../components/tooltip.css" layer(components);
+@import "../components/nav-tooltip.css" layer(components);
 @import "../components/topbar.css" layer(components);
 @import "../components/user-search.css" layer(components);
 

--- a/src/main/css/components/nav-tooltip.css
+++ b/src/main/css/components/nav-tooltip.css
@@ -1,0 +1,56 @@
+.nav-tooltip-anchor--active {
+  anchor-name: --nav-tooltip-anchor;
+}
+
+[role="tooltip"][popover] {
+  --nav-tooltip-opacity-duration: 150ms;
+
+  /* native popover reset */
+  inset: auto;
+  margin: 0;
+
+  position-anchor: --nav-tooltip-anchor;
+  position-area: top;
+  margin-bottom: --spacing(2);
+
+  padding: --spacing(1) --spacing(2);
+  font-size: var(--text-sm);
+  color: var(--color-gray-50);
+  background-color: var(--color-gray-950);
+  text-align: center;
+  border-radius: var(--radius-md);
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.08),
+    0 1px 4px rgba(0, 0, 0, 0.04);
+
+  opacity: 0;
+  transition: opacity var(--nav-tooltip-opacity-duration);
+
+  &:popover-open {
+    opacity: 1;
+  }
+
+  &:popover-open.uv-tooltip--is-hiding {
+    --nav-tooltip-opacity-duration: 100ms;
+    opacity: 0;
+  }
+
+  @variant dark {
+    color: var(--color-zinc-300);
+    background-color: var(--color-zinc-950);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+}
+
+[role="tooltip"][popover][data-placement="right"] {
+  position-area: right;
+  margin-bottom: 0;
+  margin-left: --spacing(2);
+}
+
+@starting-style {
+  [role="tooltip"][popover]:popover-open {
+    opacity: 0;
+  }
+}

--- a/src/main/css/components/navigation.css
+++ b/src/main/css/components/navigation.css
@@ -1,24 +1,21 @@
 .navigation-container {
-  --navigation-bg-color: var(--color-white);
-
-  @variant dark {
-    --navigation-bg-color: var(--color-zinc-950);
-  }
-
   grid-area: navigation;
-  anchor-name: --navigation-container-anchor;
 
   .navigation-button {
     padding: --spacing(4);
   }
 
   .navigation {
-    background-color: var(--navigation-bg-color);
+    background-color: var(--color-white);
     width: 100dvw;
 
     /* prevent body scrolling with overscroll behaviour and full height */
     overscroll-behavior: none;
     height: calc(100dvh - anchor-size(height) - var(--info-banner-height));
+
+    @variant dark {
+      background-color: var(--color-zinc-950);
+    }
 
     .navigation-inner {
       padding: --spacing(8);
@@ -27,16 +24,20 @@
 
       display: flex;
       flex-direction: column;
-      gap: --spacing(8);
+      gap: --spacing(1);
 
       .navigation-inner__bottom {
         margin-top: auto;
-        background-color: var(--navigation-bg-color);
+        background: white;
         padding: --spacing(2) 0;
         border-top: 1px solid transparent;
         transition: border-color 150ms;
 
-        &.z-sticky--stuck {
+        @variant dark {
+          background-color: var(--color-zinc-950);
+        }
+
+        &.uv-sticky--stuck {
           border-top-color: var(--color-gray-100);
 
           @variant dark {
@@ -49,49 +50,119 @@
     ul {
       display: flex;
       flex-direction: column;
-      gap: calc(--spacing(1) / 2);
+      gap: --spacing(1);
+    }
+
+    .subnav-group {
+      margin-top: --spacing(1);
+      gap: --spacing(3);
+    }
+
+    .navigation-link,
+    .navigation-sublink {
+      display: block;
+      color: inherit;
+      text-decoration: none;
     }
 
     .navigation-link {
-      --navigation-link-color: inherit;
-      --navigation-link-bg-color: inherit;
-      --navigation-link-hover-color: inherit;
-      --navigation-link-hover-bg-color: var(--color-blue-50);
-
-      @variant dark {
-        --navigation-link-color: var(--color-zinc-200);
-        --navigation-link-bg-color: inerit;
-        --navigation-link-hover-color: var(--color-zinc-100);
-        --navigation-link-hover-bg-color: var(--color-zinc-800);
-      }
-
-      display: block;
-      text-decoration: none;
       padding: --spacing(2);
-      border-radius: var(--radius);
-      color: var(--navigation-link-color);
-      background-color: var(--navigation-link-bg-color);
+      @apply rounded;
+      background-color: transparent;
 
       --duration: 150ms;
       transition:
         color var(--duration),
         background-color var(--duration);
 
+      &:is(button) {
+        appearance: none;
+        border: none;
+        font: inherit;
+        cursor: pointer;
+        text-align: start;
+        width: 100%;
+      }
+
       &:hover {
-        color: var(--navigation-link-hover-color);
-        background-color: var(--navigation-link-hover-bg-color);
+        background-color: var(--color-blue-50);
+      }
+
+      @variant dark {
+        color: var(--color-zinc-200);
+
+        &:hover {
+          color: var(--color-zinc-100);
+          background-color: var(--color-zinc-800);
+        }
+      }
+    }
+
+    .navigation-sublink {
+      --dot-size: 0.5rem;
+      --dot-color: var(--color-blue-300);
+      --color: var(--color-gray-900);
+
+      position: relative;
+      display: flex;
+      align-items: center;
+      gap: --spacing(2);
+
+      margin-left: --spacing(4);
+      /* two times dot-size because of loading spinner */
+      padding-left: calc(var(--dot-size) * 2 + --spacing(1));
+      padding-right: --spacing(1);
+
+      color: var(--color);
+
+      /* dot (+ ::after as spinner) */
+      &::before {
+        --duration: 300ms;
+        transition:
+          background-color var(--duration),
+          border-color var(--duration);
+
+        position: absolute;
+        top: calc(50% - (var(--dot-size) / 2));
+        left: calc(var(--dot-size) / 2);
+
+        content: "";
+        display: block;
+        width: var(--dot-size);
+        aspect-ratio: 1;
+        border-radius: 9999px;
+        border: 1px solid var(--dot-color);
+        background-color: transparent;
+      }
+
+      &:hover,
+      &.navigation-sublink--active {
+        &::before {
+          background-color: var(--dot-color);
+        }
+      }
+
+      @variant dark {
+        --dot-color: var(--color-sky-600);
+        --color: var(--color-zinc-300);
       }
     }
 
     .navigation-link--active {
-      --navigation-link-bg-color: var(--color-blue-50);
-      --navigation-link-hover-bg-color: var(--color-blue-100);
+      background-color: var(--color-blue-50);
+
+      &:hover {
+        background-color: var(--color-blue-100);
+      }
 
       @variant dark {
-        --navigation-link-color: var(--color-zinc-300);
-        --navigation-link-bg-color: var(--color-zinc-800);
-        --navigation-link-hover-color: var(--color-zinc-50);
-        --navigation-link-hover-bg-color: var(--color-zinc-700);
+        color: var(--color-zinc-100);
+        background-color: var(--color-zinc-800);
+
+        &:hover {
+          color: var(--color-zinc-50);
+          background-color: var(--color-zinc-700);
+        }
       }
     }
 
@@ -115,11 +186,51 @@
         --to: var(--color-zinc-800);
       }
     }
+
+    .navigation-sublink--loading {
+      /* spinner */
+      &::after {
+        --gradient-shift: calc((var(--dot-size) / 2) - 1px);
+
+        content: "";
+        position: absolute;
+        top: calc(50% - var(--dot-size));
+        left: 0;
+
+        display: block;
+        width: calc(var(--dot-size) * 2);
+        aspect-ratio: 1;
+        border-radius: 9999px;
+        background:
+          radial-gradient(farthest-side, var(--dot-color) 94%, #0000)
+            top/var(--gradient-shift) var(--gradient-shift) no-repeat,
+          conic-gradient(#0000 30%, var(--dot-color));
+        -webkit-mask: radial-gradient(
+          farthest-side,
+          #0000 calc(100% - var(--gradient-shift)),
+          #000 0
+        );
+        animation: rotate-loading 1s infinite linear;
+      }
+    }
+  }
+
+  .nav-group-label {
+    display: block;
+    margin-bottom: --spacing(2);
+    @apply font-mono;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-gray-400);
+
+    @variant dark {
+      color: var(--color-zinc-500);
+    }
   }
 }
 
 .nav-popover-menu-container {
-  border-radius: var(--radius-2xl);
+  @apply rounded-2xl;
 
   .navigation-popover-menu-header {
     padding: --spacing(2) --spacing(4);
@@ -159,6 +270,7 @@
         padding: --spacing(3);
         padding-left: --spacing(6);
         padding-right: --spacing(10);
+        @apply rounded;
 
         &:hover,
         &:focus-visible {
@@ -179,10 +291,6 @@
 
       li:first-of-type .navigation-popover-menu__link {
         @apply rounded-t-2xl;
-      }
-
-      li:last-of-type .navigation-popover-menu__link {
-        @apply rounded-b-2xl;
       }
     }
   }
@@ -231,14 +339,79 @@
   }
 }
 
+.nav-link-badge:not(svg) {
+  display: none;
+}
+
+.nav-collapse-btn {
+  display: none;
+
+  @variant desktop {
+    display: flex;
+  }
+}
+
+.nav-resize-handle {
+  display: none;
+}
+
+html.nav-resizing {
+  transition: none;
+
+  &,
+  * {
+    user-select: none;
+    cursor: col-resize !important;
+  }
+
+  .nav-resize-handle::before {
+    opacity: 1;
+  }
+}
+
 @variant desktop {
   .navigation-container {
     display: flex;
     flex-direction: column;
     padding: 0;
+    /* anchor the absolutely positioned resize handle */
+    position: relative;
 
     .navigation-button {
       display: none;
+    }
+
+    .nav-resize-handle {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      right: -4px;
+      width: 8px;
+      z-index: var(--z-index-topbar);
+      display: flex;
+      justify-content: center;
+      touch-action: none;
+
+      &::before {
+        content: "";
+        width: 2px;
+        height: 100%;
+        background-color: var(--color-blue-300);
+        opacity: 0;
+        transition: opacity 150ms;
+
+        @variant dark {
+          background-color: var(--color-sky-600);
+        }
+      }
+
+      &.nav-resize-handle--visible {
+        cursor: col-resize;
+
+        &::before {
+          opacity: 1;
+        }
+      }
     }
 
     .navigation {
@@ -254,11 +427,51 @@
       transform: unset;
 
       .navigation-inner {
-        padding: --spacing(4) --spacing(5);
+        padding: --spacing(8) --spacing(5);
         padding-bottom: --spacing(2);
+
+        .navigation-inner__bottom {
+          .uv-sticky--stuck {
+            @variant dark {
+              border-top-color: var(--color-zinc-900);
+            }
+          }
+        }
 
         .navigation-link {
           padding: --spacing(1) --spacing(2);
+          display: flex;
+          flex-direction: row;
+          gap: 0.5rem;
+          flex-wrap: nowrap;
+          white-space: nowrap;
+
+          .nav-link-badge {
+            flex-shrink: 0;
+          }
+        }
+
+        svg.nav-link-badge {
+          stroke: var(--color-gray-400);
+
+          @variant dark {
+            stroke: var(--color-zinc-500);
+          }
+        }
+
+        .navigation-link ~ .subnav-group {
+          display: none;
+        }
+
+        .navigation-link--loading ~ .subnav-group,
+        .navigation-link--active ~ .subnav-group {
+          display: flex;
+        }
+
+        .subnav-group {
+          margin-top: --spacing(1);
+          margin-bottom: --spacing(1);
+          gap: --spacing(1);
         }
       }
     }
@@ -267,5 +480,107 @@
   .nav-launchpad-popover {
     left: --spacing(2);
     right: auto;
+  }
+
+  html[data-nav-collapsed] .navigation-container {
+    .navigation-inner {
+      padding: --spacing(4) --spacing(2);
+      align-items: center;
+    }
+
+    /* while a subnav flyout is open, the resize-handle should do nothing */
+    &:has(li:hover .subnav-group),
+    &:has(li:focus-within .subnav-group) {
+      .nav-resize-handle {
+        pointer-events: none;
+      }
+    }
+
+    .nav-link-text,
+    .nav-group-label {
+      display: none;
+    }
+
+    .nav-link-badge {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.75rem;
+      height: 1.75rem;
+      border-radius: 0.375rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      flex-shrink: 0;
+
+      &:not(svg) {
+        background-color: var(--color-blue-100);
+        color: var(--color-blue-700);
+
+        @variant dark {
+          background-color: var(--color-blue-900);
+          color: var(--color-blue-100);
+        }
+      }
+    }
+
+    .navigation-inner {
+      svg.nav-link-badge {
+        stroke: var(--color-gray-950);
+
+        @variant dark {
+          stroke: var(--color-zinc-200);
+        }
+      }
+    }
+
+    .navigation-link--active .nav-link-badge:not(svg) {
+      background-color: var(--color-blue-200);
+
+      @variant dark {
+        background-color: var(--color-blue-800);
+      }
+    }
+
+    .navigation-link {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: --spacing(2) 0;
+    }
+
+    /* subnav: never visible inline in collapsed state, only as hover popover */
+    .navigation .navigation-inner {
+      .navigation-link ~ .subnav-group,
+      .navigation-link--active ~ .subnav-group,
+      .navigation-link--loading ~ .subnav-group {
+        display: none;
+      }
+
+      li:hover .navigation-link ~ .subnav-group,
+      li:focus-within .navigation-link ~ .subnav-group {
+        position: fixed;
+        inset-inline-start: calc(anchor(right) - 2px);
+        inset-block-start: anchor(top);
+        position-try-fallbacks: flip-block;
+        max-height: calc(100dvh - --spacing(4));
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: --spacing(3);
+        background: white;
+        border: 1px solid var(--color-gray-200);
+        border-radius: --spacing(2);
+        padding: --spacing(3) --spacing(3) --spacing(3) --spacing(1);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        z-index: calc(var(--z-index-topbar) - 1);
+        min-width: 160px;
+
+        @variant dark {
+          background: var(--color-zinc-800);
+          border-color: var(--color-zinc-700);
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+        }
+      }
+    }
   }
 }

--- a/src/main/css/components/tooltip.css
+++ b/src/main/css/components/tooltip.css
@@ -3,7 +3,7 @@ z-tooltip:not([data-show]) {
   @apply sr-only;
 }
 
-[role="tooltip"] {
+z-tooltip[role="tooltip"] {
   padding: --spacing(1) --spacing(2);
   @apply text-xs;
   @apply font-bold;

--- a/src/main/java/de/focusshift/zeiterfassung/security/SecurityApiConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/SecurityApiConfiguration.java
@@ -1,0 +1,30 @@
+package de.focusshift.zeiterfassung.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_USER;
+import static org.springframework.security.config.http.SessionCreationPolicy.NEVER;
+
+@Configuration
+class SecurityApiConfiguration {
+
+    @Bean
+    @Order(1)
+    SecurityFilterChain apiSecurityFilterChain(final HttpSecurity http) {
+        return http
+            .securityMatcher("/api/**")
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(requests ->
+                requests
+                    .requestMatchers("/api/**").hasAuthority(ZEITERFASSUNG_USER.name())
+                    .anyRequest().authenticated()
+            ).sessionManagement(
+                sessionManagement -> sessionManagement.sessionCreationPolicy(NEVER)
+            ).build();
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/security/SecurityWebConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/SecurityWebConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.boot.micrometer.metrics.autoconfigure.export.promethe
 import org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
@@ -48,6 +49,7 @@ public class SecurityWebConfiguration {
     }
 
     @Bean
+    @Order(2)
     SecurityFilterChain filterChain(HttpSecurity http, DelegatingSecurityContextRepository securityContextRepository, TenantContextHolder tenantContextHolder) {
         //@formatter:off
         http

--- a/src/main/java/de/focusshift/zeiterfassung/user/UpdateUserSettingsDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/user/UpdateUserSettingsDto.java
@@ -1,0 +1,6 @@
+package de.focusshift.zeiterfassung.user;
+
+import org.jspecify.annotations.Nullable;
+
+record UpdateUserSettingsDto(@Nullable Boolean navigationCollapsed) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/user/UserSettings.java
+++ b/src/main/java/de/focusshift/zeiterfassung/user/UserSettings.java
@@ -5,18 +5,26 @@ import java.util.Optional;
 
 public class UserSettings {
 
+    public static final UserSettings DEFAULT = new UserSettings(Theme.SYSTEM, false, null, null);
+
     private final Theme theme;
+    private final boolean navigationCollapsed;
     private final Locale locale;
     private final Locale localeBrowserSpecific;
 
-    UserSettings(Theme theme, Locale locale, Locale localeBrowserSpecific) {
+    UserSettings(Theme theme, boolean navigationCollapsed, Locale locale, Locale localeBrowserSpecific) {
         this.theme = theme;
+        this.navigationCollapsed = navigationCollapsed;
         this.locale = locale;
         this.localeBrowserSpecific = localeBrowserSpecific;
     }
 
     public Theme theme() {
         return theme;
+    }
+
+    public boolean navigationCollapsed() {
+        return navigationCollapsed;
     }
 
     public Optional<Locale> locale() {

--- a/src/main/java/de/focusshift/zeiterfassung/user/UserSettingsApiController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/user/UserSettingsApiController.java
@@ -1,0 +1,28 @@
+package de.focusshift.zeiterfassung.user;
+
+import de.focusshift.zeiterfassung.security.CurrentUser;
+import de.focusshift.zeiterfassung.security.oidc.CurrentOidcUser;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users/me/settings")
+class UserSettingsApiController {
+
+    private final UserSettingsService userSettingsService;
+
+    UserSettingsApiController(UserSettingsService userSettingsService) {
+        this.userSettingsService = userSettingsService;
+    }
+
+    @PatchMapping
+    ResponseEntity<Void> updateSettings(@CurrentUser CurrentOidcUser currentUser, @RequestBody UpdateUserSettingsDto dto) {
+        if (dto.navigationCollapsed() != null) {
+            userSettingsService.updateNavigationCollapsed(currentUser.getUserIdComposite(), dto.navigationCollapsed());
+        }
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/user/UserSettingsEntity.java
+++ b/src/main/java/de/focusshift/zeiterfassung/user/UserSettingsEntity.java
@@ -33,6 +33,9 @@ public class UserSettingsEntity extends AbstractTenantAwareEntity {
     @Column(name = "locale_browser_specific")
     private Locale localeBrowserSpecific;
 
+    @Column(name = "navigation_collapsed", nullable = false)
+    private boolean navigationCollapsed;
+
     protected UserSettingsEntity() {
         super(null);
     }
@@ -77,11 +80,20 @@ public class UserSettingsEntity extends AbstractTenantAwareEntity {
         this.localeBrowserSpecific = localeBrowserSpecific;
     }
 
+    public boolean isNavigationCollapsed() {
+        return navigationCollapsed;
+    }
+
+    public void setNavigationCollapsed(boolean navigationCollapsed) {
+        this.navigationCollapsed = navigationCollapsed;
+    }
+
     @Override
     public String toString() {
         return "UserSettingsEntity{" +
             "tenantUserLocalId=" + tenantUserLocalId +
             ", theme=" + theme +
+            ", navigationCollapsed=" + navigationCollapsed +
             ", locale=" + locale +
             ", localeBrowserSpecific=" + localeBrowserSpecific +
             '}';

--- a/src/main/java/de/focusshift/zeiterfassung/user/UserSettingsService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/user/UserSettingsService.java
@@ -72,6 +72,20 @@ class UserSettingsService {
     }
 
     /**
+     * Updates the navigation-collapsed preference of the given user, leaving all other settings untouched.
+     *
+     * @param userIdComposite     to update the preference for
+     * @param navigationCollapsed whether the navigation should be rendered collapsed
+     */
+    void updateNavigationCollapsed(UserIdComposite userIdComposite, boolean navigationCollapsed) {
+        final UserSettingsEntity entity = findOrGetDefault(userIdComposite);
+        entity.setTenantUserLocalId(userIdComposite.localId().value());
+        entity.setNavigationCollapsed(navigationCollapsed);
+        userSettingsRepository.save(entity);
+        LOG.info("updated user={} navigation collapsed={}", userIdComposite, navigationCollapsed);
+    }
+
+    /**
      * Sets the browser specific locale from the request.
      * <p>
      * Only saves the browser specific locale if the saved 'locale' is null.
@@ -102,7 +116,8 @@ class UserSettingsService {
 
     private UserSettingsEntity defaultUserSettingsEntity(UserIdComposite userIdComposite) {
         final UserSettingsEntity userSettingsEntity = new UserSettingsEntity();
-        userSettingsEntity.setTheme(Theme.SYSTEM);
+        userSettingsEntity.setTheme(UserSettings.DEFAULT.theme());
+        userSettingsEntity.setNavigationCollapsed(UserSettings.DEFAULT.navigationCollapsed());
         userSettingsEntity.setTenantUserLocalId(userIdComposite.localId().value());
 
         LOG.debug("created (not persisted) default userSettingsEntity={}", userSettingsEntity);
@@ -113,6 +128,7 @@ class UserSettingsService {
     private static UserSettings toUserSettings(UserSettingsEntity userSettingsEntity) {
         return new UserSettings(
             userSettingsEntity.getTheme(),
+            userSettingsEntity.isNavigationCollapsed(),
             userSettingsEntity.getLocale(),
             userSettingsEntity.getLocaleBrowserSpecific()
         );

--- a/src/main/java/de/focusshift/zeiterfassung/user/UserThemeDataProvider.java
+++ b/src/main/java/de/focusshift/zeiterfassung/user/UserThemeDataProvider.java
@@ -7,12 +7,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.ModelAndView;
-
-import java.security.Principal;
 
 import static java.lang.invoke.MethodHandles.lookup;
 
@@ -33,26 +33,26 @@ public class UserThemeDataProvider implements DataProviderInterface {
     public void postHandle(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler, ModelAndView modelAndView) {
         if (addDataIf(modelAndView)) {
 
-            final Principal userPrincipal = request.getUserPrincipal();
+            final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-            final Theme theme;
+            Theme theme = UserSettings.DEFAULT.theme();
+            boolean navigationCollapsed = UserSettings.DEFAULT.navigationCollapsed();
 
-            if (userPrincipal instanceof OAuth2AuthenticationToken token) {
+            if (authentication instanceof OAuth2AuthenticationToken token) {
                 final OAuth2User oauth2User = token.getPrincipal();
                 if (oauth2User instanceof CurrentOidcUser user) {
-                    user.getUserIdComposite();
-                    theme = userSettingsService.findTheme(user.getUserIdComposite()).orElse(DEFAULT_THEME);
+                    final UserSettings userSettings = userSettingsService.getUserSettings(user.getUserIdComposite());
+                    theme = userSettings.theme();
+                    navigationCollapsed = userSettings.navigationCollapsed();
                 } else {
-                    LOG.info("userPrincipal not of type {}. Using default system theme.", CurrentOidcUser.class.getName());
-                    theme = DEFAULT_THEME;
+                    LOG.info("authentication principal not of type {}. Using default system theme.", CurrentOidcUser.class.getName());
                 }
             } else {
-                LOG.info("userPrincipal not of type OAuth2AuthenticationToken. Using default system theme.");
-                theme = DEFAULT_THEME;
+                LOG.info("authentication not of type OAuth2AuthenticationToken. Using default system theme.");
             }
 
-            final String themeValueLowerCase = theme.name().toLowerCase();
-            modelAndView.addObject("theme", themeValueLowerCase);
+            modelAndView.addObject("theme", theme.name().toLowerCase());
+            modelAndView.addObject("navigationCollapsed", navigationCollapsed);
         }
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/web/FrameDataProvider.java
+++ b/src/main/java/de/focusshift/zeiterfassung/web/FrameDataProvider.java
@@ -72,19 +72,21 @@ class FrameDataProvider extends DataProviderInterceptor {
         final boolean settingsActive = url.startsWith(settings);
         final AriaCurrent settingsCurrent = settingsActive ? AriaCurrent.PAGE : AriaCurrent.FALSE;
 
-        final List<NavigationItemDto> items = new ArrayList<>();
-        items.add(new NavigationItemDto("main-navigation-link-timeentries", timeentries, "navigation.main.timetrack", timeentriesActive, timeentriesCurrent, "navigation-link-timeentries"));
-        items.add(new NavigationItemDto("main-navigation-link-reports", report, "navigation.main.reports", reportActive, reportCurrent, "navigation-link-reports"));
+        final List<NavigationItemDto> basic = new ArrayList<>();
+        basic.add(new NavigationItemDto("main-navigation-link-timeentries", timeentries, "navigation.main.timetrack", "clock", timeentriesActive, timeentriesCurrent, "navigation-link-timeentries"));
+        basic.add(new NavigationItemDto("main-navigation-link-reports", report, "navigation.main.reports", "chart-pie", reportActive, reportCurrent, "navigation-link-reports"));
 
+        final List<NavigationItemDto> company = new ArrayList<>();
         if (currentUser.hasAnyRole(ZEITERFASSUNG_WORKING_TIME_EDIT_ALL, ZEITERFASSUNG_OVERTIME_ACCOUNT_EDIT_ALL, ZEITERFASSUNG_PERMISSIONS_EDIT_ALL)) {
-            items.add(new NavigationItemDto("main-navigation-link-users", users, "navigation.main.users", usersActive, usersCurrent, "navigation-link-users"));
+            company.add(new NavigationItemDto("main-navigation-link-users", users, "navigation.main.users", "users", usersActive, usersCurrent, "navigation-link-users"));
         }
 
+        final List<NavigationItemDto> settingsGroup = new ArrayList<>();
         if (currentUser.hasAnyRole(ZEITERFASSUNG_WORKING_TIME_EDIT_GLOBAL, ZEITERFASSUNG_SETTINGS_GLOBAL)) {
-            items.add(new NavigationItemDto("main-navigation-link-settings", settings, "navigation.main.settings", settingsActive, settingsCurrent, "navigation-link-settings"));
+            settingsGroup.add(new NavigationItemDto("main-navigation-link-settings", settings, "navigation.main.settings", "sliders", settingsActive, settingsCurrent, "navigation-link-settings"));
         }
 
-        return new NavigationDto(items);
+        return new NavigationDto(List.of(), basic, company, settingsGroup);
     }
 
     private static SignedInUserDto oidcUserToSignedInUserDto(@NonNull CurrentOidcUser user) {

--- a/src/main/java/de/focusshift/zeiterfassung/web/NavigationDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/web/NavigationDto.java
@@ -1,6 +1,21 @@
 package de.focusshift.zeiterfassung.web;
 
 import java.util.List;
+import java.util.stream.Stream;
 
-record NavigationDto(List<NavigationItemDto> items) {
+record NavigationDto(
+    List<NavigationItemDto> favorites,
+    List<NavigationItemDto> basic,
+    List<NavigationItemDto> company,
+    List<NavigationItemDto> settings
+) {
+
+    /**
+     * @return all navigation items across every group, in group order.
+     */
+    List<NavigationItemDto> items() {
+        return Stream.of(favorites, basic, company, settings)
+            .flatMap(List::stream)
+            .toList();
+    }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/web/NavigationItemDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/web/NavigationItemDto.java
@@ -2,8 +2,10 @@ package de.focusshift.zeiterfassung.web;
 
 import de.focusshift.zeiterfassung.web.html.AriaCurrent;
 
+import java.util.List;
 import java.util.Objects;
 
+import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNullElse;
 
 class NavigationItemDto {
@@ -11,25 +13,41 @@ class NavigationItemDto {
     private final String id;
     private final String href;
     private final String messageKey;
+    private final String iconName;
     private final String dataTestId;
     private final boolean active;
     private final AriaCurrent ariaCurrent;
+    private final List<NavigationItemDto> subItems;
 
     NavigationItemDto(String id, String href, String messageKey) {
         this(id, href, messageKey, false, null);
     }
 
-    NavigationItemDto(String id, String href, String messageKey, boolean active,  AriaCurrent ariaCurrent) {
+    NavigationItemDto(String id, String href, String messageKey, boolean active, AriaCurrent ariaCurrent) {
         this(id, href, messageKey, active, ariaCurrent, null);
     }
 
     NavigationItemDto(String id, String href, String messageKey, boolean active, AriaCurrent ariaCurrent, String dataTestId) {
+        this(id, href, messageKey, null, active, ariaCurrent, dataTestId, emptyList());
+    }
+
+    NavigationItemDto(String id, String href, String messageKey, String iconName, boolean active, AriaCurrent ariaCurrent, String dataTestId) {
+        this(id, href, messageKey, iconName, active, ariaCurrent, dataTestId, emptyList());
+    }
+
+    NavigationItemDto(String id, String href, String messageKey, String iconName, boolean active, AriaCurrent ariaCurrent, String dataTestId, List<NavigationItemDto> subItems) {
         this.id = id;
         this.href = href;
         this.messageKey = messageKey;
+        this.iconName = iconName;
         this.active = active;
         this.ariaCurrent = requireNonNullElse(ariaCurrent, AriaCurrent.FALSE);
         this.dataTestId = dataTestId;
+        this.subItems = requireNonNullElse(subItems, emptyList());
+    }
+
+    NavigationItemDto withSubItems(List<NavigationItemDto> subItems) {
+        return new NavigationItemDto(id, href, messageKey, iconName, active, ariaCurrent, dataTestId, subItems);
     }
 
     public String getId() {
@@ -44,6 +62,10 @@ class NavigationItemDto {
         return messageKey;
     }
 
+    public String getIconName() {
+        return iconName;
+    }
+
     public boolean isActive() {
         return active;
     }
@@ -54,6 +76,10 @@ class NavigationItemDto {
 
     public String getDataTestId() {
         return dataTestId;
+    }
+
+    public List<NavigationItemDto> getSubItems() {
+        return subItems;
     }
 
     @Override
@@ -68,14 +94,16 @@ class NavigationItemDto {
         return id.equals(that.id)
             && href.equals(that.href)
             && messageKey.equals(that.messageKey)
+            && Objects.equals(iconName, that.iconName)
             && Objects.equals(active, that.active)
             && Objects.equals(ariaCurrent, that.ariaCurrent)
-            && Objects.equals(dataTestId, that.dataTestId);
+            && Objects.equals(dataTestId, that.dataTestId)
+            && Objects.equals(subItems, that.subItems);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, href, messageKey, active, ariaCurrent, dataTestId);
+        return Objects.hash(id, href, messageKey, iconName, active, ariaCurrent, dataTestId, subItems);
     }
 
     @Override
@@ -84,9 +112,11 @@ class NavigationItemDto {
             "id='" + id + '\'' +
             ", href='" + href + '\'' +
             ", messageKey='" + messageKey + '\'' +
+            ", iconName='" + iconName + '\'' +
             ", active='" + active + '\'' +
             ", ariaCurrent='" + ariaCurrent + '\'' +
             ", dataTestId='" + dataTestId + '\'' +
+            ", subItems=" + subItems +
             '}';
     }
 }

--- a/src/main/javascript/components/navigation/navigation.spec.ts
+++ b/src/main/javascript/components/navigation/navigation.spec.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { patchJson } from "../../http";
+
+// the module attaches a document-level click listener on import; the tooltip module
+// is stubbed so it doesn't create real popover elements / global listeners during the test
+vi.mock("../../http", () => ({
+  patchJson: vi.fn(() => Promise.resolve({ ok: true })),
+}));
+vi.mock("../tooltip/nav-tooltip", () => ({
+  setup: vi.fn(),
+  prepareTooltip: vi.fn(),
+  disposeTooltip: vi.fn(),
+}));
+
+// importing registers the click listener exactly once for the whole test file
+await import("./navigation");
+
+const SETTINGS_URL = "/api/users/me/settings";
+
+describe("navigation collapse", () => {
+  beforeEach(() => {
+    delete document.documentElement.dataset.navCollapsed;
+    document.body.innerHTML = `
+      <button id="nav-toggle" class="nav-collapse-btn navigation-link" aria-label="toggle" aria-expanded="true">
+        <span class="nav-link-text">toggle</span>
+      </button>
+    `;
+    vi.mocked(patchJson).mockClear();
+  });
+
+  afterEach(() => {
+    delete document.documentElement.dataset.navCollapsed;
+  });
+
+  test("clicking the toggle collapses the navigation and persists it", () => {
+    document.querySelector<HTMLButtonElement>("#nav-toggle")!.click();
+
+    expect(document.documentElement.dataset.navCollapsed).toBeDefined();
+    expect(
+      document.querySelector("#nav-toggle")!.getAttribute("aria-expanded"),
+    ).toBe("false");
+    expect(patchJson).toHaveBeenCalledWith(SETTINGS_URL, {
+      navigationCollapsed: true,
+    });
+  });
+
+  test("clicking the toggle while collapsed expands the navigation and persists it", () => {
+    document.documentElement.dataset.navCollapsed = "";
+
+    document.querySelector<HTMLButtonElement>("#nav-toggle")!.click();
+
+    expect(document.documentElement.dataset.navCollapsed).toBeUndefined();
+    expect(
+      document.querySelector("#nav-toggle")!.getAttribute("aria-expanded"),
+    ).toBe("true");
+    expect(patchJson).toHaveBeenCalledWith(SETTINGS_URL, {
+      navigationCollapsed: false,
+    });
+  });
+});

--- a/src/main/javascript/components/navigation/navigation.ts
+++ b/src/main/javascript/components/navigation/navigation.ts
@@ -1,3 +1,13 @@
+import { patchJson } from "../../http";
+import {
+  disposeTooltip,
+  prepareTooltip,
+  setup as setupTooltips,
+} from "../tooltip/nav-tooltip";
+
+const NAV_COLLAPSED_ATTR = "data-nav-collapsed";
+const TOOLTIP_DELAY = 500;
+
 document.addEventListener("click", function (event) {
   const target = event.target as HTMLElement;
 
@@ -6,12 +16,34 @@ document.addEventListener("click", function (event) {
     event.metaKey ||
     event.ctrlKey ||
     event.altKey ||
-    target.getAttribute("target") === "_blank"
+    target.getAttribute("target") === "_blank" ||
+    target.closest("button:not(.navigation-link)")
   ) {
     // shiftKey: new window
     // metaKey: new tab (macOS)
     // ctrlKey: new tab (not macOS)
     // altKey: download
+    return;
+  }
+
+  if (target.closest("#nav-toggle")) {
+    setNavCollapsed(!isNavCollapsed());
+    return;
+  }
+
+  const navLinkButton = target.closest<HTMLElement>(
+    "button.navigation-link[data-href]",
+  );
+  if (navLinkButton) {
+    // in the expanded state the parent button navigates; in the collapsed state it only
+    // opens the hover/focus subnav flyout, so a click must not navigate
+    if (!isNavCollapsed()) {
+      navLinkButton.classList.add("navigation-link--loading");
+      const href = navLinkButton.dataset.href;
+      if (href) {
+        globalThis.location.href = href;
+      }
+    }
     return;
   }
 
@@ -55,5 +87,304 @@ function subnavlink(element: HTMLElement) {
   if (link) {
     // element is replaced on response and loading class removed
     link.classList.add("navigation-sublink--loading");
+  }
+}
+
+function isNavCollapsed(): boolean {
+  return document.documentElement.hasAttribute(NAV_COLLAPSED_ATTR);
+}
+
+/**
+ * Apply the collapsed state to the DOM (attribute, aria, tooltips) and persist it to the
+ * backend, but only when it actually changed.
+ */
+function setNavCollapsed(collapsed: boolean) {
+  if (collapsed === isNavCollapsed()) {
+    return;
+  }
+  applyNavState(collapsed);
+  persistNavCollapsed(collapsed);
+}
+
+function persistNavCollapsed(collapsed: boolean) {
+  void patchJson("/api/users/me/settings", { navigationCollapsed: collapsed });
+}
+
+function applyNavState(collapsed: boolean) {
+  const toggleButton = document.querySelector("#nav-toggle");
+  if (!toggleButton) {
+    return;
+  }
+  if (collapsed) {
+    document.documentElement.setAttribute(NAV_COLLAPSED_ATTR, "");
+    toggleButton.setAttribute("aria-expanded", "false");
+    addTooltips();
+  } else {
+    document.documentElement.removeAttribute(NAV_COLLAPSED_ATTR);
+    toggleButton.setAttribute("aria-expanded", "true");
+    removeTooltips();
+  }
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  setupTooltips();
+
+  // pair each collapsed submenu with its parent button via a unique anchor-name
+  // so the fixed-positioned subnav-group can anchor() to the right button
+  for (const [index, subnavGroup] of [
+    ...document.querySelectorAll<HTMLElement>(".navigation .subnav-group"),
+  ].entries()) {
+    const link = subnavGroup
+      .closest("li")
+      ?.querySelector<HTMLElement>(".navigation-link");
+    if (!link) {
+      continue;
+    }
+    const name = `--nav-subnav-${index}`;
+    link.style.anchorName = name;
+    subnavGroup.style.positionAnchor = name;
+  }
+
+  const toggleButton = document.querySelector("#nav-toggle");
+  if (!toggleButton) {
+    return;
+  }
+
+  const collapsed = isNavCollapsed();
+  toggleButton.setAttribute("aria-expanded", String(!collapsed));
+  if (collapsed) {
+    addTooltips();
+  }
+
+  setupNavResizeHandle();
+});
+
+const NAV_WIDTH_EXPANDED = 300;
+const NAV_RESIZE_THRESHOLD = 4;
+const NAV_RESIZE_RESISTANCE = 0.3;
+const NAV_RESIZE_MAX_OVERSHOOT = 40;
+const NAV_RESIZE_HOVER_DELAY = 150;
+const NAV_RESIZE_VISIBLE_CLASS = "nav-resize-handle--visible";
+
+/**
+ * Adds a drag handle on the right edge of the navigation. Dragging follows the pointer to give
+ * live width feedback; on release the nav snaps to either the collapsed or expanded state based
+ * on the net drag direction (right expands, left collapses, no movement keeps the current state).
+ * A double-click toggles like the #nav-toggle button.
+ */
+function setupNavResizeHandle() {
+  const container = document.querySelector<HTMLElement>(
+    ".navigation-container",
+  );
+  if (!container) {
+    return;
+  }
+
+  const html = document.documentElement;
+  const remInPx = Number.parseFloat(getComputedStyle(html).fontSize) || 16;
+  // collapsed width mirrors `html[data-nav-collapsed] { --nav-width: 5rem }`
+  const collapsedWidth = remInPx * 5;
+  const midpoint = (collapsedWidth + NAV_WIDTH_EXPANDED) / 2;
+
+  const handle = document.createElement("div");
+  handle.className = "nav-resize-handle";
+  handle.setAttribute("aria-hidden", "true");
+  container.append(handle);
+
+  let startX = 0;
+  let lastX = 0;
+  let pointerId: number | undefined;
+  let startCollapsed = false;
+  let dragging = false;
+  let moved = false;
+  let revealTimer: ReturnType<typeof setTimeout> | undefined;
+  // cached on pointerdown so pointermove never calls getBoundingClientRect()
+  // (a layout read after a style write thrashes layout, very slow in Safari)
+  let containerLeft = 0;
+  // coalesce style writes to one per frame
+  let rafId: number | undefined;
+  let pendingX = 0;
+
+  function reveal() {
+    handle.classList.add(NAV_RESIZE_VISIBLE_CLASS);
+  }
+
+  function hide() {
+    clearTimeout(revealTimer);
+    handle.classList.remove(NAV_RESIZE_VISIBLE_CLASS);
+  }
+
+  function widthForPointer(clientX: number): number {
+    let width = clientX - containerLeft;
+    // rubber-band beyond the snap targets with diminishing resistance
+    if (width < collapsedWidth) {
+      width =
+        collapsedWidth -
+        Math.min(
+          NAV_RESIZE_MAX_OVERSHOOT,
+          (collapsedWidth - width) * NAV_RESIZE_RESISTANCE,
+        );
+    } else if (width > NAV_WIDTH_EXPANDED) {
+      width =
+        NAV_WIDTH_EXPANDED +
+        Math.min(
+          NAV_RESIZE_MAX_OVERSHOOT,
+          (width - NAV_WIDTH_EXPANDED) * NAV_RESIZE_RESISTANCE,
+        );
+    }
+    return width;
+  }
+
+  handle.addEventListener("pointerdown", function (event) {
+    event.preventDefault();
+    // a drag may start before the hover delay elapsed: reveal immediately
+    clearTimeout(revealTimer);
+    reveal();
+    dragging = true;
+    moved = false;
+    startX = event.clientX;
+    lastX = event.clientX;
+    pointerId = event.pointerId;
+    startCollapsed = isNavCollapsed();
+    containerLeft = container.getBoundingClientRect().left;
+    handle.setPointerCapture(event.pointerId);
+    html.classList.add("nav-resizing");
+  });
+
+  function applyWidth() {
+    rafId = undefined;
+    const width = widthForPointer(pendingX);
+    html.style.setProperty("--nav-width", `${width}px`);
+    // flip the layout attribute at the midpoint for live feedback; tooltips are
+    // intentionally left untouched here and reconciled once on release
+    if (width < midpoint) {
+      html.setAttribute(NAV_COLLAPSED_ATTR, "");
+    } else {
+      html.removeAttribute(NAV_COLLAPSED_ATTR);
+    }
+  }
+
+  handle.addEventListener("pointermove", function (event) {
+    if (!dragging) {
+      return;
+    }
+    lastX = event.clientX;
+    // ignore sub-threshold jitter so a plain click neither resizes nor flips
+    if (!moved && Math.abs(event.clientX - startX) < NAV_RESIZE_THRESHOLD) {
+      return;
+    }
+    moved = true;
+
+    // coalesce: one layout-triggering write per frame, not per pointermove
+    pendingX = event.clientX;
+    if (rafId === undefined) {
+      rafId = requestAnimationFrame(applyWidth);
+    }
+  });
+
+  function endDrag() {
+    if (!dragging) {
+      return;
+    }
+    dragging = false;
+    // drop any frame still queued so it can't write width after release
+    if (rafId !== undefined) {
+      cancelAnimationFrame(rafId);
+      rafId = undefined;
+    }
+    if (pointerId !== undefined && handle.hasPointerCapture(pointerId)) {
+      handle.releasePointerCapture(pointerId);
+    }
+    pointerId = undefined;
+
+    // net direction from the drag start decides the final state; lastX is used
+    // (not the event) so cleanup is correct even when pointer capture is lost
+    const finalCollapsed = moved ? lastX < startX : startCollapsed;
+
+    // reconcile DOM (attribute, aria, tooltips) for the final state
+    applyNavState(finalCollapsed);
+    html.classList.remove("nav-resizing");
+    // drop the inline width next frame so the attribute-driven target animates
+    // the snap (and any rubber-band overshoot) over the re-enabled transition
+    requestAnimationFrame(() => html.style.removeProperty("--nav-width"));
+
+    if (finalCollapsed !== startCollapsed) {
+      persistNavCollapsed(finalCollapsed);
+    }
+
+    // keep visible only while still hovering, otherwise reset
+    if (!handle.matches(":hover")) {
+      hide();
+    }
+  }
+
+  handle.addEventListener("pointerup", endDrag);
+  handle.addEventListener("pointercancel", endDrag);
+  // fast pointer movement can drop the implicit capture without a pointerup
+  // reaching the handle; this guarantees the drag state is always cleaned up
+  handle.addEventListener("lostpointercapture", endDrag);
+
+  // reveal the cursor + line only after a short hover, hide immediately on leave
+  handle.addEventListener("pointerenter", function () {
+    revealTimer = setTimeout(reveal, NAV_RESIZE_HOVER_DELAY);
+  });
+  handle.addEventListener("pointerleave", function () {
+    // keep it visible while dragging even when the pointer leaves the handle
+    if (!dragging) {
+      hide();
+    }
+  });
+
+  handle.addEventListener("dblclick", function () {
+    setNavCollapsed(!isNavCollapsed());
+  });
+}
+
+function addTooltips() {
+  for (const element of document.querySelectorAll<HTMLElement>(
+    ".navigation-link",
+  )) {
+    // ignore submenu groups
+    const li = element.closest("li");
+    if (li && !li.querySelector(".subnav-group")) {
+      const text = element.querySelector(".nav-link-text")?.textContent;
+      if (text) {
+        prepareTooltip(element, {
+          text,
+          placement: "right",
+          delay: TOOLTIP_DELAY,
+        });
+      }
+    }
+  }
+
+  const helpButton = document.querySelector<HTMLElement>(
+    "#global-help-button.navigation-link",
+  );
+  const helpText = helpButton?.querySelector(".nav-link-text")?.textContent;
+  if (helpButton && helpText) {
+    prepareTooltip(helpButton, {
+      text: helpText,
+      placement: "right",
+      delay: TOOLTIP_DELAY,
+    });
+  }
+
+  const toggleButton = document.querySelector<HTMLElement>("#nav-toggle");
+  const toggleLabel = toggleButton?.getAttribute("aria-label");
+  if (toggleButton && toggleLabel) {
+    prepareTooltip(toggleButton, {
+      text: toggleLabel,
+      placement: "right",
+      delay: TOOLTIP_DELAY,
+    });
+  }
+}
+
+function removeTooltips() {
+  for (const element of document.querySelectorAll<HTMLElement>(
+    ".navigation-link",
+  )) {
+    disposeTooltip(element);
   }
 }

--- a/src/main/javascript/components/tooltip/nav-tooltip.spec.ts
+++ b/src/main/javascript/components/tooltip/nav-tooltip.spec.ts
@@ -1,0 +1,405 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { prepareTooltip, setup, teardown } from "./nav-tooltip";
+
+function sut(): HTMLElement {
+  return document.querySelector("#nav-tooltip") as HTMLElement;
+}
+
+function spyOnPopover(element: HTMLElement) {
+  element.showPopover = vi.fn();
+  element.hidePopover = vi.fn();
+  // @ts-expect-error .__.
+  element.animate = vi.fn(function () {
+    return { cancel: vi.fn(), finished: Promise.resolve() };
+  });
+  return {
+    show: element.showPopover,
+    hide: element.hidePopover,
+    animate: element.animate,
+  };
+}
+
+type Child = HTMLElement | SVGElement;
+
+function anchorWith(title: string, ...children: Child[]) {
+  const button = document.createElement("button");
+  button.setAttribute("title", title);
+  button.append(...children);
+  return button;
+}
+
+describe("nav-tooltip", function () {
+  beforeEach(function () {
+    vi.useFakeTimers();
+    // @ts-expect-error .__.
+    globalThis.matchMedia = vi.fn(function (query) {
+      return {
+        matches: !query.includes("reduce"),
+        addEventListener() {},
+        removeEventListener() {},
+      };
+    });
+    setup();
+  });
+
+  afterEach(function () {
+    teardown();
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  test("mouseover on a tooltip anchor shows the tooltip after the 300ms hover delay", function () {
+    const button = anchorWith("Edit user");
+    document.body.append(button);
+
+    const { show } = spyOnPopover(sut());
+
+    button.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(299);
+    expect(show).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(show).toHaveBeenCalledOnce();
+    expect(button.classList.contains("nav-tooltip-anchor--active")).toBe(true);
+    expect(button.getAttribute("aria-describedby")).toBe("nav-tooltip");
+    expect(sut().textContent).toBe("Edit user");
+    expect(button.hasAttribute("title")).toBe(false);
+    expect(button.dataset.title).toBe("Edit user");
+  });
+
+  test("focusin on a tooltip anchor shows the tooltip immediately (0ms delay)", function () {
+    const button = anchorWith("Submit");
+    document.body.append(button);
+
+    const { show } = spyOnPopover(sut());
+
+    button.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    expect(show).toHaveBeenCalledOnce();
+    expect(button.classList.contains("nav-tooltip-anchor--active")).toBe(true);
+    expect(button.getAttribute("aria-describedby")).toBe("nav-tooltip");
+    expect(sut().textContent).toBe("Submit");
+  });
+
+  test("mouseover honors a custom data-tooltip-delay over the default 300ms", function () {
+    const button = anchorWith("Edit user");
+    button.dataset.tooltipDelay = "800";
+    document.body.append(button);
+
+    const { show } = spyOnPopover(sut());
+
+    button.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(799);
+    expect(show).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(show).toHaveBeenCalledOnce();
+  });
+
+  test("mouseover with data-tooltip-delay=0 shows the tooltip immediately", function () {
+    const button = anchorWith("Edit user");
+    button.dataset.tooltipDelay = "0";
+    document.body.append(button);
+
+    const { show } = spyOnPopover(sut());
+
+    button.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(0);
+
+    expect(show).toHaveBeenCalledOnce();
+  });
+
+  test("focusin shows immediately even when a custom data-tooltip-delay is set", function () {
+    const button = anchorWith("Submit");
+    button.dataset.tooltipDelay = "800";
+    document.body.append(button);
+
+    const { show } = spyOnPopover(sut());
+
+    button.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    expect(show).toHaveBeenCalledOnce();
+  });
+
+  test("mouseover on another tooltip anchor while open retargets instantly without re-opening", function () {
+    const first = anchorWith("First");
+    const second = anchorWith("Second");
+    document.body.append(first, second);
+
+    const { show, hide } = spyOnPopover(sut());
+
+    first.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(300);
+    expect(show).toHaveBeenCalledOnce();
+
+    second.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    expect(show).toHaveBeenCalledOnce();
+    expect(hide).not.toHaveBeenCalled();
+    expect(first.classList.contains("nav-tooltip-anchor--active")).toBe(false);
+    expect(first.hasAttribute("aria-describedby")).toBe(false);
+    expect(second.classList.contains("nav-tooltip-anchor--active")).toBe(true);
+    expect(second.getAttribute("aria-describedby")).toBe("nav-tooltip");
+    expect(sut().textContent).toBe("Second");
+  });
+
+  test("mouseout from an open tooltip anchor delays hidePopover until the fade-out completes", function () {
+    const button = anchorWith("Edit user");
+    document.body.append(button);
+
+    const { hide } = spyOnPopover(sut());
+
+    button.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(300);
+
+    button.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
+
+    expect(hide).not.toHaveBeenCalled();
+    expect(sut().classList.contains("nav-tooltip--is-hiding")).toBe(true);
+    expect(button.classList.contains("nav-tooltip-anchor--active")).toBe(true);
+    expect(button.getAttribute("aria-describedby")).toBe("nav-tooltip");
+
+    vi.advanceTimersByTime(100);
+
+    expect(hide).toHaveBeenCalledOnce();
+    expect(sut().classList.contains("nav-tooltip--is-hiding")).toBe(false);
+    expect(button.classList.contains("nav-tooltip-anchor--active")).toBe(false);
+    expect(button.hasAttribute("aria-describedby")).toBe(false);
+  });
+
+  test("mouseover on another tooltip anchor during pending-hide cancels the hide without toggling popover", function () {
+    const first = anchorWith("First");
+    const second = anchorWith("Second");
+    document.body.append(first, second);
+
+    const { show, hide } = spyOnPopover(sut());
+
+    first.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(300);
+    expect(show).toHaveBeenCalledTimes(1);
+
+    first.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
+    expect(hide).not.toHaveBeenCalled();
+    expect(sut().classList.contains("nav-tooltip--is-hiding")).toBe(true);
+
+    vi.advanceTimersByTime(50);
+    second.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    expect(show).toHaveBeenCalledTimes(1);
+    expect(hide).not.toHaveBeenCalled();
+    expect(sut().classList.contains("nav-tooltip--is-hiding")).toBe(false);
+    expect(first.classList.contains("nav-tooltip-anchor--active")).toBe(false);
+    expect(first.hasAttribute("aria-describedby")).toBe(false);
+    expect(second.classList.contains("nav-tooltip-anchor--active")).toBe(true);
+    expect(second.getAttribute("aria-describedby")).toBe("nav-tooltip");
+    expect(sut().textContent).toBe("Second");
+
+    vi.advanceTimersByTime(100);
+    expect(hide).not.toHaveBeenCalled();
+    expect(second.classList.contains("nav-tooltip-anchor--active")).toBe(true);
+  });
+
+  test("mouseover on an element without title or data-title is a no-op", function () {
+    const plain = document.createElement("div");
+    document.body.append(plain);
+
+    const { show } = spyOnPopover(sut());
+
+    plain.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(1000);
+
+    expect(show).not.toHaveBeenCalled();
+    expect(plain.classList.contains("nav-tooltip-anchor--active")).toBe(false);
+    expect(plain.hasAttribute("aria-describedby")).toBe(false);
+  });
+
+  test("mouseover events bubbling from child elements of the same anchor do not restart the show timer", function () {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const button = anchorWith("Edit", svg);
+    document.body.append(button);
+
+    const { show } = spyOnPopover(sut());
+
+    button.dispatchEvent(
+      new MouseEvent("mouseover", {
+        bubbles: true,
+        relatedTarget: document.body,
+      }),
+    );
+    vi.advanceTimersByTime(200);
+
+    svg.dispatchEvent(
+      new MouseEvent("mouseover", { bubbles: true, relatedTarget: button }),
+    );
+    vi.advanceTimersByTime(100);
+
+    expect(show).toHaveBeenCalledOnce();
+  });
+
+  test("leaving a tooltip anchor before its show-delay elapses cancels the pending show", function () {
+    const first = anchorWith("First");
+    const second = anchorWith("Second");
+    const third = anchorWith("Third");
+    document.body.append(first, second, third);
+
+    const { show } = spyOnPopover(sut());
+
+    first.dispatchEvent(
+      new MouseEvent("mouseover", {
+        bubbles: true,
+        relatedTarget: document.body,
+      }),
+    );
+    vi.advanceTimersByTime(100);
+
+    first.dispatchEvent(
+      new MouseEvent("mouseout", { bubbles: true, relatedTarget: second }),
+    );
+    second.dispatchEvent(
+      new MouseEvent("mouseover", { bubbles: true, relatedTarget: first }),
+    );
+    vi.advanceTimersByTime(100);
+
+    second.dispatchEvent(
+      new MouseEvent("mouseout", { bubbles: true, relatedTarget: third }),
+    );
+    third.dispatchEvent(
+      new MouseEvent("mouseover", { bubbles: true, relatedTarget: second }),
+    );
+    vi.advanceTimersByTime(100);
+
+    third.dispatchEvent(
+      new MouseEvent("mouseout", {
+        bubbles: true,
+        relatedTarget: document.body,
+      }),
+    );
+    vi.advanceTimersByTime(1000);
+
+    expect(show).not.toHaveBeenCalled();
+  });
+
+  test("handoff to another anchor animates the tooltip slide via WAAPI", function () {
+    const first = anchorWith("First");
+    const second = anchorWith("Second");
+    document.body.append(first, second);
+
+    const { animate } = spyOnPopover(sut());
+
+    first.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(300);
+    expect(animate).not.toHaveBeenCalled();
+
+    second.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    expect(animate).toHaveBeenCalledOnce();
+    // @ts-expect-error .__.
+    const [keyframes, options] = animate.mock.calls[0];
+    expect(keyframes).toHaveLength(2);
+    expect(keyframes[0]).toHaveProperty("translate");
+    expect(keyframes[1]).toEqual({ translate: "0 0" });
+    expect(options).toMatchObject({ duration: 150, easing: "ease-out" });
+  });
+
+  test("handoff does not animate when prefers-reduced-motion is reduce", function () {
+    // @ts-expect-error .__.
+    globalThis.matchMedia = vi.fn(function (query) {
+      return {
+        matches: query.includes("reduce"),
+        addEventListener() {},
+        removeEventListener() {},
+      };
+    });
+    teardown();
+    setup();
+
+    const first = anchorWith("First");
+    const second = anchorWith("Second");
+    document.body.append(first, second);
+
+    const { animate } = spyOnPopover(sut());
+
+    first.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(300);
+    second.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    expect(animate).not.toHaveBeenCalled();
+    expect(second.classList.contains("nav-tooltip-anchor--active")).toBe(true);
+  });
+
+  test("prepareTooltip writes data-tooltip-delay when a delay is given", function () {
+    const button = document.createElement("button");
+    document.body.append(button);
+
+    prepareTooltip(button, { text: "Edit user", delay: 500 });
+
+    expect(button.dataset.tooltipDelay).toBe("500");
+  });
+
+  test("prepareTooltip writes data-tooltip-placement when a placement is given", function () {
+    const button = document.createElement("button");
+    document.body.append(button);
+
+    prepareTooltip(button, { text: "Edit user", placement: "right" });
+
+    expect(button.dataset.tooltipPlacement).toBe("right");
+  });
+
+  test("prepareTooltip leaves data-tooltip-placement untouched when placement is omitted", function () {
+    const button = document.createElement("button");
+    button.dataset.tooltipPlacement = "right";
+    document.body.append(button);
+
+    prepareTooltip(button, { text: "Edit user" });
+
+    expect(button.dataset.tooltipPlacement).toBe("right");
+  });
+
+  test("showing a tooltip mirrors the anchor placement onto the tooltip element", function () {
+    const button = anchorWith("Edit user");
+    button.dataset.tooltipPlacement = "right";
+    document.body.append(button);
+
+    spyOnPopover(sut());
+
+    button.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    expect(sut().dataset.placement).toBe("right");
+  });
+
+  test("showing a tooltip without placement defaults the tooltip element to top", function () {
+    const button = anchorWith("Edit user");
+    document.body.append(button);
+
+    spyOnPopover(sut());
+
+    button.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    expect(sut().dataset.placement).toBe("top");
+  });
+
+  test("mouseout to a child within the same anchor does not begin hide", function () {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const button = anchorWith("Edit", svg);
+    document.body.append(button);
+
+    const { hide } = spyOnPopover(sut());
+
+    button.dispatchEvent(
+      new MouseEvent("mouseover", {
+        bubbles: true,
+        relatedTarget: document.body,
+      }),
+    );
+    vi.advanceTimersByTime(300);
+
+    button.dispatchEvent(
+      new MouseEvent("mouseout", { bubbles: true, relatedTarget: svg }),
+    );
+    vi.advanceTimersByTime(100);
+
+    expect(hide).not.toHaveBeenCalled();
+    expect(sut().classList.contains("nav-tooltip--is-hiding")).toBe(false);
+    expect(button.classList.contains("nav-tooltip-anchor--active")).toBe(true);
+  });
+});

--- a/src/main/javascript/components/tooltip/nav-tooltip.ts
+++ b/src/main/javascript/components/tooltip/nav-tooltip.ts
@@ -1,0 +1,283 @@
+/**
+ * Imperative, delegation-based tooltip used by the collapsed navigation.
+ *
+ * A single shared popover element is reused for every anchor. Anchors opt in via a `title`
+ * (migrated to `data-title` so the browser doesn't render its own tooltip) and an optional
+ * `data-tooltip-delay`. This is intentionally separate from the declarative `z-tooltip`
+ * web component: the navigation needs to add/remove tooltips imperatively as it collapses
+ * and expands, and wants a hover delay so they don't flash while scanning the rail.
+ *
+ * https://www.nngroup.com/articles/tooltip-guidelines/
+ */
+
+const HOVER_SHOW_DELAY_MS = 300;
+const FADE_OUT_MS = 100;
+const SLIDE_MS = 150;
+const TOOLTIP_ID = "nav-tooltip";
+const ANCHOR_ACTIVE_CLASS = "nav-tooltip-anchor--active";
+const TOOLTIP_HIDING_CLASS = "nav-tooltip--is-hiding";
+
+type State = "idle" | "open" | "pendingShow" | "pendingHide";
+
+type TooltipPlacement = "top" | "right";
+
+type TooltipOptions = {
+  text: string;
+  placement?: TooltipPlacement;
+  delay?: number;
+};
+
+let tooltip: HTMLElement | undefined;
+let showTimerId: ReturnType<typeof setTimeout> | undefined;
+let hideTimerId: ReturnType<typeof setTimeout> | undefined;
+let activeAnchor: HTMLElement | undefined;
+let pendingAnchor: HTMLElement | undefined;
+let slideAnim: Animation | undefined;
+let state: State = "idle";
+
+export function setup(): void {
+  if (!tooltip) {
+    tooltip = document.createElement("div");
+    tooltip.id = TOOLTIP_ID;
+    tooltip.setAttribute("role", "tooltip");
+    tooltip.setAttribute("popover", "hint");
+    document.body.append(tooltip);
+  }
+  document.addEventListener("mouseover", onPointerEnter);
+  document.addEventListener("mouseout", onPointerLeave);
+  document.addEventListener("focusin", onPointerEnter);
+  document.addEventListener("focusout", onPointerLeave);
+}
+
+export function teardown(): void {
+  document.removeEventListener("mouseover", onPointerEnter);
+  document.removeEventListener("mouseout", onPointerLeave);
+  document.removeEventListener("focusin", onPointerEnter);
+  document.removeEventListener("focusout", onPointerLeave);
+  clearTimeout(showTimerId);
+  clearTimeout(hideTimerId);
+  showTimerId = undefined;
+  hideTimerId = undefined;
+  pendingAnchor = undefined;
+  if (slideAnim) {
+    slideAnim.cancel();
+    slideAnim = undefined;
+  }
+  if (activeAnchor) {
+    activeAnchor.classList.remove(ANCHOR_ACTIVE_CLASS);
+    activeAnchor.removeAttribute("aria-describedby");
+    activeAnchor = undefined;
+  }
+  if (tooltip) {
+    tooltip.classList.remove(TOOLTIP_HIDING_CLASS);
+    tooltip.remove();
+    tooltip = undefined;
+  }
+  state = "idle";
+}
+
+function onPointerEnter(event: MouseEvent | FocusEvent): void {
+  const anchor = closestTooltipAnchor(event.target as HTMLElement);
+  if (!anchor || isInternalCrossing(event, anchor)) {
+    return;
+  }
+  if (anchor === activeAnchor && state !== "pendingHide") {
+    return;
+  }
+  if (state === "open" || state === "pendingHide") {
+    handoffTo(anchor);
+    return;
+  }
+  clearTimeout(showTimerId);
+  pendingAnchor = anchor;
+  state = "pendingShow";
+  if (event.type === "focusin") {
+    showOn(anchor);
+  } else {
+    const delay = anchor.dataset.tooltipDelay;
+    showTimerId = setTimeout(
+      function () {
+        showOn(anchor);
+      },
+      delay === undefined ? HOVER_SHOW_DELAY_MS : Number(delay),
+    );
+  }
+}
+
+function onPointerLeave(event: MouseEvent | FocusEvent): void {
+  const anchor = closestTooltipAnchor(event.target as HTMLElement);
+  if (!anchor || isInternalCrossing(event, anchor)) {
+    return;
+  }
+  if (anchor === pendingAnchor) {
+    clearTimeout(showTimerId);
+    showTimerId = undefined;
+    pendingAnchor = undefined;
+    state = "idle";
+    return;
+  }
+  if (anchor === activeAnchor) {
+    beginHide();
+  }
+}
+
+function isInternalCrossing(
+  event: MouseEvent | FocusEvent,
+  anchor: HTMLElement,
+): boolean {
+  return (
+    event.relatedTarget instanceof Node && anchor.contains(event.relatedTarget)
+  );
+}
+
+function handoffTo(anchor: HTMLElement): void {
+  clearTimeout(hideTimerId);
+  hideTimerId = undefined;
+  tooltip?.classList.remove(TOOLTIP_HIDING_CLASS);
+  retargetTo(anchor);
+  state = "open";
+}
+
+function beginHide() {
+  clearTimeout(showTimerId);
+  if (state !== "open") {
+    return;
+  }
+  state = "pendingHide";
+  tooltip?.classList.add(TOOLTIP_HIDING_CLASS);
+  hideTimerId = setTimeout(finalizeHide, FADE_OUT_MS);
+}
+
+function finalizeHide(): void {
+  hideTimerId = undefined;
+  tooltip?.classList.remove(TOOLTIP_HIDING_CLASS);
+  tooltip?.hidePopover();
+  if (activeAnchor) {
+    activeAnchor.classList.remove(ANCHOR_ACTIVE_CLASS);
+    activeAnchor.removeAttribute("aria-describedby");
+    activeAnchor = undefined;
+  }
+  state = "idle";
+}
+
+function showOn(anchor: HTMLElement): void {
+  pendingAnchor = undefined;
+  showTimerId = undefined;
+  retargetTo(anchor);
+  tooltip?.showPopover();
+  state = "open";
+}
+
+function retargetTo(anchor: HTMLElement): void {
+  if (!tooltip) {
+    return;
+  }
+  const isHandoff = activeAnchor && activeAnchor !== anchor;
+  const previousAnchorRect = isHandoff
+    ? activeAnchor!.getBoundingClientRect()
+    : undefined;
+
+  if (slideAnim) {
+    slideAnim.cancel();
+    slideAnim = undefined;
+  }
+
+  if (isHandoff) {
+    activeAnchor!.classList.remove(ANCHOR_ACTIVE_CLASS);
+    activeAnchor!.removeAttribute("aria-describedby");
+  }
+  ensureMigratedTitle(anchor);
+  anchor.classList.add(ANCHOR_ACTIVE_CLASS);
+  anchor.setAttribute("aria-describedby", TOOLTIP_ID);
+  tooltip.textContent = anchor.dataset.title ?? "";
+  const placement =
+    anchor.dataset.tooltipPlacement === "right" ? "right" : "top";
+  tooltip.dataset.placement = placement;
+  activeAnchor = anchor;
+
+  if (previousAnchorRect && !prefersReducedMotion()) {
+    const nextAnchorRect = anchor.getBoundingClientRect();
+    // both ends of a handoff share the same placement, so the reference point follows it
+    let dx;
+    let dy;
+    if (placement === "right") {
+      // tooltip is left-aligned right of anchor.right and vertically centered on the anchor
+      dx = previousAnchorRect.right - nextAnchorRect.right;
+      dy =
+        previousAnchorRect.top +
+        previousAnchorRect.height / 2 -
+        (nextAnchorRect.top + nextAnchorRect.height / 2);
+    } else {
+      // tooltip is centered horizontally over the anchor and bottom-aligned above anchor.top
+      dx =
+        previousAnchorRect.left +
+        previousAnchorRect.width / 2 -
+        (nextAnchorRect.left + nextAnchorRect.width / 2);
+      dy = previousAnchorRect.top - nextAnchorRect.top;
+    }
+    slideAnim = tooltip.animate(
+      [{ translate: `${dx}px ${dy}px` }, { translate: "0 0" }],
+      {
+        duration: SLIDE_MS,
+        easing: "ease-out",
+        fill: "none",
+      },
+    );
+  }
+}
+
+function prefersReducedMotion() {
+  return (
+    globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false
+  );
+}
+
+function ensureMigratedTitle(anchor: HTMLElement): void {
+  if (anchor.hasAttribute("title")) {
+    anchor.dataset.title = anchor.getAttribute("title") ?? "";
+    anchor.removeAttribute("title");
+  }
+}
+
+function closestTooltipAnchor(
+  element: HTMLElement | null,
+): HTMLElement | undefined {
+  if (!element) {
+    return undefined;
+  }
+  if (
+    element.getAttribute &&
+    (element.getAttribute("title") || element.dataset?.title)
+  ) {
+    return element;
+  }
+  return closestTooltipAnchor(element.parentElement);
+}
+
+/**
+ * Prepares the given element to show a tooltip on hover.
+ */
+export function prepareTooltip(
+  element: HTMLElement,
+  { text, placement, delay }: TooltipOptions,
+) {
+  if (element.dataset.title) {
+    element.dataset.title = text;
+  } else {
+    element.setAttribute("title", text);
+  }
+  if (delay !== undefined) {
+    element.dataset.tooltipDelay = String(delay);
+  }
+  if (placement !== undefined) {
+    element.dataset.tooltipPlacement = placement;
+  }
+}
+
+/**
+ * Removes everything tooltip related from the given element.
+ */
+export function disposeTooltip(element: HTMLElement): void {
+  element.removeAttribute("title");
+  delete element.dataset.title;
+}

--- a/src/main/javascript/http.spec.ts
+++ b/src/main/javascript/http.spec.ts
@@ -1,0 +1,332 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { doGet, patchJson, post } from "./http";
+
+describe("http module", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("post", () => {
+    it("sends POST request with correct method and body", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers({ "Content-Type": "application/json" }),
+        json: () => Promise.resolve({ id: 1 }),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      const result = await post("/api/users", JSON.stringify({ name: "John" }));
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/users",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "John" }),
+          credentials: "same-origin",
+        }),
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it("includes CSRF header", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers(),
+        text: () => Promise.resolve(""),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      await post("/api/users", "{}");
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "X-Requested-With": "ajax",
+          }),
+        }),
+      );
+    });
+
+    it("merges custom headers with defaults", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers(),
+        text: () => Promise.resolve(""),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      await post("/api/users", "{}", {
+        headers: { Authorization: "Bearer token" },
+      });
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "X-Requested-With": "ajax",
+            Authorization: "Bearer token",
+          }),
+        }),
+      );
+    });
+
+    it("parses JSON response", async () => {
+      const responseData = { id: 1, name: "John" };
+      const mockResponse = {
+        ok: true,
+        headers: new Headers({ "Content-Type": "application/json" }),
+        json: () => Promise.resolve(responseData),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      const result = await post("/api/users", "{}");
+
+      expect(result.data).toEqual(responseData);
+    });
+  });
+
+  describe("patchJson", () => {
+    it("sends PATCH request with JSON method and stringified body", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers({ "Content-Type": "application/json" }),
+        json: () => Promise.resolve({}),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      const payload = { status: "active" };
+      await patchJson("/api/users/1", payload);
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/users/1",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify(payload),
+        }),
+      );
+    });
+
+    it("sets Content-Type to application/json", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers(),
+        text: () => Promise.resolve(""),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      await patchJson("/api/users/1", { status: "active" });
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+          }),
+        }),
+      );
+    });
+
+    it("merges headers with Content-Type", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers(),
+        text: () => Promise.resolve(""),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      await patchJson(
+        "/api/users/1",
+        {},
+        {
+          headers: { Authorization: "Bearer token" },
+        },
+      );
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            Authorization: "Bearer token",
+          }),
+        }),
+      );
+    });
+
+    it("parses JSON response", async () => {
+      const responseData = { id: 1, status: "active" };
+      const mockResponse = {
+        ok: true,
+        headers: new Headers({ "Content-Type": "application/json" }),
+        json: () => Promise.resolve(responseData),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      const result = await patchJson("/api/users/1", {});
+
+      expect(result.data).toEqual(responseData);
+    });
+  });
+
+  describe("doGet", () => {
+    it("sends GET request", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers({ "Content-Type": "application/json" }),
+        json: () => Promise.resolve([]),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      await doGet("/api/users");
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/users",
+        expect.objectContaining({
+          method: "GET",
+          credentials: "same-origin",
+        }),
+      );
+    });
+
+    it("includes CSRF header on GET", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers(),
+        text: () => Promise.resolve(""),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      await doGet("/api/users");
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "X-Requested-With": "ajax",
+          }),
+        }),
+      );
+    });
+
+    it("parses JSON response", async () => {
+      const responseData = [{ id: 1, name: "John" }];
+      const mockResponse = {
+        ok: true,
+        headers: new Headers({ "Content-Type": "application/json" }),
+        json: () => Promise.resolve(responseData),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      const result = await doGet("/api/users");
+
+      expect(result.data).toEqual(responseData);
+    });
+  });
+
+  describe("response parsing", () => {
+    it("parses JSON when Content-Type includes json", async () => {
+      const responseData = { message: "success" };
+      const mockResponse = {
+        ok: true,
+        headers: new Headers({
+          "Content-Type": "application/json; charset=utf-8",
+        }),
+        json: () => Promise.resolve(responseData),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      const result = await doGet("/api/data");
+
+      expect(result.data).toEqual(responseData);
+    });
+
+    it("parses text when Content-Type is not json", async () => {
+      const responseText = "plain text response";
+      const mockResponse = {
+        ok: true,
+        headers: new Headers({ "Content-Type": "text/plain" }),
+        text: () => Promise.resolve(responseText),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      const result = await doGet("/api/data");
+
+      expect(result.data).toEqual(responseText);
+    });
+
+    it("does not parse response when status is not ok", async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        headers: new Headers({ "Content-Type": "application/json" }),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      const result = await doGet("/api/notfound");
+
+      expect(result.ok).toBe(false);
+      expect(result.data).toBeUndefined();
+    });
+
+    it("handles JSON parse error gracefully", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers({ "Content-Type": "application/json" }),
+        json: () => Promise.reject(new Error("Invalid JSON")),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      const result = await doGet("/api/data");
+
+      expect(result.ok).toBe(true);
+      expect(result.data).toBeUndefined();
+    });
+
+    it("handles missing Content-Type header", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers(),
+        text: () => Promise.resolve("response"),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      const result = await doGet("/api/data");
+
+      expect(result.data).toEqual("response");
+    });
+  });
+
+  describe("credentials and origin", () => {
+    it("sets credentials to same-origin on all requests", async () => {
+      const mockResponse = {
+        ok: true,
+        headers: new Headers(),
+        text: () => Promise.resolve(""),
+      } as Response;
+      vi.mocked(globalThis.fetch).mockResolvedValue(mockResponse);
+
+      await post("/api/data", "{}");
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ credentials: "same-origin" }),
+      );
+
+      await patchJson("/api/data", {});
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ credentials: "same-origin" }),
+      );
+
+      await doGet("/api/data");
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ credentials: "same-origin" }),
+      );
+    });
+  });
+});

--- a/src/main/javascript/http.ts
+++ b/src/main/javascript/http.ts
@@ -21,8 +21,36 @@ export function post<T>(
 ): Promise<ResponseWithData<T>> {
   return doFetch(url, {
     ...options,
-    method: "post",
+    method: "POST",
     body: data,
+  });
+}
+
+/**
+ * This method does a PATCH request and internally handles app specific security aspects like CSRF.
+ *
+ * @param {string} url the endpoint for the request
+ * @param {BodyInit} data data used as RequestBody
+ * @param {RequestInit} [options]
+ *              configure the request with meta info. please see [native fetch init parameter](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)
+ *              for more detail.
+ * @returns {Promise<ResponseWithData>}
+ *              returns a promise eventually resolve with the original `Response` object enriched
+ *              with a `data` attribute which contains the deserialized response data.
+ */
+export function patchJson<T>(
+  url: string | URL,
+  data: Record<string, unknown>,
+  options: RequestInit = {},
+): Promise<ResponseWithData<T>> {
+  return doFetch(url, {
+    ...options,
+    method: "PATCH",
+    body: JSON.stringify(data),
+    headers: {
+      ...options.headers,
+      "Content-Type": "application/json",
+    },
   });
 }
 
@@ -38,7 +66,7 @@ export function doGet<T>(
 ): Promise<ResponseWithData<T>> {
   return doFetch(url, {
     ...options,
-    method: "get",
+    method: "GET",
   });
 }
 

--- a/src/main/resources/db/changelog/changelog-3.1.0-add-navigation-collapsed-to-user-settings.xml
+++ b/src/main/resources/db/changelog/changelog-3.1.0-add-navigation-collapsed-to-user-settings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd">
+
+  <changeSet author="seber" id="3.1.0-add-navigation-collapsed-to-user-settings">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="user_settings"/>
+      <not>
+        <columnExists tableName="user_settings" columnName="navigation_collapsed"/>
+      </not>
+    </preConditions>
+
+    <addColumn tableName="user_settings">
+      <column name="navigation_collapsed" type="BOOLEAN" defaultValueBoolean="false">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-main.xml
+++ b/src/main/resources/db/changelog/db.changelog-main.xml
@@ -41,4 +41,5 @@
   <include relativeToChangelogFile="true" file="changelog-2.25.0-add-company-vacation.xml"/>
   <include relativeToChangelogFile="true" file="changelog-2.25.2-remove-not-nullable-of-time-entry-aud.xml"/>
   <include relativeToChangelogFile="true" file="changelog-3.0.0-add-user-settings.xml"/>
+  <include relativeToChangelogFile="true" file="changelog-3.1.0-add-navigation-collapsed-to-user-settings.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -249,6 +249,11 @@ navigation.main.timetrack=Zeit
 navigation.main.reports=Berichte
 navigation.main.users=Personen
 navigation.main.settings=Einstellungen
+navigation.basic=me
+navigation.company=Unternehmen
+navigation.settings=Einstellungen
+nav.toggle.text=Einklappen
+nav.toggle.aria-label=Navigationsleiste umschalten
 
 timeclock.start=Start
 timeclock.stop=Fertig

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -247,6 +247,11 @@ navigation.main.timetrack=Time
 navigation.main.reports=Reports
 navigation.main.users=Persons
 navigation.main.settings=Settings
+navigation.basic=me
+navigation.company=Company
+navigation.settings=Settings
+nav.toggle.aria-label=Toggle navigation sidebar
+nav.toggle.text=Collapse
 
 timeclock.start=Start
 timeclock.stop=Finished

--- a/src/main/resources/templates/_layout.html
+++ b/src/main/resources/templates/_layout.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head

--- a/src/main/resources/templates/_navigation.html
+++ b/src/main/resources/templates/_navigation.html
@@ -6,6 +6,78 @@
     <title>Navigation</title>
   </head>
   <body>
+    <!--
+      Renders a single navigation link. Items without sub-items render as an anchor.
+      Items with sub-items render as a button opening a popover sub-navigation (collapsed state).
+      The icon (or a first-letter fallback) is always rendered so the collapsed, icon-only
+      navigation stays usable; the textual label lives in `.nav-link-text` and is hidden when collapsed.
+    -->
+    <th:block th:fragment="navLink(link)">
+      <a
+        th:if="${#lists.isEmpty(link.subItems)}"
+        class="navigation-link flex items-center gap-2"
+        th:classappend="${link.active ? 'navigation-link--active' : ''}"
+        th:id="${link.id}"
+        th:href="@{__${link.href}__}"
+        th:data-testid="${link.dataTestId}"
+        th:aria-current="${link.ariaCurrent}"
+      >
+        <th:block th:replace="~{_navigation::navIcon(${link})}" />
+        <span
+          class="nav-link-text"
+          th:text="${#messages.msg(link.messageKey)}"
+        ></span>
+      </a>
+
+      <th:block th:if="${not #lists.isEmpty(link.subItems)}">
+        <button
+          type="button"
+          class="navigation-link flex items-center gap-2"
+          th:classappend="${link.active ? 'navigation-link--active' : ''}"
+          th:id="${link.id}"
+          th:data-href="@{__${link.href}__}"
+          th:data-testid="${link.dataTestId}"
+          aria-haspopup="true"
+        >
+          <th:block th:replace="~{_navigation::navIcon(${link})}" />
+          <span
+            class="nav-link-text"
+            th:text="${#messages.msg(link.messageKey)}"
+          ></span>
+        </button>
+        <ul class="subnav-group">
+          <li th:each="subLink : ${link.subItems}">
+            <a
+              class="navigation-sublink"
+              th:classappend="${subLink.active ? 'navigation-sublink--active' : ''}"
+              th:href="@{__${subLink.href}__}"
+              th:id="${subLink.id}"
+              th:data-testid="${subLink.dataTestId}"
+              th:aria-current="${subLink.ariaCurrent}"
+            >
+              <th:block
+                th:text="${#messages.msg(subLink.messageKey)}"
+              ></th:block>
+            </a>
+          </li>
+        </ul>
+      </th:block>
+    </th:block>
+
+    <!-- icon for a navigation link, falling back to the first letter of the label when no icon is set -->
+    <th:block th:fragment="navIcon(link)">
+      <svg
+        th:if="${not #strings.isEmpty(link.iconName)}"
+        th:replace="~{'icons/' + __${link.iconName}__ :: svg(className='nav-link-badge w-5 h-5')}"
+      />
+      <span
+        th:if="${#strings.isEmpty(link.iconName)}"
+        class="nav-link-badge"
+        aria-hidden="true"
+        th:text="${#strings.substring(#messages.msg(link.messageKey), 0, 1)}"
+      ></span>
+    </th:block>
+
     <th:block th:fragment="nav">
       <div class="topbar-cell navigation-container desktop:h-auto">
         <button
@@ -21,21 +93,54 @@
           class="navigation popover popover--slide-to-right"
         >
           <div class="navigation-inner">
-            <div>
-              <ul>
-                <li th:each="link : ${navigation.items}">
-                  <a
-                    class="navigation-link"
-                    th:classappend="${link.active ? 'navigation-link--active' : ''}"
-                    th:id="${link.id}"
-                    th:href="@{__${link.href}__}"
-                    th:data-testid="${link.dataTestId}"
-                    th:aria-current="${link.ariaCurrent}"
-                  >
-                    <th:block
-                      th:text="${#messages.msg(link.messageKey)}"
-                    ></th:block>
-                  </a>
+            <div th:if="${not #lists.isEmpty(navigation.favorites)}">
+              <span
+                id="nav-group-favorites-label"
+                class="sr-only nav-group-label"
+              >
+                <th:block th:text="#{nav.group.basic}">Persönlich</th:block>
+              </span>
+              <ul aria-labelledby="nav-group-favorites-label">
+                <li th:each="link : ${navigation.favorites}">
+                  <th:block th:replace="~{_navigation::navLink(${link})}" />
+                </li>
+              </ul>
+            </div>
+            <div th:if="${not #lists.isEmpty(navigation.basic)}">
+              <span id="nav-group-basic-label" class="sr-only nav-group-label">
+                <th:block th:text="#{navigation.basic}">Me</th:block>
+              </span>
+              <ul aria-labelledby="nav-group-basic-label">
+                <li th:each="link : ${navigation.basic}">
+                  <th:block th:replace="~{_navigation::navLink(${link})}" />
+                </li>
+              </ul>
+            </div>
+            <div th:if="${not #lists.isEmpty(navigation.company)}">
+              <span
+                id="nav-group-company-label"
+                class="sr-only nav-group-label"
+              >
+                <th:block th:text="#{navigation.company}">Unternehmen</th:block>
+              </span>
+              <ul aria-labelledby="nav-group-company-label">
+                <li th:each="link : ${navigation.company}">
+                  <th:block th:replace="~{_navigation::navLink(${link})}" />
+                </li>
+              </ul>
+            </div>
+            <div th:if="${not #lists.isEmpty(navigation.settings)}">
+              <span
+                id="nav-group-settings-label"
+                class="sr-only nav-group-label"
+              >
+                <th:block th:text="#{navigation.settings}"
+                  >Einstellungen</th:block
+                >
+              </span>
+              <ul aria-labelledby="nav-group-settings-label">
+                <li th:each="link : ${navigation.settings}">
+                  <th:block th:replace="~{_navigation::navLink(${link})}" />
                 </li>
               </ul>
             </div>
@@ -43,22 +148,37 @@
               data-sticky="bottom"
               class="navigation-inner__bottom flex flex-col gap-2"
             >
-              <div class="flex items-center gap-4">
-                <a
-                  class="flex-1 navigation-link flex items-center gap-2"
-                  th:href="${menuHelpUrl}"
-                  target="_blank"
-                  rel="noopener"
+              <a
+                id="global-help-button"
+                class="flex-1 navigation-link flex items-center gap-2"
+                th:href="${menuHelpUrl}"
+                target="_blank"
+                rel="noopener"
+              >
+                <svg
+                  th:replace="~{icons/help-circle::svg(className='nav-help-icon h-5 w-5')}"
+                />
+                <span
+                  class="nav-link-text whitespace-nowrap text-ellipsis overflow-hidden"
+                  style="min-width: 0"
+                  th:text="#{nav.help.title}"
+                ></span>
+              </a>
+              <div class="flex items-center justify-between gap-2">
+                <button
+                  id="nav-toggle"
+                  class="nav-collapse-btn navigation-link flex items-center gap-2"
+                  th:aria-label="#{nav.toggle.aria-label}"
+                  aria-expanded="true"
                 >
-                  <span
-                    class="whitespace-nowrap text-ellipsis overflow-hidden"
-                    style="min-width: 0"
-                    th:text="#{nav.help.title}"
-                  ></span>
                   <svg
-                    th:replace="~{icons/external-link::svg(className='h-4 w-4')}"
-                  ></svg>
-                </a>
+                    th:replace="~{icons/panel-left::svg(className='w-5 h-5')}"
+                  />
+                  <span
+                    class="nav-link-text"
+                    th:text="#{nav.toggle.text}"
+                  ></span>
+                </button>
                 <div id="feedback-heart-container"></div>
               </div>
             </z-sticky>

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head th:replace="~{_layout::head(title=~{::title})}">

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head th:replace="~{_layout::head(~{::title})}">

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head th:replace="~{_layout::head(~{::title})}">

--- a/src/main/resources/templates/icons/panel-left.html
+++ b/src/main/resources/templates/icons/panel-left.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Title</title>
+  </head>
+  <body>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      role="img"
+      aria-hidden="true"
+      focusable="false"
+      th:classappend="${className}"
+    >
+      <rect width="18" height="18" x="3" y="3" rx="2"></rect>
+      <path d="M9 3v18"></path>
+    </svg>
+  </body>
+</html>

--- a/src/main/resources/templates/reports/_report-time-entries.html
+++ b/src/main/resources/templates/reports/_report-time-entries.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head>

--- a/src/main/resources/templates/reports/_user-select.html
+++ b/src/main/resources/templates/reports/_user-select.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head>

--- a/src/main/resources/templates/reports/user-report-edit-time-entry.html
+++ b/src/main/resources/templates/reports/user-report-edit-time-entry.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head

--- a/src/main/resources/templates/reports/user-report-month.html
+++ b/src/main/resources/templates/reports/user-report-month.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head>

--- a/src/main/resources/templates/reports/user-report-week.html
+++ b/src/main/resources/templates/reports/user-report-week.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head>

--- a/src/main/resources/templates/reports/user-report.html
+++ b/src/main/resources/templates/reports/user-report.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head

--- a/src/main/resources/templates/settings/settings.html
+++ b/src/main/resources/templates/settings/settings.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head

--- a/src/main/resources/templates/timeclock/timeclock-edit-form.html
+++ b/src/main/resources/templates/timeclock/timeclock-edit-form.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head>

--- a/src/main/resources/templates/timeclock/timeclock-edit.html
+++ b/src/main/resources/templates/timeclock/timeclock-edit.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head th:replace="~{_layout::head(~{::title})}">

--- a/src/main/resources/templates/timeentries/index.html
+++ b/src/main/resources/templates/timeentries/index.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head

--- a/src/main/resources/templates/user/user-settings.html
+++ b/src/main/resources/templates/user/user-settings.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head

--- a/src/main/resources/templates/usermanagement/user/overtime-account-settings.html
+++ b/src/main/resources/templates/usermanagement/user/overtime-account-settings.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head>

--- a/src/main/resources/templates/usermanagement/user/permission-settings.html
+++ b/src/main/resources/templates/usermanagement/user/permission-settings.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head>

--- a/src/main/resources/templates/usermanagement/user/working-time-edit.html
+++ b/src/main/resources/templates/usermanagement/user/working-time-edit.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head>

--- a/src/main/resources/templates/usermanagement/user/working-time-edit_working-time-weekday.html
+++ b/src/main/resources/templates/usermanagement/user/working-time-edit_working-time-weekday.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head>

--- a/src/main/resources/templates/usermanagement/user/working-time-settings.html
+++ b/src/main/resources/templates/usermanagement/user/working-time-settings.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head>

--- a/src/main/resources/templates/usermanagement/users.html
+++ b/src/main/resources/templates/usermanagement/users.html
@@ -3,6 +3,7 @@
   lang="en"
   th:lang="${language}"
   th:class="|theme-${theme}|"
+  th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
 >
   <head th:replace="~{_layout::head(title=~{::title}, styles=~{::styles})}">

--- a/src/test/java/de/focusshift/zeiterfassung/user/UserSettingsApiControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/user/UserSettingsApiControllerTest.java
@@ -1,0 +1,85 @@
+package de.focusshift.zeiterfassung.user;
+
+import de.focusshift.zeiterfassung.ControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+@ExtendWith(MockitoExtension.class)
+class UserSettingsApiControllerTest implements ControllerTest {
+
+    private UserSettingsApiController sut;
+
+    @Mock
+    private UserSettingsService userSettingsService;
+
+    @BeforeEach
+    void setUp() {
+        sut = new UserSettingsApiController(userSettingsService);
+    }
+
+    @Nested
+    class UpdateSettings {
+
+        @Test
+        void ensureUpdateNavigationCollapsedReturnsNoContentWithoutUpdatingNavigationCollapsed() throws Exception {
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+
+            perform(patch("/api/users/me/settings").with(oidcSubject(userIdComposite))
+                .contentType(APPLICATION_JSON)
+                .content(asJsonString(new UpdateUserSettingsDto(null)))
+            )
+                .andExpect(status().isNoContent());
+
+            verifyNoInteractions(userSettingsService);
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        void ensureUpdateNavigationCollapsedReturnsNoContentAndPersists(boolean givenNavigationCollapsed) throws Exception {
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+
+            perform(patch("/api/users/me/settings").with(oidcSubject(userIdComposite))
+                .contentType(APPLICATION_JSON)
+                .content(asJsonString(new UpdateUserSettingsDto(givenNavigationCollapsed)))
+            )
+                .andExpect(status().isNoContent());
+
+            verify(userSettingsService).updateNavigationCollapsed(userIdComposite, givenNavigationCollapsed);
+        }
+    }
+
+    public static String asJsonString(final Object obj) {
+        try {
+            return new JsonMapper().writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {
+        return standaloneSetup(sut)
+            .addFilters(new SecurityContextHolderFilter(new HttpSessionSecurityContextRepository()))
+            .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+            .build()
+            .perform(builder);
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/user/UserSettingsServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/user/UserSettingsServiceTest.java
@@ -66,6 +66,23 @@ class UserSettingsServiceTest {
         }
 
         @Test
+        void ensureUserSettingsExposesNavigationCollapsed() {
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+            final Long localId = userIdComposite.localId().value();
+
+            final UserSettingsEntity entity = new UserSettingsEntity();
+            entity.setTenantUserLocalId(localId);
+            entity.setTheme(Theme.DARK);
+            entity.setNavigationCollapsed(true);
+
+            when(userSettingsRepository.findById(localId)).thenReturn(Optional.of(entity));
+
+            final UserSettings actual = sut.getUserSettings(userIdComposite);
+
+            assertThat(actual.navigationCollapsed()).isTrue();
+        }
+
+        @Test
         void ensureUserSettingsForPersonReturnsDefault() {
             final UserIdComposite userIdComposite = anyUserIdComposite();
             final Long localId = userIdComposite.localId().value();
@@ -76,6 +93,7 @@ class UserSettingsServiceTest {
 
             assertThat(actual.theme()).isEqualTo(Theme.SYSTEM);
             assertThat(actual.locale()).isEmpty();
+            assertThat(actual.navigationCollapsed()).isFalse();
         }
     }
 
@@ -183,6 +201,73 @@ class UserSettingsServiceTest {
                     assertThat(userSettingsEntity.getLocale()).isEqualTo(GERMAN);
                     assertThat(userSettingsEntity.getLocaleBrowserSpecific()).isNull();
                 });
+        }
+    }
+
+    @Nested
+    class UpdateNavigationCollapsed {
+
+        @Test
+        void ensureUpdateNavigationCollapsedSavesFlag() {
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+            final Long localId = userIdComposite.localId().value();
+
+            final UserSettingsEntity entity = new UserSettingsEntity();
+            entity.setTenantUserLocalId(localId);
+            entity.setTheme(Theme.DARK);
+            entity.setNavigationCollapsed(false);
+
+            when(userSettingsRepository.findById(localId)).thenReturn(Optional.of(entity));
+            when(userSettingsRepository.save(entity)).thenReturn(entity);
+
+            sut.updateNavigationCollapsed(userIdComposite, true);
+
+            final ArgumentCaptor<UserSettingsEntity> captor = ArgumentCaptor.forClass(UserSettingsEntity.class);
+            verify(userSettingsRepository).save(captor.capture());
+            assertThat(captor.getValue().isNavigationCollapsed()).isTrue();
+        }
+
+        @Test
+        void ensureUpdateNavigationCollapsedPreservesThemeAndLocale() {
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+            final Long localId = userIdComposite.localId().value();
+
+            final UserSettingsEntity entity = new UserSettingsEntity();
+            entity.setTenantUserLocalId(localId);
+            entity.setTheme(Theme.DARK);
+            entity.setLocale(GERMAN);
+            entity.setLocaleBrowserSpecific(ENGLISH);
+
+            when(userSettingsRepository.findById(localId)).thenReturn(Optional.of(entity));
+            when(userSettingsRepository.save(entity)).thenReturn(entity);
+
+            sut.updateNavigationCollapsed(userIdComposite, true);
+
+            final ArgumentCaptor<UserSettingsEntity> captor = ArgumentCaptor.forClass(UserSettingsEntity.class);
+            verify(userSettingsRepository).save(captor.capture());
+            assertThat(captor.getValue()).satisfies(saved -> {
+                assertThat(saved.getTheme()).isEqualTo(Theme.DARK);
+                assertThat(saved.getLocale()).isEqualTo(GERMAN);
+                assertThat(saved.getLocaleBrowserSpecific()).isEqualTo(ENGLISH);
+            });
+        }
+
+        @Test
+        void ensureUpdateNavigationCollapsedCreatesDefaultWhenNotFound() {
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+            final Long localId = userIdComposite.localId().value();
+
+            when(userSettingsRepository.findById(localId)).thenReturn(Optional.empty());
+
+            sut.updateNavigationCollapsed(userIdComposite, true);
+
+            final ArgumentCaptor<UserSettingsEntity> captor = ArgumentCaptor.forClass(UserSettingsEntity.class);
+            verify(userSettingsRepository).save(captor.capture());
+            assertThat(captor.getValue()).satisfies(saved -> {
+                assertThat(saved.getTenantUserLocalId()).isEqualTo(localId);
+                assertThat(saved.getTheme()).isEqualTo(Theme.SYSTEM);
+                assertThat(saved.isNavigationCollapsed()).isTrue();
+            });
         }
     }
 

--- a/src/test/java/de/focusshift/zeiterfassung/user/UserSettingsViewControllerIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/user/UserSettingsViewControllerIT.java
@@ -64,7 +64,7 @@ class UserSettingsViewControllerTest implements ControllerTest {
 
         final UserIdComposite userIdComposite = anyUserIdComposite();
 
-        final UserSettings userSettings = new UserSettings(Theme.DARK, Locale.GERMAN, null);
+        final UserSettings userSettings = new UserSettings(Theme.DARK, false, Locale.GERMAN, null);
         when(userSettingsService.getUserSettings(userIdComposite)).thenReturn(userSettings);
 
         when(supportedLocaleService.getSupportedLocales()).thenReturn(Set.of(Locale.GERMAN, Locale.ENGLISH));

--- a/src/test/java/de/focusshift/zeiterfassung/user/UserThemeDataProviderTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/user/UserThemeDataProviderTest.java
@@ -1,0 +1,74 @@
+package de.focusshift.zeiterfassung.user;
+
+import de.focusshift.zeiterfassung.ControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+@ExtendWith(MockitoExtension.class)
+class UserThemeDataProviderTest implements ControllerTest {
+
+    @Controller
+    static class DummyController {
+        @GetMapping("/test-endpoint")
+        public String handleRequest() {
+            return "dummy-view";
+        }
+    }
+
+    private UserThemeDataProvider sut;
+
+    @Mock
+    private UserSettingsService userSettingsService;
+
+    @BeforeEach
+    void setUp() {
+        sut = new UserThemeDataProvider(userSettingsService);
+    }
+
+    @Test
+    void ensureNavigationCollapsedAndThemeModelAttributes() throws Exception {
+
+        final UserIdComposite userIdComposite = anyUserIdComposite();
+        when(userSettingsService.getUserSettings(userIdComposite))
+            .thenReturn(new UserSettings(Theme.DARK, true, null, null));
+
+        final MvcResult result = perform(
+            get("/test-endpoint").with(oidcSubject(userIdComposite, List.of(ZEITERFASSUNG_USER)))
+        )
+            .andExpect(status().isOk())
+            .andReturn();
+
+        assertThat(result.getModelAndView().getModel())
+            .containsEntry("theme", "dark")
+            .containsEntry("navigationCollapsed", true);
+    }
+
+    private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {
+        return standaloneSetup(new DummyController())
+            .addInterceptors(sut)
+            .addFilters(new SecurityContextHolderFilter(new HttpSessionSecurityContextRepository()))
+            .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+            .build()
+            .perform(builder);
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/web/FrameDataProviderTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/web/FrameDataProviderTest.java
@@ -25,6 +25,7 @@ import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_SE
 import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_USER;
 import static de.focusshift.zeiterfassung.security.SecurityRole.ZEITERFASSUNG_WORKING_TIME_EDIT_ALL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
@@ -370,6 +371,53 @@ class FrameDataProviderTest implements ControllerTest {
 
         assertThat(items.get(0).getDataTestId()).isEqualTo("navigation-link-timeentries");
         assertThat(items.get(1).getDataTestId()).isEqualTo("navigation-link-reports");
+    }
+
+    // ==================== Navigation Icon + Group Tests ====================
+
+    @Test
+    void ensureBasicNavigationItemsCarryIcons() throws Exception {
+
+        final MvcResult result = perform("/test-endpoint", List.of(ZEITERFASSUNG_USER));
+
+        assertThat(navigationDto(result).basic())
+            .extracting(NavigationItemDto::getHref, NavigationItemDto::getIconName)
+            .containsExactly(
+                tuple("/timeentries", "clock"),
+                tuple("/report", "chart-pie")
+            );
+    }
+
+    @Test
+    void ensureTimeentriesAndReportsLiveInBasicGroup() throws Exception {
+
+        final MvcResult result = perform("/test-endpoint", List.of(ZEITERFASSUNG_USER));
+
+        final NavigationDto navigation = navigationDto(result);
+        assertThat(navigation.basic()).extracting(NavigationItemDto::getHref).containsExactly("/timeentries", "/report");
+        assertThat(navigation.company()).isEmpty();
+        assertThat(navigation.settings()).isEmpty();
+        assertThat(navigation.favorites()).isEmpty();
+    }
+
+    @Test
+    void ensureUsersLinkLivesInCompanyGroupWithIcon() throws Exception {
+
+        final MvcResult result = perform("/test-endpoint", List.of(ZEITERFASSUNG_USER, ZEITERFASSUNG_WORKING_TIME_EDIT_ALL));
+
+        assertThat(navigationDto(result).company())
+            .extracting(NavigationItemDto::getHref, NavigationItemDto::getIconName)
+            .containsExactly(tuple("/users", "users"));
+    }
+
+    @Test
+    void ensureSettingsLinkLivesInSettingsGroupWithIcon() throws Exception {
+
+        final MvcResult result = perform("/test-endpoint", List.of(ZEITERFASSUNG_USER, ZEITERFASSUNG_SETTINGS_GLOBAL));
+
+        assertThat(navigationDto(result).settings())
+            .extracting(NavigationItemDto::getHref, NavigationItemDto::getIconName)
+            .containsExactly(tuple("/settings", "sliders"));
     }
 
     private NavigationDto navigationDto(MvcResult result) {


### PR DESCRIPTION
closes #1889 

* add icons to navigation items
* Collapse Button at the bottom
* State is persisted in backend
* resize-handle between navigation and content (only on desktop)
  * moving it to the right -> expand
  * moving it to the left -> collapse
  * double click -> toggle

Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
