### PR TITLE
only set html email body when there is html text

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/email/EMailService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/email/EMailService.java
@@ -7,6 +7,8 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
+import static org.springframework.util.StringUtils.hasText;
+
 @Service
 public class EMailService {
 
@@ -33,7 +35,11 @@ public class EMailService {
         message.setTo(to);
         message.setSubject(subject);
         message.setReplyTo(generateMailAddressAndDisplayName(replyTo, replayToDisplayName));
-        message.setText(plainText, htmlText);
+        if (hasText(htmlText)) {
+            message.setText(plainText, htmlText);
+        } else {
+            message.setText(plainText);
+        }
         this.mailSender.send(mimeMessage);
     }
 


### PR DESCRIPTION
Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
