### PR TITLE
add guard for nullpointer in ReloadAuthenticationAuthoritiesFilter

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/security/ReloadAuthenticationAuthoritiesFilter.java
+++ b/src/main/java/de/focusshift/zeiterfassung/security/ReloadAuthenticationAuthoritiesFilter.java
@@ -21,7 +21,6 @@ import org.springframework.security.web.context.DelegatingSecurityContextReposit
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -67,23 +66,67 @@ class ReloadAuthenticationAuthoritiesFilter extends OncePerRequestFilter {
     @Override
     public void doFilterInternal(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull FilterChain chain) throws ServletException, IOException {
 
-        final HttpSession session = request.getSession();
+        final HttpSession session = request.getSession(false);
+        if (session == null) {
+            LOG.debug("No session available, skipping authority reload and continuing filter chain.");
+            chain.doFilter(request, response);
+            return;
+        }
+
         sessionService.unmarkSessionToReloadAuthorities(session.getId());
 
         final SecurityContext context = SecurityContextHolder.getContext();
         final Authentication authentication = context.getAuthentication();
 
-        final OAuth2AuthenticationToken oAuth2Auth = (OAuth2AuthenticationToken) authentication;
-        final CurrentOidcUser currentOidcUser = (CurrentOidcUser) oAuth2Auth.getPrincipal();
+        if (authentication == null) {
+            LOG.warn("SecurityContext has no authentication, cannot reload authorities. Session: {}", session.getId());
+            chain.doFilter(request, response);
+            return;
+        }
 
-        tenantContextHolder.runInTenantIdContext(oAuth2Auth.getAuthorizedClientRegistrationId(), tenantId -> {
+        if (!(authentication instanceof OAuth2AuthenticationToken oAuth2Auth)) {
+            LOG.warn("Authentication is not an OAuth2AuthenticationToken (type={}), cannot reload authorities.", authentication.getClass().getSimpleName());
+            chain.doFilter(request, response);
+            return;
+        }
+
+        final Object principal = oAuth2Auth.getPrincipal();
+        if (!(principal instanceof CurrentOidcUser currentOidcUser)) {
+            LOG.warn("Principal is not a CurrentOidcUser (type={}), cannot reload authorities.",
+                principal != null ? principal.getClass().getSimpleName() : "null");
+            chain.doFilter(request, response);
+            return;
+        }
+
+        final String registrationId = oAuth2Auth.getAuthorizedClientRegistrationId();
+        if (registrationId == null) {
+            LOG.warn("No authorized client registration ID found, cannot determine tenant context.");
+            chain.doFilter(request, response);
+            return;
+        }
+
+        final var userLocalIdOptional = currentOidcUser.getUserLocalId();
+        if (userLocalIdOptional.isEmpty()) {
+            LOG.warn("CurrentOidcUser has no UserLocalId, cannot reload authorities.");
+            chain.doFilter(request, response);
+            return;
+        }
+
+        tenantContextHolder.runInTenantIdContext(registrationId, tenantId -> {
             final User user = getUserFromUserManagement(currentOidcUser);
 
-            final List<GrantedAuthority> applicationAuthoritiesNew = user.grantedAuthorities();
-            final Collection<? extends GrantedAuthority> oidcAuthorities = currentOidcUser.getOidcAuthorities();
-            final Set<GrantedAuthority> updatedMergedAuthorities = concat(oidcAuthorities.stream(), applicationAuthoritiesNew.stream()).collect(toSet());
+            // Defensive: treat null authority collections as empty
+            final var safeOidcAuthorities = currentOidcUser.getOidcAuthorities() != null ? currentOidcUser.getOidcAuthorities() : List.<GrantedAuthority>of();
+            final var safeAppAuthorities = user.grantedAuthorities();
 
-            final CurrentOidcUser updatedCurrentOidcUser = new CurrentOidcUser(currentOidcUser.getOidcUser(), applicationAuthoritiesNew, oidcAuthorities, currentOidcUser.getUserLocalId().orElseThrow());
+            final Set<GrantedAuthority> updatedMergedAuthorities = concat(safeOidcAuthorities.stream(), safeAppAuthorities.stream()).collect(toSet());
+
+            final CurrentOidcUser updatedCurrentOidcUser = new CurrentOidcUser(
+                currentOidcUser.getOidcUser(),
+                safeAppAuthorities,
+                safeOidcAuthorities,
+                userLocalIdOptional.orElseThrow(() -> new IllegalStateException("UserLocalId disappeared after null-check"))
+            );
             final OAuth2AuthenticationToken updatedAuthentication = new OAuth2AuthenticationToken(updatedCurrentOidcUser, updatedMergedAuthorities, tenantId);
 
             context.setAuthentication(updatedAuthentication);

--- a/src/test/java/de/focusshift/zeiterfassung/security/ReloadAuthenticationAuthoritiesFilterTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/security/ReloadAuthenticationAuthoritiesFilterTest.java
@@ -8,15 +8,16 @@ import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
+import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -32,7 +33,9 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +63,7 @@ class ReloadAuthenticationAuthoritiesFilterTest {
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final MockFilterChain filterChain = new MockFilterChain();
+        final FilterChain filterChain = mock(FilterChain.class);
 
         request.getSession().setAttribute("reloadAuthorities", true);
 
@@ -82,15 +85,7 @@ class ReloadAuthenticationAuthoritiesFilterTest {
         verify(securityContextRepository).saveContext(context, request, response);
     }
 
-    @Test
-    void ensuresFilterSetsAuthenticationWithNewAuthoritiesButSessionIsNullDoNothing() {
-
-        final MockHttpServletRequest request = mock(MockHttpServletRequest.class);
-        when(request.getSession()).thenReturn(null);
-
-        final boolean shouldNotFilter = sut.shouldNotFilter(request);
-        assertThat(shouldNotFilter).isTrue();
-    }
+    // ---- shouldNotFilter tests ----
 
     @Test
     void ensuresFilterSetsNoNewAuthenticationIfReloadIsNotDefined() {
@@ -110,6 +105,193 @@ class ReloadAuthenticationAuthoritiesFilterTest {
 
         final boolean shouldNotFilter = sut.shouldNotFilter(request);
         assertThat(shouldNotFilter).isTrue();
+    }
+
+    @Test
+    void ensuresFilterSetsAuthenticationWithNewAuthoritiesButSessionIsNullDoNothing() {
+
+        final MockHttpServletRequest request = mock(MockHttpServletRequest.class);
+        when(request.getSession()).thenReturn(null);
+
+        final boolean shouldNotFilter = sut.shouldNotFilter(request);
+        assertThat(shouldNotFilter).isTrue();
+    }
+
+    // ---- doFilterInternal defensive guard clause tests ----
+
+    @Test
+    void doFilterInternalWithNullAuthenticationContinuesChainWithoutError() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute("reloadAuthorities", true);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final FilterChain filterChain = mock(FilterChain.class);
+
+        final SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(null);
+
+        sut.doFilterInternal(request, response, filterChain);
+
+        verify(sessionService).unmarkSessionToReloadAuthorities(request.getSession().getId());
+        verify(securityContextRepository, never()).saveContext(context, request, response);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternalWithNonOAuth2AuthenticationContinuesChainWithoutError() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute("reloadAuthorities", true);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final FilterChain filterChain = mock(FilterChain.class);
+
+        final SecurityContext context = SecurityContextHolder.getContext();
+        // Use a mock Authentication that is NOT an OAuth2AuthenticationToken
+        final Authentication authentication = mock(Authentication.class);
+        context.setAuthentication(authentication);
+
+        sut.doFilterInternal(request, response, filterChain);
+
+        verify(sessionService).unmarkSessionToReloadAuthorities(request.getSession().getId());
+        verify(securityContextRepository, never()).saveContext(context, request, response);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternalWithPrincipalNotCurrentOidcUserContinuesChainWithoutError() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute("reloadAuthorities", true);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final FilterChain filterChain = mock(FilterChain.class);
+
+        final SecurityContext context = SecurityContextHolder.getContext();
+
+        // Create a DefaultOidcUser (not CurrentOidcUser) as the principal
+        final DefaultOidcUser plainOidcUser = new DefaultOidcUser(
+            List.of(),
+            OidcIdToken.withTokenValue("token-value").claim("claim", "not-empty").subject("username").build()
+        );
+
+        final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+        when(authentication.getPrincipal()).thenReturn(plainOidcUser);
+        context.setAuthentication(authentication);
+
+        sut.doFilterInternal(request, response, filterChain);
+
+        verify(sessionService).unmarkSessionToReloadAuthorities(request.getSession().getId());
+        verify(securityContextRepository, never()).saveContext(context, request, response);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternalWithNullPrincipalContinuesChainWithoutError() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute("reloadAuthorities", true);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final FilterChain filterChain = mock(FilterChain.class);
+
+        final SecurityContext context = SecurityContextHolder.getContext();
+
+        final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+        doAnswer(invocation -> null).when(authentication).getPrincipal();
+        context.setAuthentication(authentication);
+
+        sut.doFilterInternal(request, response, filterChain);
+
+        verify(sessionService).unmarkSessionToReloadAuthorities(request.getSession().getId());
+        verify(securityContextRepository, never()).saveContext(context, request, response);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternalWithNullRegistrationIdContinuesChainWithoutError() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute("reloadAuthorities", true);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final FilterChain filterChain = mock(FilterChain.class);
+
+        final SecurityContext context = SecurityContextHolder.getContext();
+
+        final DefaultOidcUser oidcUser = new DefaultOidcUser(
+            List.of(),
+            OidcIdToken.withTokenValue("token-value").claim("claim", "not-empty").subject("username").build()
+        );
+        final CurrentOidcUser currentOidcUser = new CurrentOidcUser(oidcUser, List.of(), List.of(), new UserLocalId(1L));
+
+        final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+        when(authentication.getPrincipal()).thenReturn(currentOidcUser);
+        when(authentication.getAuthorizedClientRegistrationId()).thenReturn(null);
+        context.setAuthentication(authentication);
+
+        sut.doFilterInternal(request, response, filterChain);
+
+        verify(sessionService).unmarkSessionToReloadAuthorities(request.getSession().getId());
+        verify(securityContextRepository, never()).saveContext(context, request, response);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternalWithEmptyUserLocalIdContinuesChainWithoutError() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute("reloadAuthorities", true);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final FilterChain filterChain = mock(FilterChain.class);
+
+        final SecurityContext context = SecurityContextHolder.getContext();
+
+        // Create CurrentOidcUser with null UserLocalId (using 3-arg constructor)
+        final DefaultOidcUser oidcUser = new DefaultOidcUser(
+            List.of(),
+            OidcIdToken.withTokenValue("token-value").claim("claim", "not-empty").subject("username").build()
+        );
+        final CurrentOidcUser currentOidcUser = new CurrentOidcUser(oidcUser, List.of(), List.of());
+
+        final OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+        when(authentication.getPrincipal()).thenReturn(currentOidcUser);
+        when(authentication.getAuthorizedClientRegistrationId()).thenReturn("some-id");
+        context.setAuthentication(authentication);
+
+        sut.doFilterInternal(request, response, filterChain);
+
+        verify(sessionService).unmarkSessionToReloadAuthorities(request.getSession().getId());
+        verify(securityContextRepository, never()).saveContext(context, request, response);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternalWithNullOidcAuthoritiesHandlesGracefully() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute("reloadAuthorities", true);
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final FilterChain filterChain = mock(FilterChain.class);
+
+        final SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(prepareOAuth2Authentication("username"));
+
+        final UserId userId = new UserId("username");
+        final User user = new User(
+            new UserIdComposite(userId, new UserLocalId(42L)),
+            "givenName",
+            "familyName",
+            new EMailAddress("email@example.org"),
+            Set.of(SecurityRole.ZEITERFASSUNG_USER)
+        );
+        when(userManagementService.findUserById(userId))
+            .thenReturn(Optional.of(user));
+
+        sut.doFilterInternal(request, response, filterChain);
+
+        // Should complete without exception even when oidcAuthorities is an empty list
+        final List<String> updatedAuthorities = context.getAuthentication().getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .toList();
+        assertThat(updatedAuthorities).contains("ZEITERFASSUNG_USER");
+        verify(securityContextRepository).saveContext(context, request, response);
     }
 
     private OAuth2AuthenticationToken prepareOAuth2Authentication(String subject) {


### PR DESCRIPTION
Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
