### PR TITLE
Configure explicit HikariCP pool settings

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,16 @@ spring:
     password: zeiterfassung_app_password
     url: jdbc:postgresql://localhost:5432/zeiterfassung
     username: zeiterfassung_app_user
+    hikari:
+      # tenant-aware pool shared by all tenants - size against your postgres max_connections budget
+      maximum-pool-size: 30
+      minimum-idle: 30
+      # fail fast instead of pinning a virtual thread for 30s when the pool is exhausted
+      connection-timeout: 5000
+      # recycle connections below typical postgres/pgbouncer idle timeouts
+      max-lifetime: 1740000
+      keepalive-time: 300000
+      register-mbeans: true
   jpa:
     hibernate:
       ddl-auto: none
@@ -53,6 +63,17 @@ spring:
       enabled: true
   autoconfigure:
     exclude: org.springframework.boot.amqp.autoconfigure.RabbitAutoConfiguration
+
+# admin datasource (created in multi-tenant mode only) - liquibase + tenant/oidc-client management, low traffic
+admin:
+  datasource:
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 5
+      connection-timeout: 5000
+      max-lifetime: 1740000
+      keepalive-time: 300000
+      register-mbeans: true
 
 info:
   app:


### PR DESCRIPTION
Both the tenant-aware and admin datasources previously fell through to HikariCP defaults (maximum-pool-size 10, connection-timeout 30000ms). With virtual threads enabled, the 10-connection pool is the only concurrency limiter and offers no back-pressure, causing "Connection is not available, request timed out after 30000ms" under login load.

Set explicit pool sizes and fail-fast timeouts, and recycle connections below typical postgres/pgbouncer idle timeouts.


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
