### PR TITLE
fix: scale month report overtime bar against month axis max

### DIFF
--- a/src/main/resources/templates/reports/user-report-month.html
+++ b/src/main/resources/templates/reports/user-report-month.html
@@ -239,7 +239,7 @@
                   <th:block
                     th:if="${day.hoursWorked != 0 && day.hoursWorked > day.hoursWorkedShould}"
                     th:with="
-                      heightOvertime=${chartHeight * (day.hoursWorked / week.graphLegendMaxHour)},
+                      heightOvertime=${chartHeight * (day.hoursWorked / monthReport.graphLegendMaxHour)},
                       bottomOvertime=${topHours + heightOvertime}
                     "
                   >


### PR DESCRIPTION
The overtime portion of a day's bar in the month report chart was scaled against the week's axis maximum (week.graphLegendMaxHour) while every other element (gridlines, base bar, should bar) was scaled against the month's maximum (monthReport.graphLegendMaxHour).

Since the month max is derived as the maximum across all weeks, it is always
>= any single week's max. Dividing by the smaller week value inflated the
overtime bar, so e.g. a ~9h bar could visually rise above the 10h gridline.

Use monthReport.graphLegendMaxHour so the overtime bar matches the rest of the chart's scale.


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
