### PR TITLE
Fix planned hours affected by another user's absence in reports

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImpl.java
+++ b/src/main/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImpl.java
@@ -135,8 +135,17 @@ class WorkingTimeCalendarServiceImpl implements WorkingTimeCalendarService {
 
         sortedWorkingTimes.forEach((userIdComposite, workingTimes) -> {
 
+            final List<Absence> userAbsences = absencesByUser.getOrDefault(userIdComposite, List.of());
+
+            // the date-range for which PlannedWorkingHours are calculated must only be expanded by THIS user's
+            // own absences. Otherwise another user's absence (overlapping the requested interval) would add
+            // planned working hours for dates outside the requested interval to this user's calendar, which then
+            // leaks into aggregated ShouldWorkingHours (e.g. adjacent-month days shown in a report).
+            final LocalDate userMinDate = minStartDate(List.of(userAbsences), from);
+            final LocalDate userMaxDateExclusive = maxEndDate(List.of(userAbsences), toExclusive.minusDays(1)).plusDays(1);
+
             final Map<LocalDate, List<Absence>> absencesByDate = new HashMap<>();
-            for (Absence absence : absencesByUser.get(userIdComposite)) {
+            for (Absence absence : userAbsences) {
                 Instant date = absence.startDate();
                 while (!date.isAfter(absence.endDate())) {
                     absencesByDate.computeIfAbsent(LocalDate.ofInstant(date, UTC), unused -> new ArrayList<>()).add(absence);
@@ -144,7 +153,7 @@ class WorkingTimeCalendarServiceImpl implements WorkingTimeCalendarService {
                 }
             }
 
-            final WorkingTimeCalendar workingTimeCalendar = toWorkingTimeCalendar(minDate, maxDateExclusive, workingTimes, absencesByDate, isPublicHoliday);
+            final WorkingTimeCalendar workingTimeCalendar = toWorkingTimeCalendar(userMinDate, userMaxDateExclusive, workingTimes, absencesByDate, isPublicHoliday);
             workingTimeCalenderByUser.put(userIdComposite, workingTimeCalendar);
         });
 

--- a/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImplTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/workingtime/WorkingTimeCalendarServiceImplTest.java
@@ -42,6 +42,7 @@ import static java.util.Collections.min;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -452,6 +453,62 @@ class WorkingTimeCalendarServiceImplTest {
                     LocalDate.of(2023, 2, 18), new PlannedWorkingHours(Duration.ofHours(2)),
                     LocalDate.of(2023, 2, 19), new PlannedWorkingHours(Duration.ofHours(1))
                 ), Map.of()));
+        }
+
+        @Test
+        void ensureAbsenceOfOneUserDoesNotAffectPlannedHoursOfAnotherUser() {
+
+            final UserId userIdOne = new UserId("uuid-1");
+            final UserLocalId userLocalIdOne = new UserLocalId(1L);
+            final UserIdComposite userIdCompositeOne = new UserIdComposite(userIdOne, userLocalIdOne);
+
+            final UserId userIdTwo = new UserId("uuid-2");
+            final UserLocalId userLocalIdTwo = new UserLocalId(2L);
+            final UserIdComposite userIdCompositeTwo = new UserIdComposite(userIdTwo, userLocalIdTwo);
+
+            final LocalDate from = LocalDate.of(2023, 2, 13); // monday
+            final LocalDate toExclusive = from.plusWeeks(1);   // 2023-02-20
+
+            // user A has a full-day holiday absence starting BEFORE the requested interval (2023-02-09)
+            // but overlapping into it (2023-02-14)
+            final Absence absenceA = new Absence(userIdOne,
+                LocalDate.of(2023, 2, 9).atStartOfDay().toInstant(UTC),
+                LocalDate.of(2023, 2, 14).atStartOfDay().toInstant(UTC),
+                FULL, foo -> "", RED, HOLIDAY);
+
+            final LocalDate expandedFrom = LocalDate.of(2023, 2, 9);
+
+            // first fetch for the requested interval
+            when(absenceService.getAbsencesByUserIds(any(), eq(from), eq(toExclusive)))
+                .thenReturn(Map.of(userIdCompositeOne, List.of(absenceA), userIdCompositeTwo, List.of()));
+            // second fetch with expanded interval because A's absence overlaps the requested interval start
+            when(absenceService.getAbsencesByUserIds(any(), eq(expandedFrom), eq(toExclusive)))
+                .thenReturn(Map.of(userIdCompositeOne, List.of(absenceA), userIdCompositeTwo, List.of()));
+
+            when(workingTimeService.getWorkingTimesByUsers(expandedFrom, toExclusive, List.of(userLocalIdOne, userLocalIdTwo)))
+                .thenReturn(Map.of(
+                    userIdCompositeOne, List.of(
+                        WorkingTime.builder(userIdCompositeOne, new WorkingTimeId(UUID.randomUUID()))
+                            .federalState(NONE).worksOnPublicHoliday(WorksOnPublicHoliday.NO)
+                            .monday(8).tuesday(8).wednesday(8).thursday(8).friday(8).saturday(8).sunday(8).build()
+                    ),
+                    userIdCompositeTwo, List.of(
+                        WorkingTime.builder(userIdCompositeTwo, new WorkingTimeId(UUID.randomUUID()))
+                            .federalState(NONE).worksOnPublicHoliday(WorksOnPublicHoliday.NO)
+                            .monday(8).tuesday(8).wednesday(8).thursday(8).friday(8).saturday(8).sunday(8).build()
+                    )
+                ));
+
+            final Map<UserIdComposite, WorkingTimeCalendar> actual =
+                sut.getWorkingTimeCalendarForUsers(from, toExclusive, List.of(userLocalIdOne, userLocalIdTwo));
+
+            // User B has NO absence and was requested for the week starting 2023-02-13.
+            // B's calendar must NOT contain planned working hours for dates before the requested 'from'.
+            final WorkingTimeCalendar calendarB = actual.get(userIdCompositeTwo);
+            assertThat(calendarB.plannedWorkingHours(LocalDate.of(2023, 2, 9)))
+                .as("User B's planned hours must not be affected by user A's absence range")
+                .isEmpty();
+            assertThat(calendarB.plannedWorkingHours(LocalDate.of(2023, 2, 12))).isEmpty();
         }
 
         @Test


### PR DESCRIPTION
The "Geplant" (ShouldWorkingHours) column in the report table showed wrong values for a person when another selected person had an absence that reached beyond the requested interval.

WorkingTimeCalendarServiceImpl#toWorkingTimeCalendar computed the date-range for building each user's plannedWorkingHoursByDate from the absences of ALL users combined. An absence of user A overlapping the interval boundary thus expanded the range for every user, so user B's calendar gained planned hours for dates outside the requested interval (e.g. adjacent-month days shown in a month report), which then leaked into B's aggregated ShouldWorkingHours.

The planned-hours range is now expanded per user by that user's own absences only. The batch fetch of working times and public holidays stays global.

closes #2111


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
