### PR TITLE
Fix: continue processing remaining tenants when one tenant fails

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/importer/TenantImporterComponent.java
+++ b/src/main/java/de/focusshift/zeiterfassung/importer/TenantImporterComponent.java
@@ -101,7 +101,13 @@ class TenantImporterComponent {
                         return;
                     }
                     LOG.info("tenantId={} has no users, starting import {} users!", passedTenantId, importerData.users().size());
-                    importerData.users().forEach(userToImport -> importUser(userToImport, new TenantId(passedTenantId)));
+                    importerData.users().forEach(userToImport -> {
+                        try {
+                            importUser(userToImport, new TenantId(passedTenantId));
+                        } catch (Exception exception) {
+                            LOG.error("Unexpected error while importing user={} of tenantId={}. Continuing with remaining users.", userToImport.user().externalId(), passedTenantId, exception);
+                        }
+                    });
                     LOG.info("finished importing {} users of tenantId={}", importerData.users().size(), passedTenantId);
                 } catch (Exception e) {
                     LOG.error("Error occurred while importing users", e);

--- a/src/main/java/de/focusshift/zeiterfassung/overtime/OvertimePublisher.java
+++ b/src/main/java/de/focusshift/zeiterfassung/overtime/OvertimePublisher.java
@@ -69,13 +69,17 @@ public class OvertimePublisher {
         final Map<UserIdComposite, OvertimeAccount> overtimeAccountByUserId = overtimeAccountService.getAllOvertimeAccounts();
 
         overtimeService.getOvertimeForDate(event.date()).forEach((userIdComposite, overtimeHours) -> {
-            // currently we just know whether overtime is allowed or not.
-            // this may change in the future to have a date range for this info or more granular stuff.
-            final OvertimeAccount overtimeAccount = overtimeAccountByUserId.get(userIdComposite);
-            if (overtimeAccount.isAllowed()) {
-                publishUpdated(userIdComposite, event.date(), overtimeHours);
-            } else {
-                LOG.info("Overtime not allowed, ignore DayLockedEvent for User {}", userIdComposite);
+            try {
+                // currently we just know whether overtime is allowed or not.
+                // this may change in the future to have a date range for this info or more granular stuff.
+                final OvertimeAccount overtimeAccount = overtimeAccountByUserId.get(userIdComposite);
+                if (overtimeAccount.isAllowed()) {
+                    publishUpdated(userIdComposite, event.date(), overtimeHours);
+                } else {
+                    LOG.info("Overtime not allowed, ignore DayLockedEvent for User {}", userIdComposite);
+                }
+            } catch (Exception exception) {
+                LOG.error("Unexpected error while publishing overtime for user={} and date={}. Continuing with remaining users.", userIdComposite, event.date(), exception);
             }
         });
     }

--- a/src/main/java/de/focusshift/zeiterfassung/settings/SettingsService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/SettingsService.java
@@ -143,7 +143,13 @@ class SettingsService implements FederalStateSettingsService, LockTimeEntriesSet
         final LocalDate actualLockTimeEntryDate = today.minusDays(actualLockTimeEntriesDaysInPast).minusDays(1);
 
         iterate(oldLockTimeEntryDate, date -> !date.isAfter(actualLockTimeEntryDate), date -> date.plusDays(1))
-            .forEach(lockedDate -> applicationEventPublisher.publishEvent(new DayLockedEvent(lockedDate, zoneId)));
+            .forEach(lockedDate -> {
+                try {
+                    applicationEventPublisher.publishEvent(new DayLockedEvent(lockedDate, zoneId));
+                } catch (Exception exception) {
+                    LOG.error("Unexpected error while publishing DayLockedEvent for lockedDate={}. Continuing with remaining dates.", lockedDate, exception);
+                }
+            });
     }
 
     private Optional<LockTimeEntriesSettingsEntity> getLockTimeEntriesSettingsEntity() {

--- a/src/main/java/de/focusshift/zeiterfassung/tenancy/registration/property/TenantRegistryFromOAuthPropertiesImporterService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/tenancy/registration/property/TenantRegistryFromOAuthPropertiesImporterService.java
@@ -49,8 +49,12 @@ class TenantRegistryFromOAuthPropertiesImporterService {
             .values()
             .forEach(registration -> {
                 final String tenantId = registration.getProvider();
-                final String clientSecret = registration.getClientSecret();
-                tenantRegistrationService.registerNewTenant(new TenantRegistration(tenantId, clientSecret));
+                try {
+                    final String clientSecret = registration.getClientSecret();
+                    tenantRegistrationService.registerNewTenant(new TenantRegistration(tenantId, clientSecret));
+                } catch (Exception exception) {
+                    LOG.error("Unexpected error while importing tenantId={} from oAuth2ClientProperties. Continuing with remaining registrations.", tenantId, exception);
+                }
             });
         LOG.info("imported tenants from oAuth2ClientProperties to database!");
     }

--- a/src/main/java/de/focusshift/zeiterfassung/tenancy/tenant/TenantContextRunner.java
+++ b/src/main/java/de/focusshift/zeiterfassung/tenancy/tenant/TenantContextRunner.java
@@ -1,11 +1,16 @@
 package de.focusshift.zeiterfassung.tenancy.tenant;
 
+import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
 import java.util.stream.Stream;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 @Component
 public class TenantContextRunner {
+
+    private static final Logger LOG = getLogger(TenantContextRunner.class);
 
     private final TenantContextHolder tenantContextHolder;
     private final TenantService tenantService;
@@ -26,7 +31,13 @@ public class TenantContextRunner {
      * @return a runnable
      */
     public Runnable runForEachActiveTenant(Runnable function) {
-        return () -> getAllActiveTenants().forEach(tenant -> tenantContextHolder.runInTenantIdContext(new TenantId(tenant.tenantId()), function));
+        return () -> getAllActiveTenants().forEach(tenant -> {
+            try {
+                tenantContextHolder.runInTenantIdContext(new TenantId(tenant.tenantId()), function);
+            } catch (Exception exception) {
+                LOG.error("Unexpected error while running function for tenant={}. Continuing with remaining tenants.", tenant.tenantId(), exception);
+            }
+        });
     }
 
     private Stream<Tenant> getAllActiveTenants() {

--- a/src/test/java/de/focusshift/zeiterfassung/importer/TenantImporterComponentTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/importer/TenantImporterComponentTest.java
@@ -56,6 +56,7 @@ import static java.time.DayOfWeek.WEDNESDAY;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anySet;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -84,8 +85,12 @@ class TenantImporterComponentTest {
     private ImportInputProvider importInputProvider;
 
     private static TenantExport exportedData() {
-        UserExport userExport = new UserExport(
-            new UserDTO("externalId", "marlene", "muster", "my.name@example.org", Instant.now().minus(365, ChronoUnit.DAYS), Set.of(SecurityRole.ZEITERFASSUNG_USER.name())),
+        return new TenantExport("tenantId", Instant.now(), List.of(userExport("externalId", "marlene", "muster")));
+    }
+
+    private static UserExport userExport(String externalId, String givenName, String familyName) {
+        return new UserExport(
+            new UserDTO(externalId, givenName, familyName, "my.name@example.org", Instant.now().minus(365, ChronoUnit.DAYS), Set.of(SecurityRole.ZEITERFASSUNG_USER.name())),
             new OvertimeAccountDTO(true, Duration.ofHours(8)),
             new WorkingTimeDTO(
                 new WorkDayDTO("MONDAY", Duration.ofHours(8)),
@@ -103,7 +108,6 @@ class TenantImporterComponentTest {
                 new TimeEntryDTO("lala", ZonedDateTime.parse("2024-06-01T06:00:00.123Z"), ZonedDateTime.parse("2024-06-01T10:00:00.123Z"), false)
             )
         );
-        return new TenantExport("tenantId", Instant.now(), List.of(userExport));
     }
 
     @Test
@@ -161,6 +165,36 @@ class TenantImporterComponentTest {
             userLocalId, "lala", ZonedDateTime.parse("2024-06-01T08:00:00.123+02:00[Europe/Berlin]"), ZonedDateTime.parse("2024-06-01T12:00:00.123+02:00[Europe/Berlin]"), false
         );
 
+    }
+
+    @Test
+    void whenImportOfOneUserFailsRemainingUsersAreStillImported() {
+
+        final UserExport userOne = userExport("one", "marlene", "muster");
+        final UserExport userTwo = userExport("two", "erika", "musterfrau");
+        final TenantExport tenantExport = new TenantExport("tenantId", Instant.now(), List.of(userOne, userTwo));
+
+        when(importInputProvider.fromExport()).thenReturn(Optional.of(tenantExport));
+        Instant firstLoginAt = Instant.now().minus(365, ChronoUnit.DAYS);
+        when(tenantService.getTenantByTenantId(anyString())).thenReturn(Optional.of(new Tenant("tenantId", firstLoginAt, firstLoginAt, TenantStatus.ACTIVE)));
+        when(tenantUserService.findAllUsers()).thenReturn(List.of());
+
+        final UserLocalId userTwoLocalId = new UserLocalId(2L);
+
+        when(tenantUserService.createNewUser(eq("one"), anyString(), anyString(), any(EMailAddress.class), anySet()))
+            .thenThrow(new IllegalStateException("boom"));
+        when(tenantUserService.createNewUser(eq("two"), anyString(), anyString(), any(EMailAddress.class), anySet()))
+            .thenReturn(new TenantUser("two", userTwoLocalId.value(), "erika", "musterfrau", new EMailAddress("my.name@example.org"), firstLoginAt, Set.of(SecurityRole.ZEITERFASSUNG_USER), firstLoginAt, firstLoginAt, null, null, UserStatus.ACTIVE));
+
+        sut.runImport();
+
+        verify(tenantUserService).createNewUser(eq("one"), anyString(), anyString(), any(EMailAddress.class), anySet());
+        verify(tenantUserService).createNewUser(eq("two"), anyString(), anyString(), any(EMailAddress.class), anySet());
+
+        verify(overtimeAccountService).updateOvertimeAccount(userTwoLocalId, true, Duration.ofHours(8));
+        verify(workingTimeService).createWorkingTime(eq(userTwoLocalId), eq(null), eq(FederalState.GLOBAL), eq(null), any());
+        verify(timeClockService).importTimeClock(any(TimeClock.class));
+        verify(timeEntryService).createTimeEntry(eq(userTwoLocalId), anyString(), any(), any(), eq(false));
     }
 
     @Test

--- a/src/test/java/de/focusshift/zeiterfassung/overtime/OvertimePublisherTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/overtime/OvertimePublisherTest.java
@@ -148,6 +148,29 @@ class OvertimePublisherTest {
 
             verifyNoInteractions(applicationEventPublisher);
         }
+
+        @Test
+        void ensureExceptionForOneUserDoesNotAbortRemainingUsers() {
+
+            final UserIdComposite userOne = anyUserIdComposite();
+            final UserIdComposite userTwo = new UserIdComposite(new UserId("user-id-2"), new UserLocalId(2L));
+
+            // userOne has no OvertimeAccount configured -> overtimeAccount.isAllowed() throws a NullPointerException
+            when(overtimeAccountService.getAllOvertimeAccounts()).thenReturn(Map.of(
+                userTwo, new OvertimeAccount(userTwo, true)
+            ));
+
+            final LocalDate date = LocalDate.parse("2026-03-06");
+            when(overtimeService.getOvertimeForDate(date)).thenReturn(Map.of(
+                userOne, OvertimeHours.EIGHT_POSITIVE,
+                userTwo, OvertimeHours.EIGHT_POSITIVE
+            ));
+
+            sut.publishOvertime(new DayLockedEvent(date, ZoneId.of("Europe/Berlin")));
+
+            verify(applicationEventPublisher).publishEvent(new UserHasWorkedOvertimeEvent(userTwo, date, OvertimeHours.EIGHT_POSITIVE));
+            verifyNoMoreInteractions(applicationEventPublisher);
+        }
     }
 
     @Nested

--- a/src/test/java/de/focusshift/zeiterfassung/settings/SettingsServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/settings/SettingsServiceTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -188,6 +189,30 @@ class SettingsServiceTest {
             final LocalDate today = LocalDate.now(clock.withZone(zoneId));
 
             verify(applicationEventPublisher).publishEvent(new DayLockedEvent(today.minusDays(11), zoneId));
+        }
+
+        @Test
+        void ensureExceptionForOneDayLockedEventDoesNotAbortRemainingDates() {
+
+            final LockTimeEntriesSettingsEntity entity = new LockTimeEntriesSettingsEntity();
+            entity.setId(1L);
+            entity.setLockingIsActive(true);
+            entity.setLockTimeEntriesDaysInPast(2);
+
+            when(lockTimeEntriesSettingsRepository.findAll()).thenReturn(List.of(entity));
+            when(lockTimeEntriesSettingsRepository.save(any(LockTimeEntriesSettingsEntity.class))).thenAnswer(returnsFirstArg());
+
+            final ZoneId zoneId = ZoneId.of("Europe/Berlin");
+            final LocalDate today = LocalDate.now(clock.withZone(zoneId));
+
+            doThrow(new IllegalStateException("boom"))
+                .when(applicationEventPublisher).publishEvent(new DayLockedEvent(today.minusDays(2), zoneId));
+
+            sut.updateLockTimeEntriesSettings(true, 0);
+
+            verify(applicationEventPublisher).publishEvent(new DayLockedEvent(today.minusDays(3), zoneId));
+            verify(applicationEventPublisher).publishEvent(new DayLockedEvent(today.minusDays(2), zoneId));
+            verify(applicationEventPublisher).publishEvent(new DayLockedEvent(today.minusDays(1), zoneId));
         }
 
         @Test

--- a/src/test/java/de/focusshift/zeiterfassung/tenancy/registration/property/TenantRegistryFromOAuthPropertiesImporterServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/tenancy/registration/property/TenantRegistryFromOAuthPropertiesImporterServiceTest.java
@@ -1,0 +1,75 @@
+package de.focusshift.zeiterfassung.tenancy.registration.property;
+
+import de.focusshift.zeiterfassung.tenancy.registration.TenantRegistration;
+import de.focusshift.zeiterfassung.tenancy.registration.TenantRegistrationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TenantRegistryFromOAuthPropertiesImporterServiceTest {
+
+    private TenantRegistryFromOAuthPropertiesImporterService sut;
+
+    @Mock
+    private OAuth2ClientProperties oAuth2ClientProperties;
+
+    @Mock
+    private TenantRegistrationService tenantRegistrationService;
+
+    @BeforeEach
+    void setUp() {
+        sut = new TenantRegistryFromOAuthPropertiesImporterService(oAuth2ClientProperties, tenantRegistrationService);
+    }
+
+    @Test
+    void ensureRegistersEveryTenantFromProperties() {
+
+        final Map<String, OAuth2ClientProperties.Registration> registrations = new LinkedHashMap<>();
+        registrations.put("one", registration("one", "secret-one"));
+        registrations.put("two", registration("two", "secret-two"));
+
+        when(oAuth2ClientProperties.getRegistration()).thenReturn(registrations);
+
+        sut.importOIDCClientsFromProperties();
+
+        verify(tenantRegistrationService).registerNewTenant(new TenantRegistration("one", "secret-one"));
+        verify(tenantRegistrationService).registerNewTenant(new TenantRegistration("two", "secret-two"));
+    }
+
+    @Test
+    void ensureExceptionForOneRegistrationDoesNotAbortRemainingRegistrations() {
+
+        final Map<String, OAuth2ClientProperties.Registration> registrations = new LinkedHashMap<>();
+        registrations.put("one", registration("one", "secret-one"));
+        registrations.put("two", registration("two", "secret-two"));
+
+        when(oAuth2ClientProperties.getRegistration()).thenReturn(registrations);
+
+        doThrow(new IllegalStateException("boom"))
+            .when(tenantRegistrationService).registerNewTenant(eq(new TenantRegistration("one", "secret-one")));
+
+        sut.importOIDCClientsFromProperties();
+
+        verify(tenantRegistrationService).registerNewTenant(new TenantRegistration("one", "secret-one"));
+        verify(tenantRegistrationService).registerNewTenant(new TenantRegistration("two", "secret-two"));
+    }
+
+    private static OAuth2ClientProperties.Registration registration(String provider, String clientSecret) {
+        final OAuth2ClientProperties.Registration registration = new OAuth2ClientProperties.Registration();
+        registration.setProvider(provider);
+        registration.setClientSecret(clientSecret);
+        return registration;
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/tenancy/registration/property/TenantRegistryFromOAuthPropertiesImporterServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/tenancy/registration/property/TenantRegistryFromOAuthPropertiesImporterServiceTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2Clien
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -58,7 +57,7 @@ class TenantRegistryFromOAuthPropertiesImporterServiceTest {
         when(oAuth2ClientProperties.getRegistration()).thenReturn(registrations);
 
         doThrow(new IllegalStateException("boom"))
-            .when(tenantRegistrationService).registerNewTenant(eq(new TenantRegistration("one", "secret-one")));
+            .when(tenantRegistrationService).registerNewTenant(new TenantRegistration("one", "secret-one"));
 
         sut.importOIDCClientsFromProperties();
 

--- a/src/test/java/de/focusshift/zeiterfassung/tenancy/tenant/TenantContextRunnerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/tenancy/tenant/TenantContextRunnerTest.java
@@ -44,8 +44,8 @@ class TenantContextRunnerTest {
         final Runnable function = () -> {};
         sut.runForEachActiveTenant(function).run();
 
-        verify(tenantContextHolder).runInTenantIdContext(eq(new TenantId("one")), eq(function));
-        verify(tenantContextHolder).runInTenantIdContext(eq(new TenantId("two")), eq(function));
+        verify(tenantContextHolder).runInTenantIdContext(new TenantId("one"), function);
+        verify(tenantContextHolder).runInTenantIdContext(new TenantId("two"), function);
         verify(tenantContextHolder, times(0)).runInTenantIdContext(eq(new TenantId("three")), any(Runnable.class));
     }
 
@@ -60,12 +60,12 @@ class TenantContextRunnerTest {
         final Runnable function = () -> {};
 
         doThrow(new IllegalStateException("boom"))
-            .when(tenantContextHolder).runInTenantIdContext(eq(new TenantId("one")), eq(function));
+            .when(tenantContextHolder).runInTenantIdContext(new TenantId("one"), function);
 
         sut.runForEachActiveTenant(function).run();
 
-        verify(tenantContextHolder).runInTenantIdContext(eq(new TenantId("one")), eq(function));
-        verify(tenantContextHolder).runInTenantIdContext(eq(new TenantId("two")), eq(function));
+        verify(tenantContextHolder).runInTenantIdContext(new TenantId("one"), function);
+        verify(tenantContextHolder).runInTenantIdContext(new TenantId("two"), function);
     }
 
     private static Tenant tenant(String tenantId, TenantStatus status) {

--- a/src/test/java/de/focusshift/zeiterfassung/tenancy/tenant/TenantContextRunnerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/tenancy/tenant/TenantContextRunnerTest.java
@@ -1,0 +1,74 @@
+package de.focusshift.zeiterfassung.tenancy.tenant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TenantContextRunnerTest {
+
+    private TenantContextRunner sut;
+
+    @Mock
+    private TenantContextHolder tenantContextHolder;
+
+    @Mock
+    private TenantService tenantService;
+
+    @BeforeEach
+    void setUp() {
+        sut = new TenantContextRunner(tenantContextHolder, tenantService);
+    }
+
+    @Test
+    void ensureRunsFunctionForEveryActiveTenant() {
+
+        final Tenant tenantOne = tenant("one", TenantStatus.ACTIVE);
+        final Tenant tenantTwo = tenant("two", TenantStatus.ACTIVE);
+        final Tenant tenantThree = tenant("three", TenantStatus.DISABLED);
+
+        when(tenantService.findAllTenants()).thenReturn(List.of(tenantOne, tenantTwo, tenantThree));
+
+        final Runnable function = () -> {};
+        sut.runForEachActiveTenant(function).run();
+
+        verify(tenantContextHolder).runInTenantIdContext(eq(new TenantId("one")), eq(function));
+        verify(tenantContextHolder).runInTenantIdContext(eq(new TenantId("two")), eq(function));
+        verify(tenantContextHolder, times(0)).runInTenantIdContext(eq(new TenantId("three")), any(Runnable.class));
+    }
+
+    @Test
+    void ensureExceptionForOneTenantDoesNotAbortRemainingTenants() {
+
+        final Tenant tenantOne = tenant("one", TenantStatus.ACTIVE);
+        final Tenant tenantTwo = tenant("two", TenantStatus.ACTIVE);
+
+        when(tenantService.findAllTenants()).thenReturn(List.of(tenantOne, tenantTwo));
+
+        final Runnable function = () -> {};
+
+        doThrow(new IllegalStateException("boom"))
+            .when(tenantContextHolder).runInTenantIdContext(eq(new TenantId("one")), eq(function));
+
+        sut.runForEachActiveTenant(function).run();
+
+        verify(tenantContextHolder).runInTenantIdContext(eq(new TenantId("one")), eq(function));
+        verify(tenantContextHolder).runInTenantIdContext(eq(new TenantId("two")), eq(function));
+    }
+
+    private static Tenant tenant(String tenantId, TenantStatus status) {
+        return new Tenant(tenantId, Instant.now(), Instant.now(), status);
+    }
+}


### PR DESCRIPTION
TenantContextRunner#runForEachActiveTenant let an exception thrown for one tenant abort the whole forEach loop, silently skipping all tenants processed after it. Catch and log per-tenant exceptions so the remaining tenants are still processed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

closes #2160


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
