### PR TITLE
add republishing of DayLockedEvents for a date range

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishEventHandlerRabbitmq.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishEventHandlerRabbitmq.java
@@ -1,0 +1,31 @@
+package de.focusshift.zeiterfassung.timeentry.republish;
+
+import org.slf4j.Logger;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.util.StringUtils;
+
+import static de.focusshift.zeiterfassung.timeentry.republish.DayLockedRepublishRabbitmqConfiguration.ZEITERFASSUNG_DAY_LOCKED_REPUBLISH_QUEUE;
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.slf4j.LoggerFactory.getLogger;
+
+class DayLockedRepublishEventHandlerRabbitmq {
+
+    private static final Logger LOG = getLogger(lookup().lookupClass());
+
+    private final DayLockedRepublishService dayLockedRepublishService;
+
+    DayLockedRepublishEventHandlerRabbitmq(DayLockedRepublishService dayLockedRepublishService) {
+        this.dayLockedRepublishService = dayLockedRepublishService;
+    }
+
+    @RabbitListener(queues = {ZEITERFASSUNG_DAY_LOCKED_REPUBLISH_QUEUE})
+    void on(DayLockedRepublishRequest event) {
+        if (StringUtils.hasText(event.tenantId())) {
+            LOG.info("Received DayLockedRepublishRequest tenantId={} from={} to={}", event.tenantId(), event.from(), event.to());
+            dayLockedRepublishService.republishDayLockedEvents(event.tenantId(), event.from(), event.to());
+        } else {
+            LOG.info("Received DayLockedRepublishRequest from={} to={}", event.from(), event.to());
+            dayLockedRepublishService.republishDayLockedEvents(event.from(), event.to());
+        }
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishRabbitmqConfiguration.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishRabbitmqConfiguration.java
@@ -1,0 +1,58 @@
+package de.focusshift.zeiterfassung.timeentry.republish;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static de.focusshift.zeiterfassung.tenancy.TenantConfigurationProperties.MULTI;
+
+@Configuration
+@ConditionalOnProperty(value = "zeiterfassung.tenant.mode", havingValue = MULTI)
+@EnableConfigurationProperties(DayLockedRepublishRabbitmqConfigurationProperties.class)
+class DayLockedRepublishRabbitmqConfiguration {
+
+    static final String ZEITERFASSUNG_DAY_LOCKED_REPUBLISH_QUEUE = "zeiterfassung.queue.day-locked-republish";
+
+    @Configuration
+    @ConditionalOnProperty(value = "zeiterfassung.integration.day-locked-republish.enabled", havingValue = "true")
+    static class DayLockedRepublishListenerConfiguration {
+
+        @Bean
+        DayLockedRepublishEventHandlerRabbitmq dayLockedRepublishEventHandlerRabbitmq(DayLockedRepublishService dayLockedRepublishService) {
+            return new DayLockedRepublishEventHandlerRabbitmq(dayLockedRepublishService);
+        }
+    }
+
+    @Configuration
+    @ConditionalOnProperty(value = "zeiterfassung.integration.day-locked-republish.manage-topology", havingValue = "true")
+    static class ManageTopologyConfiguration {
+
+        private final DayLockedRepublishRabbitmqConfigurationProperties properties;
+
+        ManageTopologyConfiguration(DayLockedRepublishRabbitmqConfigurationProperties properties) {
+            this.properties = properties;
+        }
+
+        @Bean
+        TopicExchange dayLockedRepublishTopic() {
+            return new TopicExchange(properties.topic());
+        }
+
+        @Bean
+        Queue dayLockedRepublishQueue() {
+            return new Queue(ZEITERFASSUNG_DAY_LOCKED_REPUBLISH_QUEUE, true);
+        }
+
+        @Bean
+        Binding bindDayLockedRepublishQueue() {
+            return BindingBuilder.bind(dayLockedRepublishQueue())
+                .to(dayLockedRepublishTopic())
+                .with(properties.routingKey());
+        }
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishRabbitmqConfigurationProperties.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishRabbitmqConfigurationProperties.java
@@ -1,0 +1,16 @@
+package de.focusshift.zeiterfassung.timeentry.republish;
+
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties("zeiterfassung.integration.day-locked-republish")
+record DayLockedRepublishRabbitmqConfigurationProperties(
+    @DefaultValue("false") boolean enabled,
+    @DefaultValue("false") boolean manageTopology,
+    @DefaultValue("zeiterfassung.topic") @NotEmpty String topic,
+    @DefaultValue("ZE.EVENT.DAYLOCKED.REPUBLISH") @NotEmpty String routingKey
+) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishRequest.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishRequest.java
@@ -1,0 +1,22 @@
+package de.focusshift.zeiterfassung.timeentry.republish;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.jspecify.annotations.Nullable;
+
+import java.time.LocalDate;
+
+/**
+ * RabbitMQ payload that triggers republishing of
+ * {@link de.focusshift.zeiterfassung.timeentry.events.DayLockedEvent} for the given inclusive date range.
+ *
+ * @param tenantId optional tenant to republish for; when {@code null} or blank the events are republished for all active tenants
+ * @param from     first day to republish (inclusive)
+ * @param to       last day to republish (inclusive)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+record DayLockedRepublishRequest(
+    @Nullable String tenantId,
+    LocalDate from,
+    LocalDate to
+) {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishService.java
@@ -1,0 +1,27 @@
+package de.focusshift.zeiterfassung.timeentry.republish;
+
+import de.focusshift.zeiterfassung.timeentry.events.DayLockedEvent;
+
+import java.time.LocalDate;
+
+interface DayLockedRepublishService {
+
+    /**
+     * Republishes {@link DayLockedEvent} for every active tenant, for each day in the
+     * inclusive range {@code [from, to]}.
+     *
+     * @param from first day to republish (inclusive)
+     * @param to   last day to republish (inclusive)
+     */
+    void republishDayLockedEvents(LocalDate from, LocalDate to);
+
+    /**
+     * Republishes {@link DayLockedEvent} for the given tenant only, for each day in the
+     * inclusive range {@code [from, to]}.
+     *
+     * @param tenantId tenant to republish for
+     * @param from     first day to republish (inclusive)
+     * @param to       last day to republish (inclusive)
+     */
+    void republishDayLockedEvents(String tenantId, LocalDate from, LocalDate to);
+}

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishServiceMultiTenant.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishServiceMultiTenant.java
@@ -1,0 +1,100 @@
+package de.focusshift.zeiterfassung.timeentry.republish;
+
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextRunner;
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantId;
+import de.focusshift.zeiterfassung.timeentry.events.DayLockedEvent;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static de.focusshift.zeiterfassung.tenancy.TenantConfigurationProperties.MULTI;
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.slf4j.LoggerFactory.getLogger;
+
+@Service
+@ConditionalOnProperty(value = "zeiterfassung.tenant.mode", havingValue = MULTI)
+class DayLockedRepublishServiceMultiTenant implements DayLockedRepublishService {
+
+    private static final Logger LOG = getLogger(lookup().lookupClass());
+
+    // using Europe/Berlin because this is also the hard coded value in UserSettingProvider currently
+    // and our application is used in germany. (same as DayLockedSchedulerServiceMultiTenant)
+    private static final ZoneId ZONE_ID = ZoneId.of("Europe/Berlin");
+
+    private final TenantContextRunner tenantContextRunner;
+    private final TenantContextHolder tenantContextHolder;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    DayLockedRepublishServiceMultiTenant(
+        TenantContextRunner tenantContextRunner,
+        TenantContextHolder tenantContextHolder,
+        ApplicationEventPublisher applicationEventPublisher
+    ) {
+        this.tenantContextRunner = tenantContextRunner;
+        this.tenantContextHolder = tenantContextHolder;
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    @Override
+    public void republishDayLockedEvents(LocalDate from, LocalDate to) {
+
+        if (invalidRange(from, to)) {
+            return;
+        }
+
+        LOG.info("Republishing DayLockedEvents for all active tenants from={} to={}", from, to);
+        tenantContextRunner.runForEachActiveTenant(() -> republishForCurrentTenant(from, to)).run();
+    }
+
+    @Override
+    public void republishDayLockedEvents(String tenantId, LocalDate from, LocalDate to) {
+
+        if (invalidRange(from, to)) {
+            return;
+        }
+
+        final TenantId tenant = new TenantId(tenantId);
+        if (!tenant.valid()) {
+            LOG.info("Ignoring republish request - 'tenantId' must be valid. tenantId={}", tenantId);
+            return;
+        }
+
+        LOG.info("Republishing DayLockedEvents for tenantId={} from={} to={}", tenantId, from, to);
+        try {
+            tenantContextHolder.runInTenantIdContext(tenant, () -> republishForCurrentTenant(from, to));
+        } catch (Exception exception) {
+            LOG.error("Unexpected error while republishing DayLockedEvents for tenantId={}.", tenantId, exception);
+        }
+    }
+
+    private boolean invalidRange(LocalDate from, LocalDate to) {
+        if (from == null || to == null) {
+            LOG.info("Ignoring republish request - 'from' and 'to' must both be present. from={} to={}", from, to);
+            return true;
+        }
+        if (from.isAfter(to)) {
+            LOG.info("Ignoring republish request - 'from' must not be after 'to'. from={} to={}", from, to);
+            return true;
+        }
+        return false;
+    }
+
+    private void republishForCurrentTenant(LocalDate from, LocalDate to) {
+        // 'to' is inclusive, therefore iterate until the day after
+        from.datesUntil(to.plusDays(1)).forEach(day -> {
+            DayLockedEvent event = of(day);
+            LOG.debug("Republishing DayLockedEvent for date={} zoneId={}", event.date(), event.zoneId());
+            applicationEventPublisher.publishEvent(event);
+        });
+    }
+
+    private static @NonNull DayLockedEvent of(LocalDate day) {
+        return new DayLockedEvent(day, ZONE_ID);
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishEventHandlerRabbitmqTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishEventHandlerRabbitmqTest.java
@@ -1,0 +1,63 @@
+package de.focusshift.zeiterfassung.timeentry.republish;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static java.time.Month.JULY;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class DayLockedRepublishEventHandlerRabbitmqTest {
+
+    private DayLockedRepublishEventHandlerRabbitmq sut;
+
+    @Mock
+    private DayLockedRepublishService dayLockedRepublishService;
+
+    @BeforeEach
+    void setUp() {
+        sut = new DayLockedRepublishEventHandlerRabbitmq(dayLockedRepublishService);
+    }
+
+    @Test
+    void ensureDelegatesRequestWithoutTenantIdToAllActiveTenants() {
+
+        final LocalDate from = LocalDate.of(2026, JULY, 1);
+        final LocalDate to = LocalDate.of(2026, JULY, 3);
+
+        sut.on(new DayLockedRepublishRequest(null, from, to));
+
+        verify(dayLockedRepublishService).republishDayLockedEvents(from, to);
+        verifyNoMoreInteractions(dayLockedRepublishService);
+    }
+
+    @Test
+    void ensureDelegatesRequestWithTenantIdToGivenTenant() {
+
+        final LocalDate from = LocalDate.of(2026, JULY, 1);
+        final LocalDate to = LocalDate.of(2026, JULY, 3);
+
+        sut.on(new DayLockedRepublishRequest("tenant-1", from, to));
+
+        verify(dayLockedRepublishService).republishDayLockedEvents("tenant-1", from, to);
+        verifyNoMoreInteractions(dayLockedRepublishService);
+    }
+
+    @Test
+    void ensureDelegatesRequestWithBlankTenantIdToAllActiveTenants() {
+
+        final LocalDate from = LocalDate.of(2026, JULY, 1);
+        final LocalDate to = LocalDate.of(2026, JULY, 3);
+
+        sut.on(new DayLockedRepublishRequest(" ", from, to));
+
+        verify(dayLockedRepublishService).republishDayLockedEvents(from, to);
+        verifyNoMoreInteractions(dayLockedRepublishService);
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishServiceMultiTenantTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/republish/DayLockedRepublishServiceMultiTenantTest.java
@@ -1,0 +1,139 @@
+package de.focusshift.zeiterfassung.timeentry.republish;
+
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextHolder;
+import de.focusshift.zeiterfassung.tenancy.tenant.TenantContextRunner;
+import de.focusshift.zeiterfassung.timeentry.events.DayLockedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static java.time.Month.JULY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DayLockedRepublishServiceMultiTenantTest {
+
+    private DayLockedRepublishServiceMultiTenant sut;
+
+    @Mock
+    private TenantContextRunner tenantContextRunner;
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    private TenantContextHolder tenantContextHolder;
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @BeforeEach
+    void setUp() {
+        sut = new DayLockedRepublishServiceMultiTenant(tenantContextRunner, tenantContextHolder, applicationEventPublisher);
+    }
+
+    private void runnableExecutesForSingleTenant() {
+        // run the given runnable once, simulating a single active tenant
+        when(tenantContextRunner.runForEachActiveTenant(any())).thenAnswer(invocation -> (Runnable) invocation.getArgument(0));
+    }
+
+    @Test
+    void ensurePublishesDayLockedEventForEachDayInInclusiveRange() {
+
+        runnableExecutesForSingleTenant();
+
+        sut.republishDayLockedEvents(LocalDate.of(2026, JULY, 1), LocalDate.of(2026, JULY, 3));
+
+        final ArgumentCaptor<DayLockedEvent> captor = ArgumentCaptor.forClass(DayLockedEvent.class);
+        verify(applicationEventPublisher, times(3)).publishEvent(captor.capture());
+
+        assertThat(captor.getAllValues())
+            .extracting(DayLockedEvent::date)
+            .containsExactly(
+                LocalDate.of(2026, JULY, 1),
+                LocalDate.of(2026, JULY, 2),
+                LocalDate.of(2026, JULY, 3)
+            );
+
+        assertThat(captor.getAllValues())
+            .extracting(DayLockedEvent::zoneId)
+            .containsOnly(ZoneId.of("Europe/Berlin"));
+    }
+
+    @Test
+    void ensurePublishesSingleEventWhenFromEqualsTo() {
+
+        runnableExecutesForSingleTenant();
+
+        sut.republishDayLockedEvents(LocalDate.of(2026, JULY, 1), LocalDate.of(2026, JULY, 1));
+
+        verify(applicationEventPublisher, times(1)).publishEvent(any(DayLockedEvent.class));
+    }
+
+    @Test
+    void ensureIgnoresRequestWithNullFrom() {
+
+        sut.republishDayLockedEvents(null, LocalDate.of(2026, JULY, 3));
+
+        verifyNoInteractions(tenantContextRunner, applicationEventPublisher);
+    }
+
+    @Test
+    void ensureIgnoresRequestWithNullTo() {
+
+        sut.republishDayLockedEvents(LocalDate.of(2026, JULY, 1), null);
+
+        verifyNoInteractions(tenantContextRunner, applicationEventPublisher);
+    }
+
+    @Test
+    void ensureIgnoresRequestWhenFromIsAfterTo() {
+
+        sut.republishDayLockedEvents(LocalDate.of(2026, JULY, 3), LocalDate.of(2026, JULY, 1));
+
+        verifyNoInteractions(tenantContextRunner, applicationEventPublisher);
+    }
+
+    @Test
+    void ensurePublishesForGivenTenantOnlyWithoutIteratingActiveTenants() {
+
+        sut.republishDayLockedEvents("tenant-1", LocalDate.of(2026, JULY, 1), LocalDate.of(2026, JULY, 3));
+
+        final ArgumentCaptor<DayLockedEvent> captor = ArgumentCaptor.forClass(DayLockedEvent.class);
+        verify(applicationEventPublisher, times(3)).publishEvent(captor.capture());
+
+        assertThat(captor.getAllValues())
+            .extracting(DayLockedEvent::date)
+            .containsExactly(
+                LocalDate.of(2026, JULY, 1),
+                LocalDate.of(2026, JULY, 2),
+                LocalDate.of(2026, JULY, 3)
+            );
+
+        verifyNoInteractions(tenantContextRunner);
+    }
+
+    @Test
+    void ensureIgnoresSingleTenantRequestWithInvalidTenantId() {
+
+        sut.republishDayLockedEvents(" ", LocalDate.of(2026, JULY, 1), LocalDate.of(2026, JULY, 3));
+
+        verifyNoInteractions(tenantContextRunner, tenantContextHolder, applicationEventPublisher);
+    }
+
+    @Test
+    void ensureIgnoresSingleTenantRequestWhenFromIsAfterTo() {
+
+        sut.republishDayLockedEvents("tenant-1", LocalDate.of(2026, JULY, 3), LocalDate.of(2026, JULY, 1));
+
+        verifyNoInteractions(tenantContextRunner, tenantContextHolder, applicationEventPublisher);
+    }
+}


### PR DESCRIPTION
Adds a multi-tenant-only capability to republish DayLockedEvent for every active tenant across an inclusive from/to date range.


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
