### PR TITLE
Fix: Abwesenheit einer Person verändert geplante Stunden einer anderen im Bericht

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/development/DemoDataConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/development/DemoDataConfiguration.java
@@ -1,5 +1,7 @@
 package de.focusshift.zeiterfassung.development;
 
+import de.focusshift.zeiterfassung.absence.AbsenceTypeService;
+import de.focusshift.zeiterfassung.absence.AbsenceWriteService;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -12,7 +14,10 @@ import org.springframework.context.annotation.Configuration;
 public class DemoDataConfiguration {
 
     @Bean
-    DemoDataCreationService demoDataCreationService(TimeEntryService timeEntryService, DemoDataProperties demoDataProperties) {
-        return new DemoDataCreationService(timeEntryService, demoDataProperties);
+    DemoDataCreationService demoDataCreationService(TimeEntryService timeEntryService,
+                                                    AbsenceWriteService absenceWriteService,
+                                                    AbsenceTypeService absenceTypeService,
+                                                    DemoDataProperties demoDataProperties) {
+        return new DemoDataCreationService(timeEntryService, absenceWriteService, absenceTypeService, demoDataProperties);
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/development/DemoDataCreationService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/development/DemoDataCreationService.java
@@ -1,28 +1,44 @@
 package de.focusshift.zeiterfassung.development;
 
+import de.focusshift.zeiterfassung.absence.AbsenceColor;
+import de.focusshift.zeiterfassung.absence.AbsenceTypeCategory;
+import de.focusshift.zeiterfassung.absence.AbsenceTypeService;
+import de.focusshift.zeiterfassung.absence.AbsenceTypeSourceId;
+import de.focusshift.zeiterfassung.absence.AbsenceTypeUpdate;
+import de.focusshift.zeiterfassung.absence.AbsenceWrite;
+import de.focusshift.zeiterfassung.absence.AbsenceWriteService;
+import de.focusshift.zeiterfassung.absence.DayLength;
 import de.focusshift.zeiterfassung.tenancy.user.TenantUser;
 import de.focusshift.zeiterfassung.tenancy.user.TenantUserCreatedEvent;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryService;
+import de.focusshift.zeiterfassung.user.UserId;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.time.ZoneOffset.UTC;
 
 class DemoDataCreationService {
 
     private static final Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());
 
     private static final LocalTime END_OF_WORK_DAY = LocalTime.of(17, 0);
+
+    // demo "Urlaub" absence type that the created HOLIDAY absences refer to
+    private static final long DEMO_HOLIDAY_TYPE_SOURCE_ID = 1L;
 
     private static final String[] comments = {
         "Telefonat mit Kunden zur Livegang \uD83D\uDE80",
@@ -48,10 +64,15 @@ class DemoDataCreationService {
     private static final Random RANDOM = new Random();
 
     private final TimeEntryService timeEntryService;
+    private final AbsenceWriteService absenceWriteService;
+    private final AbsenceTypeService absenceTypeService;
     private final DemoDataProperties demoDataProperties;
 
-    DemoDataCreationService(TimeEntryService timeEntryService, DemoDataProperties demoDataProperties) {
+    DemoDataCreationService(TimeEntryService timeEntryService, AbsenceWriteService absenceWriteService,
+                            AbsenceTypeService absenceTypeService, DemoDataProperties demoDataProperties) {
         this.timeEntryService = timeEntryService;
+        this.absenceWriteService = absenceWriteService;
+        this.absenceTypeService = absenceTypeService;
         this.demoDataProperties = demoDataProperties;
     }
 
@@ -81,6 +102,86 @@ class DemoDataCreationService {
                 endTime = randomTimeBetween(startTime, END_OF_WORK_DAY).plusMinutes(30);
             }
         });
+
+        createDemoAbsences(user, now);
+    }
+
+    /**
+     * Creates a few demo absences for the given user. The set contains absences that overlap a month boundary
+     * (both into the previous and into the next month) as well as absences fully contained within a single month.
+     * Which of the month-overlapping absences a user gets depends on the user's localId, so that different users
+     * have different absences and the effect of one user's absence on a multi-person report can be observed.
+     */
+    private void createDemoAbsences(TenantUser user, LocalDate now) {
+
+        // make sure the "Urlaub" absence type the HOLIDAY absences refer to exists
+        absenceTypeService.updateAbsenceType(new AbsenceTypeUpdate(
+            DEMO_HOLIDAY_TYPE_SOURCE_ID,
+            AbsenceTypeCategory.HOLIDAY,
+            AbsenceColor.BLUE,
+            Map.of(Locale.GERMAN, "Urlaub", Locale.ENGLISH, "Holiday")
+        ));
+
+        final UserId userId = new UserId(user.id());
+        final long localId = user.localId();
+
+        final LocalDate firstOfThisMonth = now.withDayOfMonth(1);
+        final LocalDate firstOfNextMonth = firstOfThisMonth.plusMonths(1);
+
+        // unique, deterministic sourceIds per user so absences are not deduplicated across users/restarts
+        long sourceId = localId * 1000;
+
+        // 1) month overlap: previous -> current month (only every second user)
+        if (localId % 2 == 0) {
+            addHolidayAbsence(userId, sourceId++, firstOfThisMonth.minusDays(3), firstOfThisMonth.plusDays(2), DayLength.FULL);
+        }
+
+        // 2) month overlap: current -> next month (the other users)
+        if (localId % 2 == 1) {
+            addHolidayAbsence(userId, sourceId++, firstOfNextMonth.minusDays(2), firstOfNextMonth.plusDays(3), DayLength.FULL);
+        }
+
+        // 3) fully within the current month, no overlap
+        addHolidayAbsence(userId, sourceId++, firstOfThisMonth.plusDays(9), firstOfThisMonth.plusDays(11), DayLength.FULL);
+
+        // 4) half-day holiday (morning) within the current month, for some day-length variety
+        addHolidayAbsence(userId, sourceId++, firstOfThisMonth.plusDays(21), firstOfThisMonth.plusDays(21), DayLength.MORNING);
+
+        // 5) sick leave within the current month, for some absence-type variety.
+        // start day and duration vary per user so that the sick leave is spread across the month.
+        final int sickStartOffset = (int) (localId * 7 % 24);    // day 0..23 within the month
+        final int sickDurationDays = (int) (localId % 4);        // 0..3 additional days -> 1..4 days total
+        final LocalDate sickStart = firstOfThisMonth.plusDays(sickStartOffset);
+        addSickAbsence(userId, sourceId, sickStart, sickStart.plusDays(sickDurationDays));
+    }
+
+    private void addHolidayAbsence(UserId userId, long sourceId, LocalDate start, LocalDate endInclusive, DayLength dayLength) {
+        absenceWriteService.addAbsence(new AbsenceWrite(
+            sourceId,
+            userId,
+            toInstant(start),
+            toInstant(endInclusive),
+            dayLength,
+            null,
+            AbsenceTypeCategory.HOLIDAY,
+            new AbsenceTypeSourceId(DEMO_HOLIDAY_TYPE_SOURCE_ID)
+        ));
+    }
+
+    private void addSickAbsence(UserId userId, long sourceId, LocalDate start, LocalDate endInclusive) {
+        absenceWriteService.addAbsence(new AbsenceWrite(
+            sourceId,
+            userId,
+            toInstant(start),
+            toInstant(endInclusive),
+            DayLength.FULL,
+            null,
+            AbsenceTypeCategory.SICK
+        ));
+    }
+
+    private static Instant toInstant(LocalDate date) {
+        return date.atStartOfDay().toInstant(UTC);
     }
 
     private static String getRandomComment() {

--- a/src/main/java/de/focusshift/zeiterfassung/development/DemoDataCreationService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/development/DemoDataCreationService.java
@@ -23,6 +23,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
@@ -114,13 +115,9 @@ class DemoDataCreationService {
      */
     private void createDemoAbsences(TenantUser user, LocalDate now) {
 
-        // make sure the "Urlaub" absence type the HOLIDAY absences refer to exists
-        absenceTypeService.updateAbsenceType(new AbsenceTypeUpdate(
-            DEMO_HOLIDAY_TYPE_SOURCE_ID,
-            AbsenceTypeCategory.HOLIDAY,
-            AbsenceColor.BLUE,
-            Map.of(Locale.GERMAN, "Urlaub", Locale.ENGLISH, "Holiday")
-        ));
+        // make sure the "Urlaub" absence type the HOLIDAY absences refer to exists.
+        // the type is shared by all users, so it is only created once per tenant and then reused.
+        ensureHolidayAbsenceTypeExists();
 
         final UserId userId = new UserId(user.id());
         final long localId = user.localId();
@@ -153,6 +150,20 @@ class DemoDataCreationService {
         final int sickDurationDays = (int) (localId % 4);        // 0..3 additional days -> 1..4 days total
         final LocalDate sickStart = firstOfThisMonth.plusDays(sickStartOffset);
         addSickAbsence(userId, sourceId, sickStart, sickStart.plusDays(sickDurationDays));
+    }
+
+    private void ensureHolidayAbsenceTypeExists() {
+        final boolean exists = !absenceTypeService
+            .findAllByAbsenceTypeSourceIds(List.of(DEMO_HOLIDAY_TYPE_SOURCE_ID))
+            .isEmpty();
+        if (!exists) {
+            absenceTypeService.updateAbsenceType(new AbsenceTypeUpdate(
+                DEMO_HOLIDAY_TYPE_SOURCE_ID,
+                AbsenceTypeCategory.HOLIDAY,
+                AbsenceColor.BLUE,
+                Map.of(Locale.GERMAN, "Urlaub", Locale.ENGLISH, "Holiday")
+            ));
+        }
     }
 
     private void addHolidayAbsence(UserId userId, long sourceId, LocalDate start, LocalDate endInclusive, DayLength dayLength) {

--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImpl.java
@@ -135,8 +135,17 @@ class WorkingTimeCalendarServiceImpl implements WorkingTimeCalendarService {
 
         sortedWorkingTimes.forEach((userIdComposite, workingTimes) -> {
 
+            final List<Absence> userAbsences = absencesByUser.getOrDefault(userIdComposite, List.of());
+
+            // the date-range for which PlannedWorkingHours are calculated must only be expanded by THIS user's
+            // own absences. Otherwise another user's absence (overlapping the requested interval) would add
+            // planned working hours for dates outside the requested interval to this user's calendar, which then
+            // leaks into aggregated ShouldWorkingHours (e.g. adjacent-month days shown in a report).
+            final LocalDate userMinDate = minStartDate(List.of(userAbsences), from);
+            final LocalDate userMaxDateExclusive = maxEndDate(List.of(userAbsences), toExclusive.minusDays(1)).plusDays(1);
+
             final Map<LocalDate, List<Absence>> absencesByDate = new HashMap<>();
-            for (Absence absence : absencesByUser.get(userIdComposite)) {
+            for (Absence absence : userAbsences) {
                 Instant date = absence.startDate();
                 while (!date.isAfter(absence.endDate())) {
                     absencesByDate.computeIfAbsent(LocalDate.ofInstant(date, UTC), unused -> new ArrayList<>()).add(absence);
@@ -144,7 +153,7 @@ class WorkingTimeCalendarServiceImpl implements WorkingTimeCalendarService {
                 }
             }
 
-            final WorkingTimeCalendar workingTimeCalendar = toWorkingTimeCalendar(minDate, maxDateExclusive, workingTimes, absencesByDate, isPublicHoliday);
+            final WorkingTimeCalendar workingTimeCalendar = toWorkingTimeCalendar(userMinDate, userMaxDateExclusive, workingTimes, absencesByDate, isPublicHoliday);
             workingTimeCalenderByUser.put(userIdComposite, workingTimeCalendar);
         });
 

--- a/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImplTest.java
@@ -42,6 +42,7 @@ import static java.util.Collections.min;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -452,6 +453,62 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(2)),
                     LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(1))
                 ), Map.of()));
+        }
+
+        @Test
+        void ensureAbsenceOfOneUserDoesNotAffectPlannedHoursOfAnotherUser() {
+
+            final UserId userIdOne = new UserId("uuid-1");
+            final UserLocalId userLocalIdOne = new UserLocalId(1L);
+            final UserIdComposite userIdCompositeOne = new UserIdComposite(userIdOne, userLocalIdOne);
+
+            final UserId userIdTwo = new UserId("uuid-2");
+            final UserLocalId userLocalIdTwo = new UserLocalId(2L);
+            final UserIdComposite userIdCompositeTwo = new UserIdComposite(userIdTwo, userLocalIdTwo);
+
+            final LocalDate from = LocalDate.of(2023, 2, 13); // monday
+            final LocalDate toExclusive = from.plusWeeks(1);   // 2023-02-20
+
+            // user A has a full-day holiday absence starting BEFORE the requested interval (2023-02-09)
+            // but overlapping into it (2023-02-14)
+            final Absence absenceA = new Absence(userIdOne,
+                LocalDate.of(2023, 2, 9).atStartOfDay().toInstant(UTC),
+                LocalDate.of(2023, 2, 14).atStartOfDay().toInstant(UTC),
+                FULL, foo -> "", RED, HOLIDAY);
+
+            final LocalDate expandedFrom = LocalDate.of(2023, 2, 9);
+
+            // first fetch for the requested interval
+            when(absenceService.getAbsencesByUserIds(any(), eq(from), eq(toExclusive)))
+                .thenReturn(Map.of(userIdCompositeOne, List.of(absenceA), userIdCompositeTwo, List.of()));
+            // second fetch with expanded interval because A's absence overlaps the requested interval start
+            when(absenceService.getAbsencesByUserIds(any(), eq(expandedFrom), eq(toExclusive)))
+                .thenReturn(Map.of(userIdCompositeOne, List.of(absenceA), userIdCompositeTwo, List.of()));
+
+            when(workingTimeService.getWorkingTimesByUsers(expandedFrom, toExclusive, List.of(userLocalIdOne, userLocalIdTwo)))
+                .thenReturn(Map.of(
+                    userIdCompositeOne, List.of(
+                        WorkingTime.builder(userIdCompositeOne, new WorkingTimeId(UUID.randomUUID()))
+                            .federalState(NONE).worksOnPublicHoliday(WorksOnPublicHoliday.NO)
+                            .monday(8).tuesday(8).wednesday(8).thursday(8).friday(8).saturday(8).sunday(8).build()
+                    ),
+                    userIdCompositeTwo, List.of(
+                        WorkingTime.builder(userIdCompositeTwo, new WorkingTimeId(UUID.randomUUID()))
+                            .federalState(NONE).worksOnPublicHoliday(WorksOnPublicHoliday.NO)
+                            .monday(8).tuesday(8).wednesday(8).thursday(8).friday(8).saturday(8).sunday(8).build()
+                    )
+                ));
+
+            final Map<UserIdComposite, WorkingTimeCalendar> actual =
+                sut.getWorkingTimeCalendarForUsers(from, toExclusive, List.of(userLocalIdOne, userLocalIdTwo));
+
+            // User B has NO absence and was requested for the week starting 2023-02-13.
+            // B's calendar must NOT contain planned working hours for dates before the requested 'from'.
+            final WorkingTimeCalendar calendarB = actual.get(userIdCompositeTwo);
+            assertThat(calendarB.plannedWorkingHours(LocalDate.of(2023, 2, 9)))
+                .as("User B's planned hours must not be affected by user A's absence range")
+                .isEmpty();
+            assertThat(calendarB.plannedWorkingHours(LocalDate.of(2023, 2, 12))).isEmpty();
         }
 
         @Test


### PR DESCRIPTION
🐞 Behebt einen Fehler in den Berichten: In der Tabelle unter dem Graph zeigte die Spalte „Geplant" (Soll-Stunden) für eine Person falsche Werte, sobald eine **andere** im selben Bericht ausgewählte Person eine Abwesenheit hatte, die über den angefragten Zeitraum hinausreicht.

**Defektes Verhalten**

`WorkingTimeCalendarServiceImpl#toWorkingTimeCalendar` berechnete die Datumsspanne, über die für **jeden** Benutzer `plannedWorkingHoursByDate` aufgebaut wird, aus den Abwesenheiten **aller** ausgewählten Benutzer gemeinsam. Eine Abwesenheit von Person A, die den Intervallrand überlappt, erweiterte dadurch die Spanne für jeden Benutzer. So erhielt der Kalender von Person B geplante Stunden für Tage außerhalb des angefragten Zeitraums (z. B. Nachbarmonatstage im Monatsraster), die dann in B's aggregierte Soll-Stunden einflossen.

**Fix**

Die Spanne für die geplanten Stunden wird jetzt pro Benutzer nur durch dessen **eigene** Abwesenheiten erweitert. Der Batch-Abruf von Arbeitszeiten und Feiertagen bleibt global (reines Abruffenster).

Ein Regressionstest (`WorkingTimeCalendarServiceImplTest#ensureAbsenceOfOneUserDoesNotAffectPlannedHoursOfAnotherUser`) deckt das Szenario ab.

Closes #2107

---

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`? — n/a, keine neuen Entities
- [ ] New entity added to `TenantAwareDatabaseConfiguration`? — n/a
- [ ] Tested with `dev-multitenant` profile? — n/a, reine Berechnungslogik

🤖 Generated with [Claude Code](https://claude.com/claude-code)
