### PR TITLE
feat: resync overtime after changing global federal state settings

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/overtime/OvertimePublisher.java
+++ b/src/main/java/de/focusshift/zeiterfassung/overtime/OvertimePublisher.java
@@ -5,6 +5,10 @@ import de.focusshift.zeiterfassung.absence.AbsenceAddedEvent;
 import de.focusshift.zeiterfassung.absence.AbsenceDeletedEvent;
 import de.focusshift.zeiterfassung.absence.AbsenceUpdatedEvent;
 import de.focusshift.zeiterfassung.overtime.events.UserHasWorkedOvertimeEvent;
+import de.focusshift.zeiterfassung.publicholiday.FederalState;
+import de.focusshift.zeiterfassung.publicholiday.PublicHolidayCalendar;
+import de.focusshift.zeiterfassung.publicholiday.PublicHolidaysService;
+import de.focusshift.zeiterfassung.settings.FederalStateSettingsUpdatedEvent;
 import de.focusshift.zeiterfassung.settings.LockTimeEntriesSettings;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryLockService;
 import de.focusshift.zeiterfassung.timeentry.events.DayLockedEvent;
@@ -20,11 +24,14 @@ import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
 import de.focusshift.zeiterfassung.workduration.WorkDuration;
+import de.focusshift.zeiterfassung.workingtime.WorkingTime;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendarService;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCreatedEvent;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeDeletedEvent;
+import de.focusshift.zeiterfassung.workingtime.WorkingTimeService;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeUpdatedEvent;
+import de.focusshift.zeiterfassung.workingtime.WorksOnPublicHoliday;
 import jakarta.annotation.Nullable;
 import org.slf4j.Logger;
 import org.springframework.context.ApplicationEventPublisher;
@@ -33,8 +40,11 @@ import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -44,11 +54,21 @@ public class OvertimePublisher {
 
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
+    /**
+     * Lower bound for resyncing overtime after a global federal state change. Working time periods with a concrete
+     * {@code validFrom} are bounded by that date; the very first (legacy default) working time has no {@code validFrom}
+     * and would otherwise reach infinitely into the past, so it is floored here. Since only public holidays are
+     * republished this bound can be generous.
+     */
+    private static final LocalDate FEDERAL_STATE_RESYNC_FLOOR = LocalDate.of(2015, 1, 1);
+
     private final OvertimeService overtimeService;
     private final OvertimeAccountService overtimeAccountService;
     private final TimeEntryLockService timeEntryLockService;
     private final UserManagementService userManagementService;
     private final WorkingTimeCalendarService workingTimeCalendarService;
+    private final WorkingTimeService workingTimeService;
+    private final PublicHolidaysService publicHolidaysService;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final Clock clock;
 
@@ -58,6 +78,8 @@ public class OvertimePublisher {
         TimeEntryLockService timeEntryLockService,
         UserManagementService userManagementService,
         WorkingTimeCalendarService workingTimeCalendarService,
+        WorkingTimeService workingTimeService,
+        PublicHolidaysService publicHolidaysService,
         ApplicationEventPublisher applicationEventPublisher,
         Clock clock
     ) {
@@ -67,6 +89,8 @@ public class OvertimePublisher {
         this.timeEntryLockService = timeEntryLockService;
         this.userManagementService = userManagementService;
         this.workingTimeCalendarService = workingTimeCalendarService;
+        this.workingTimeService = workingTimeService;
+        this.publicHolidaysService = publicHolidaysService;
         this.clock = clock;
     }
 
@@ -227,6 +251,106 @@ public class OvertimePublisher {
     public void publishOvertimeUpdated(WorkingTimeDeletedEvent event) {
         // after deletion the preceding working time extends over the deleted range, so its planned working hours change.
         publishOvertimeForWorkingTimeChange(event.userIdComposite(), event.validFrom());
+    }
+
+    /**
+     * Recalculate and publish overtime for the locked days that are affected by a change of the global
+     * {@link de.focusshift.zeiterfassung.settings.FederalStateSettings federal state settings}.
+     *
+     * <p>
+     * Changing the global federal state (or {@code worksOnPublicHoliday}) changes which days are public holidays for
+     * every person whose {@link WorkingTime} inherits the global setting (individual federal state {@code GLOBAL} or
+     * {@code worksOnPublicHoliday} {@code GLOBAL}). Only such persons and only the days that are public holidays under
+     * the old or the new federal state are affected, so we recompute exactly those (already locked) days. Not-yet-locked
+     * days are (re)calculated by the scheduler once they get locked.
+     */
+    @EventListener
+    public void publishOvertimeUpdated(FederalStateSettingsUpdatedEvent event) {
+
+        final Optional<LocalDate> maybeLastLockedDate = getLastLockedDate();
+        if (maybeLastLockedDate.isEmpty()) {
+            LOG.debug("Locking is disabled, no locked overtime to resync for federal state settings change.");
+            return;
+        }
+
+        final LocalDate lastLockedDate = maybeLastLockedDate.get();
+        final LocalDate from = FEDERAL_STATE_RESYNC_FLOOR;
+        if (from.isAfter(lastLockedDate)) {
+            LOG.debug("Federal state settings change does not reach into the locked period (lastLockedDate={}). Nothing to resync.", lastLockedDate);
+            return;
+        }
+
+        final LocalDate toExclusive = lastLockedDate.plusDays(1);
+
+        final Set<LocalDate> affectedHolidays = affectedPublicHolidays(event, from, toExclusive);
+        if (affectedHolidays.isEmpty()) {
+            LOG.info("Federal state settings changed but no public holidays are affected in [{} - {}]. Nothing to resync.", from, lastLockedDate);
+            return;
+        }
+
+        final Map<UserIdComposite, List<WorkingTime>> workingTimesByUser = workingTimeService.getAllWorkingTimes(from, toExclusive);
+        final Map<UserIdComposite, OvertimeAccount> overtimeAccountByUser = overtimeAccountService.getAllOvertimeAccounts();
+        final LockTimeEntriesSettings lockSettings = timeEntryLockService.getLockTimeEntriesSettings();
+
+        LOG.info("Federal state settings changed. Resync overtime for {} affected public holiday(s) in [{} - {}].", affectedHolidays.size(), from, lastLockedDate);
+
+        workingTimesByUser.forEach((userIdComposite, workingTimes) -> {
+
+            final OvertimeAccount overtimeAccount = overtimeAccountByUser.get(userIdComposite);
+            if (overtimeAccount == null || !overtimeAccount.isAllowed()) {
+                LOG.debug("Skip federal state resync for user={} because overtime is not allowed.", userIdComposite);
+                return;
+            }
+
+            for (WorkingTime workingTime : workingTimes) {
+                if (!inheritsGlobalFederalStateSettings(workingTime)) {
+                    // this working time has its own federal state / worksOnPublicHoliday - not affected by the global change
+                    continue;
+                }
+
+                final LocalDate effStart = maxDate(workingTime.validFrom().orElse(from), from);
+                final LocalDate effEnd = minDate(workingTime.validTo().orElse(lastLockedDate), lastLockedDate);
+                if (effStart.isAfter(effEnd)) {
+                    continue;
+                }
+
+                for (LocalDate date : affectedHolidays) {
+                    final boolean withinPeriod = !date.isBefore(effStart) && !date.isAfter(effEnd);
+                    if (withinPeriod && timeEntryLockService.isLocked(date, lockSettings)) {
+                        publishUpdated(userIdComposite, date);
+                    }
+                }
+            }
+        });
+    }
+
+    private Set<LocalDate> affectedPublicHolidays(FederalStateSettingsUpdatedEvent event, LocalDate from, LocalDate toExclusive) {
+
+        final Set<FederalState> federalStates = new HashSet<>();
+        federalStates.add(event.oldFederalState());
+        federalStates.add(event.newFederalState());
+
+        final Map<FederalState, PublicHolidayCalendar> calendars =
+            publicHolidaysService.getPublicHolidays(from, toExclusive, federalStates);
+
+        final Set<LocalDate> dates = new HashSet<>();
+        for (PublicHolidayCalendar calendar : calendars.values()) {
+            dates.addAll(calendar.publicHolidays().keySet());
+        }
+        return dates;
+    }
+
+    private static boolean inheritsGlobalFederalStateSettings(WorkingTime workingTime) {
+        return FederalState.GLOBAL.equals(workingTime.individualFederalState())
+            || WorksOnPublicHoliday.GLOBAL.equals(workingTime.individualWorksOnPublicHoliday());
+    }
+
+    private static LocalDate maxDate(LocalDate a, LocalDate b) {
+        return a.isAfter(b) ? a : b;
+    }
+
+    private static LocalDate minDate(LocalDate a, LocalDate b) {
+        return a.isBefore(b) ? a : b;
     }
 
     /**

--- a/src/main/java/de/focusshift/zeiterfassung/settings/FederalStateSettingsUpdatedEvent.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/FederalStateSettingsUpdatedEvent.java
@@ -1,0 +1,25 @@
+package de.focusshift.zeiterfassung.settings;
+
+import de.focusshift.zeiterfassung.publicholiday.FederalState;
+
+/**
+ * Published when the global {@link FederalStateSettings} have been changed.
+ *
+ * <p>
+ * Changing the global federal state or the {@code worksOnPublicHoliday} flag alters the public holidays (and therefore
+ * the planned working hours) of every person whose {@link de.focusshift.zeiterfassung.workingtime.WorkingTime} inherits
+ * the global setting. The old and new values are carried so consumers can determine exactly which public holidays are
+ * affected (old ∪ new federal state).
+ *
+ * @param oldFederalState federal state before the update
+ * @param oldWorksOnPublicHoliday whether persons worked on public holidays before the update
+ * @param newFederalState federal state after the update
+ * @param newWorksOnPublicHoliday whether persons work on public holidays after the update
+ */
+public record FederalStateSettingsUpdatedEvent(
+    FederalState oldFederalState,
+    boolean oldWorksOnPublicHoliday,
+    FederalState newFederalState,
+    boolean newWorksOnPublicHoliday
+) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/SettingsService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/SettingsService.java
@@ -67,11 +67,31 @@ class SettingsService implements FederalStateSettingsService, LockTimeEntriesSet
      */
     FederalStateSettings updateFederalStateSettings(FederalState federalState, boolean worksOnPublicHoliday) {
 
-        final FederalStateSettingsEntity entity = getFederalStateEntity().orElseGet(FederalStateSettingsEntity::new);
+        final Optional<FederalStateSettingsEntity> maybeEntity = getFederalStateEntity();
+
+        final FederalState previousFederalState = maybeEntity
+            .map(FederalStateSettingsEntity::getFederalState)
+            .orElse(FederalStateSettings.DEFAULT.federalState());
+        final boolean previousWorksOnPublicHoliday = maybeEntity
+            .map(FederalStateSettingsEntity::isWorksOnPublicHoliday)
+            .orElse(FederalStateSettings.DEFAULT.worksOnPublicHoliday());
+
+        final FederalStateSettingsEntity entity = maybeEntity.orElseGet(FederalStateSettingsEntity::new);
         entity.setFederalState(federalState);
         entity.setWorksOnPublicHoliday(worksOnPublicHoliday);
 
         final FederalStateSettingsEntity saved = federalStateSettingsRepository.save(entity);
+
+        final boolean changed = previousFederalState != saved.getFederalState()
+            || previousWorksOnPublicHoliday != saved.isWorksOnPublicHoliday();
+
+        if (changed) {
+            LOG.info("FederalStateSettings changed (federalState {} -> {}, worksOnPublicHoliday {} -> {}). Publishing FederalStateSettingsUpdatedEvent to resync overtime.",
+                previousFederalState, saved.getFederalState(), previousWorksOnPublicHoliday, saved.isWorksOnPublicHoliday());
+            applicationEventPublisher.publishEvent(new FederalStateSettingsUpdatedEvent(
+                previousFederalState, previousWorksOnPublicHoliday, saved.getFederalState(), saved.isWorksOnPublicHoliday()
+            ));
+        }
 
         return toFederalStateSettings(saved);
     }

--- a/src/test/java/de/focusshift/zeiterfassung/overtime/OvertimePublisherTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/overtime/OvertimePublisherTest.java
@@ -6,6 +6,10 @@ import de.focusshift.zeiterfassung.absence.AbsenceDeletedEvent;
 import de.focusshift.zeiterfassung.absence.AbsenceUpdatedEvent;
 import de.focusshift.zeiterfassung.overtime.events.UserHasWorkedOvertimeEvent;
 import de.focusshift.zeiterfassung.publicholiday.FederalState;
+import de.focusshift.zeiterfassung.publicholiday.PublicHoliday;
+import de.focusshift.zeiterfassung.publicholiday.PublicHolidayCalendar;
+import de.focusshift.zeiterfassung.publicholiday.PublicHolidaysService;
+import de.focusshift.zeiterfassung.settings.FederalStateSettingsUpdatedEvent;
 import de.focusshift.zeiterfassung.settings.LockTimeEntriesSettings;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryId;
@@ -24,12 +28,15 @@ import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
 import de.focusshift.zeiterfassung.workduration.WorkDuration;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
+import de.focusshift.zeiterfassung.workingtime.WorkingTime;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendarService;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCreatedEvent;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeDeletedEvent;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeId;
+import de.focusshift.zeiterfassung.workingtime.WorkingTimeService;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeUpdatedEvent;
+import de.focusshift.zeiterfassung.workingtime.WorksOnPublicHoliday;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -48,6 +55,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,6 +65,7 @@ import java.util.stream.IntStream;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -79,6 +88,10 @@ class OvertimePublisherTest {
     @Mock
     private WorkingTimeCalendarService workingTimeCalendarService;
     @Mock
+    private WorkingTimeService workingTimeService;
+    @Mock
+    private PublicHolidaysService publicHolidaysService;
+    @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
     private final Clock clock = Clock.fixed(Instant.parse("2025-01-20T00:00:00Z"), ZoneId.of("Europe/Berlin"));
@@ -91,6 +104,8 @@ class OvertimePublisherTest {
             timeEntryLockService,
             userManagementService,
             workingTimeCalendarService,
+            workingTimeService,
+            publicHolidaysService,
             applicationEventPublisher,
             clock);
     }
@@ -1411,6 +1426,218 @@ class OvertimePublisherTest {
                 new UserHasWorkedOvertimeEvent(userIdComposite, date3, OvertimeHours.EIGHT_POSITIVE)
             );
         }
+    }
+
+    @Nested
+    class FederalStateSettingsUpdated {
+
+        @Test
+        void ensureOvertimeResyncedForGlobalWorkingTimeOnAffectedLockedHolidays() {
+
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+            final LocalDate holiday1 = LocalDate.parse("2025-01-01");
+            final LocalDate holiday2 = LocalDate.parse("2025-01-06");
+
+            when(timeEntryLockService.getMinValidTimeEntryDate(clock.getZone()))
+                .thenReturn(Optional.of(LocalDate.parse("2025-01-10"))); // lastLockedDate = 2025-01-09
+
+            when(publicHolidaysService.getPublicHolidays(any(), any(), any()))
+                .thenReturn(Map.of(FederalState.GERMANY_BADEN_WUERTTEMBERG,
+                    publicHolidayCalendar(FederalState.GERMANY_BADEN_WUERTTEMBERG, holiday1, holiday2)));
+
+            when(workingTimeService.getAllWorkingTimes(any(), any())).thenReturn(Map.of(
+                userIdComposite, List.of(globalWorkingTime(userIdComposite, null, null))
+            ));
+            when(overtimeAccountService.getAllOvertimeAccounts()).thenReturn(Map.of(
+                userIdComposite, new OvertimeAccount(userIdComposite, true)
+            ));
+
+            final LockTimeEntriesSettings lockSettings = anyLockTimeEntriesSettings();
+            when(timeEntryLockService.getLockTimeEntriesSettings()).thenReturn(lockSettings);
+            when(timeEntryLockService.isLocked(holiday1, lockSettings)).thenReturn(true);
+            when(timeEntryLockService.isLocked(holiday2, lockSettings)).thenReturn(true);
+
+            when(overtimeService.getOvertimeForDateAndUser(holiday1, userIdComposite.localId())).thenReturn(OvertimeHours.EIGHT_POSITIVE);
+            when(overtimeService.getOvertimeForDateAndUser(holiday2, userIdComposite.localId())).thenReturn(OvertimeHours.EIGHT_POSITIVE);
+
+            sut.publishOvertimeUpdated(new FederalStateSettingsUpdatedEvent(
+                FederalState.NONE, false, FederalState.GERMANY_BADEN_WUERTTEMBERG, false));
+
+            final ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            verify(applicationEventPublisher, times(2)).publishEvent(captor.capture());
+            assertThat(captor.getAllValues()).containsExactlyInAnyOrder(
+                new UserHasWorkedOvertimeEvent(userIdComposite, holiday1, OvertimeHours.EIGHT_POSITIVE),
+                new UserHasWorkedOvertimeEvent(userIdComposite, holiday2, OvertimeHours.EIGHT_POSITIVE)
+            );
+        }
+
+        @Test
+        void ensureNothingPublishedForUserWithLocalFederalState() {
+
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+            final LocalDate holiday = LocalDate.parse("2025-01-01");
+
+            when(timeEntryLockService.getMinValidTimeEntryDate(clock.getZone()))
+                .thenReturn(Optional.of(LocalDate.parse("2025-01-10")));
+
+            when(publicHolidaysService.getPublicHolidays(any(), any(), any()))
+                .thenReturn(Map.of(FederalState.GERMANY_BADEN_WUERTTEMBERG,
+                    publicHolidayCalendar(FederalState.GERMANY_BADEN_WUERTTEMBERG, holiday)));
+
+            // working time has its own concrete federal state and worksOnPublicHoliday -> not affected by global change
+            when(workingTimeService.getAllWorkingTimes(any(), any())).thenReturn(Map.of(
+                userIdComposite, List.of(workingTime(userIdComposite, FederalState.GERMANY_BADEN_WUERTTEMBERG, WorksOnPublicHoliday.NO, null, null))
+            ));
+            when(overtimeAccountService.getAllOvertimeAccounts()).thenReturn(Map.of(
+                userIdComposite, new OvertimeAccount(userIdComposite, true)
+            ));
+
+            sut.publishOvertimeUpdated(new FederalStateSettingsUpdatedEvent(
+                FederalState.NONE, false, FederalState.GERMANY_BADEN_WUERTTEMBERG, false));
+
+            verifyNoInteractions(applicationEventPublisher);
+        }
+
+        @Test
+        void ensureOnlyHolidaysWithinValidFromArePublished() {
+
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+            final LocalDate holidayBefore = LocalDate.parse("2024-12-25");
+            final LocalDate holidayAfter = LocalDate.parse("2025-01-01");
+
+            when(timeEntryLockService.getMinValidTimeEntryDate(clock.getZone()))
+                .thenReturn(Optional.of(LocalDate.parse("2025-01-10")));
+
+            when(publicHolidaysService.getPublicHolidays(any(), any(), any()))
+                .thenReturn(Map.of(FederalState.GERMANY_BADEN_WUERTTEMBERG,
+                    publicHolidayCalendar(FederalState.GERMANY_BADEN_WUERTTEMBERG, holidayBefore, holidayAfter)));
+
+            // working time valid only from 2025-01-01 -> 2024-12-25 must be ignored
+            when(workingTimeService.getAllWorkingTimes(any(), any())).thenReturn(Map.of(
+                userIdComposite, List.of(globalWorkingTime(userIdComposite, LocalDate.parse("2025-01-01"), null))
+            ));
+            when(overtimeAccountService.getAllOvertimeAccounts()).thenReturn(Map.of(
+                userIdComposite, new OvertimeAccount(userIdComposite, true)
+            ));
+
+            final LockTimeEntriesSettings lockSettings = anyLockTimeEntriesSettings();
+            when(timeEntryLockService.getLockTimeEntriesSettings()).thenReturn(lockSettings);
+            when(timeEntryLockService.isLocked(holidayAfter, lockSettings)).thenReturn(true);
+
+            when(overtimeService.getOvertimeForDateAndUser(holidayAfter, userIdComposite.localId())).thenReturn(OvertimeHours.EIGHT_POSITIVE);
+
+            sut.publishOvertimeUpdated(new FederalStateSettingsUpdatedEvent(
+                FederalState.NONE, false, FederalState.GERMANY_BADEN_WUERTTEMBERG, false));
+
+            verify(applicationEventPublisher, times(1)).publishEvent(
+                new UserHasWorkedOvertimeEvent(userIdComposite, holidayAfter, OvertimeHours.EIGHT_POSITIVE));
+        }
+
+        @Test
+        void ensureUnlockedAffectedHolidayIsNotPublished() {
+
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+            final LocalDate holiday = LocalDate.parse("2025-01-01");
+
+            when(timeEntryLockService.getMinValidTimeEntryDate(clock.getZone()))
+                .thenReturn(Optional.of(LocalDate.parse("2025-01-10")));
+
+            when(publicHolidaysService.getPublicHolidays(any(), any(), any()))
+                .thenReturn(Map.of(FederalState.GERMANY_BADEN_WUERTTEMBERG,
+                    publicHolidayCalendar(FederalState.GERMANY_BADEN_WUERTTEMBERG, holiday)));
+
+            when(workingTimeService.getAllWorkingTimes(any(), any())).thenReturn(Map.of(
+                userIdComposite, List.of(globalWorkingTime(userIdComposite, null, null))
+            ));
+            when(overtimeAccountService.getAllOvertimeAccounts()).thenReturn(Map.of(
+                userIdComposite, new OvertimeAccount(userIdComposite, true)
+            ));
+
+            final LockTimeEntriesSettings lockSettings = anyLockTimeEntriesSettings();
+            when(timeEntryLockService.getLockTimeEntriesSettings()).thenReturn(lockSettings);
+            when(timeEntryLockService.isLocked(holiday, lockSettings)).thenReturn(false);
+
+            sut.publishOvertimeUpdated(new FederalStateSettingsUpdatedEvent(
+                FederalState.NONE, false, FederalState.GERMANY_BADEN_WUERTTEMBERG, false));
+
+            verifyNoInteractions(applicationEventPublisher);
+        }
+
+        @Test
+        void ensureNothingPublishedWhenOvertimeNotAllowed() {
+
+            final UserIdComposite userIdComposite = anyUserIdComposite();
+            final LocalDate holiday = LocalDate.parse("2025-01-01");
+
+            when(timeEntryLockService.getMinValidTimeEntryDate(clock.getZone()))
+                .thenReturn(Optional.of(LocalDate.parse("2025-01-10")));
+
+            when(publicHolidaysService.getPublicHolidays(any(), any(), any()))
+                .thenReturn(Map.of(FederalState.GERMANY_BADEN_WUERTTEMBERG,
+                    publicHolidayCalendar(FederalState.GERMANY_BADEN_WUERTTEMBERG, holiday)));
+
+            when(workingTimeService.getAllWorkingTimes(any(), any())).thenReturn(Map.of(
+                userIdComposite, List.of(globalWorkingTime(userIdComposite, null, null))
+            ));
+            when(overtimeAccountService.getAllOvertimeAccounts()).thenReturn(Map.of(
+                userIdComposite, new OvertimeAccount(userIdComposite, false)
+            ));
+
+            sut.publishOvertimeUpdated(new FederalStateSettingsUpdatedEvent(
+                FederalState.NONE, false, FederalState.GERMANY_BADEN_WUERTTEMBERG, false));
+
+            verifyNoInteractions(applicationEventPublisher);
+        }
+
+        @Test
+        void ensureNothingPublishedWhenLockingIsDisabled() {
+
+            when(timeEntryLockService.getMinValidTimeEntryDate(clock.getZone())).thenReturn(Optional.empty());
+
+            sut.publishOvertimeUpdated(new FederalStateSettingsUpdatedEvent(
+                FederalState.NONE, false, FederalState.GERMANY_BADEN_WUERTTEMBERG, false));
+
+            verifyNoInteractions(applicationEventPublisher);
+            verifyNoInteractions(publicHolidaysService);
+            verifyNoInteractions(workingTimeService);
+        }
+
+        @Test
+        void ensureNothingPublishedWhenNoPublicHolidaysAffected() {
+
+            when(timeEntryLockService.getMinValidTimeEntryDate(clock.getZone()))
+                .thenReturn(Optional.of(LocalDate.parse("2025-01-10")));
+
+            when(publicHolidaysService.getPublicHolidays(any(), any(), any())).thenReturn(Map.of());
+
+            sut.publishOvertimeUpdated(new FederalStateSettingsUpdatedEvent(
+                FederalState.NONE, false, FederalState.NONE, true));
+
+            verifyNoInteractions(applicationEventPublisher);
+            verifyNoInteractions(workingTimeService);
+        }
+    }
+
+    private static WorkingTime globalWorkingTime(UserIdComposite userIdComposite, LocalDate validFrom, LocalDate validTo) {
+        return workingTime(userIdComposite, FederalState.GLOBAL, WorksOnPublicHoliday.GLOBAL, validFrom, validTo);
+    }
+
+    private static WorkingTime workingTime(UserIdComposite userIdComposite, FederalState federalState,
+                                           WorksOnPublicHoliday worksOnPublicHoliday, LocalDate validFrom, LocalDate validTo) {
+        return WorkingTime.builder(userIdComposite, anyWorkingTimeId())
+            .federalState(federalState)
+            .worksOnPublicHoliday(worksOnPublicHoliday)
+            .validFrom(validFrom)
+            .validTo(validTo)
+            .build();
+    }
+
+    private static PublicHolidayCalendar publicHolidayCalendar(FederalState federalState, LocalDate... dates) {
+        final Map<LocalDate, List<PublicHoliday>> publicHolidays = new HashMap<>();
+        for (LocalDate date : dates) {
+            publicHolidays.put(date, List.of());
+        }
+        return new PublicHolidayCalendar(federalState, publicHolidays);
     }
 
     private static WorkingTimeId anyWorkingTimeId() {

--- a/src/test/java/de/focusshift/zeiterfassung/settings/SettingsServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/settings/SettingsServiceTest.java
@@ -1,5 +1,6 @@
 package de.focusshift.zeiterfassung.settings;
 
+import de.focusshift.zeiterfassung.publicholiday.FederalState;
 import de.focusshift.zeiterfassung.timeentry.events.DayLockedEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -47,6 +48,70 @@ class SettingsServiceTest {
             subtractBreakFromTimeEntrySettingsRepository,
             applicationEventPublisher
         );
+    }
+
+    @Nested
+    class FederalStateSettingsTest {
+
+        @Test
+        void ensureUpdatePublishesEventWhenFederalStateChanges() {
+
+            final FederalStateSettingsEntity entity = new FederalStateSettingsEntity();
+            entity.setFederalState(FederalState.NONE);
+            entity.setWorksOnPublicHoliday(false);
+
+            when(federalStateSettingsRepository.findAll()).thenReturn(List.of(entity));
+            when(federalStateSettingsRepository.save(any())).thenAnswer(returnsFirstArg());
+
+            sut.updateFederalStateSettings(FederalState.GERMANY_BADEN_WUERTTEMBERG, true);
+
+            verify(applicationEventPublisher).publishEvent(new FederalStateSettingsUpdatedEvent(
+                FederalState.NONE, false, FederalState.GERMANY_BADEN_WUERTTEMBERG, true));
+        }
+
+        @Test
+        void ensureUpdatePublishesEventWhenOnlyWorksOnPublicHolidayChanges() {
+
+            final FederalStateSettingsEntity entity = new FederalStateSettingsEntity();
+            entity.setFederalState(FederalState.GERMANY_BADEN_WUERTTEMBERG);
+            entity.setWorksOnPublicHoliday(false);
+
+            when(federalStateSettingsRepository.findAll()).thenReturn(List.of(entity));
+            when(federalStateSettingsRepository.save(any())).thenAnswer(returnsFirstArg());
+
+            sut.updateFederalStateSettings(FederalState.GERMANY_BADEN_WUERTTEMBERG, true);
+
+            verify(applicationEventPublisher).publishEvent(new FederalStateSettingsUpdatedEvent(
+                FederalState.GERMANY_BADEN_WUERTTEMBERG, false, FederalState.GERMANY_BADEN_WUERTTEMBERG, true));
+        }
+
+        @Test
+        void ensureUpdatePublishesEventWhenNothingWasPersistedYet() {
+
+            when(federalStateSettingsRepository.findAll()).thenReturn(List.of());
+            when(federalStateSettingsRepository.save(any())).thenAnswer(returnsFirstArg());
+
+            sut.updateFederalStateSettings(FederalState.GERMANY_BADEN_WUERTTEMBERG, false);
+
+            // previous values fall back to FederalStateSettings.DEFAULT (NONE, false)
+            verify(applicationEventPublisher).publishEvent(new FederalStateSettingsUpdatedEvent(
+                FederalState.NONE, false, FederalState.GERMANY_BADEN_WUERTTEMBERG, false));
+        }
+
+        @Test
+        void ensureUpdateDoesNotPublishEventWhenNothingChanged() {
+
+            final FederalStateSettingsEntity entity = new FederalStateSettingsEntity();
+            entity.setFederalState(FederalState.GERMANY_BADEN_WUERTTEMBERG);
+            entity.setWorksOnPublicHoliday(true);
+
+            when(federalStateSettingsRepository.findAll()).thenReturn(List.of(entity));
+            when(federalStateSettingsRepository.save(any())).thenAnswer(returnsFirstArg());
+
+            sut.updateFederalStateSettings(FederalState.GERMANY_BADEN_WUERTTEMBERG, true);
+
+            verifyNoInteractions(applicationEventPublisher);
+        }
     }
 
     @Nested


### PR DESCRIPTION
Changing the global federal state / worksOnPublicHoliday setting changes which days are public holidays and therefore the planned working hours and overtime of everyone whose working time inherits the global setting. Until now updateFederalStateSettings only persisted the change without publishing an event, so overtime for already locked days was neither recalculated nor synchronized (RabbitMQ).

Publish a FederalStateSettingsUpdatedEvent (only on an actual change) and let OvertimePublisher resync overtime for the affected locked days:
- only users whose working time inherits the global setting (federalState or worksOnPublicHoliday GLOBAL)
- only days that are public holidays under the old or new federal state
- only already locked days, bounded per working time period by validFrom (the open-ended default working time is floored at a generous year)


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
