### PR TITLE
Add CSV export dropdown with aggregated export option to Berichte page

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportCsvController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportCsvController.java
@@ -42,7 +42,7 @@ class ReportCsvController {
         this.messageSource = messageSource;
     }
 
-    @GetMapping(value = "/report/year/{year}/week/{week}", params = {"csv"})
+    @GetMapping(value = "/report/year/{year}/week/{week}", params = {"csv=detailed"})
     public void weeklyUserReportCsv(
         @PathVariable("year") Integer year,
         @PathVariable("week") Integer week,
@@ -66,7 +66,31 @@ class ReportCsvController {
         writeCsv(fileName, response, csvWriteConsumer);
     }
 
-    @GetMapping(value = "/report/year/{year}/month/{month}", params = {"csv"})
+    @GetMapping(value = "/report/year/{year}/week/{week}", params = {"csv=aggregated"})
+    public void weeklyUserReportCsvAggregated(
+        @PathVariable("year") Integer year,
+        @PathVariable("week") Integer week,
+        @RequestParam(value = "user", required = false, defaultValue = "") List<Long> userIdsParam,
+        @CurrentUser CurrentOidcUser currentUser,
+        Locale locale,
+        HttpServletResponse response
+    ) {
+
+        final YearWeek reportYearWeek = getYearWeek(year, week)
+            .orElseThrow(() -> new ResponseStatusException(BAD_REQUEST, "Invalid week."));
+
+        final UserLocalId userLocalId = currentUser.getUserIdComposite().localId();
+        final List<UserLocalId> userLocalIds = userIdsParam.stream().map(UserLocalId::new).toList();
+        final String fileName = messageSource.getMessage("report.weekly.csv.filename.aggregated", new Object[]{year, week}, locale);
+
+        final Consumer<PrintWriter> csvWriteConsumer = userLocalIds.isEmpty()
+            ? writer -> reportCsvService.writeWeekReportCsvAggregated(Year.of(reportYearWeek.getYear()), reportYearWeek.getWeek(), locale, userLocalId, writer)
+            : writer -> reportCsvService.writeWeekReportCsvAggregatedForUserLocalIds(Year.of(reportYearWeek.getYear()), reportYearWeek.getWeek(), locale, userLocalIds, writer);
+
+        writeCsv(fileName, response, csvWriteConsumer);
+    }
+
+    @GetMapping(value = "/report/year/{year}/month/{month}", params = {"csv=detailed"})
     public void monthlyUserReportCsv(
         @PathVariable("year") Integer year,
         @PathVariable("month") Integer month,
@@ -86,6 +110,30 @@ class ReportCsvController {
         final Consumer<PrintWriter> csvWriteConsumer = userIds.isEmpty()
             ? writer -> reportCsvService.writeMonthReportCsv(yearMonth, locale, userId, writer)
             : writer -> reportCsvService.writeMonthReportCsvForUserLocalIds(yearMonth, locale, userIds, writer);
+
+        writeCsv(fileName, response, csvWriteConsumer);
+    }
+
+    @GetMapping(value = "/report/year/{year}/month/{month}", params = {"csv=aggregated"})
+    public void monthlyUserReportCsvAggregated(
+        @PathVariable("year") Integer year,
+        @PathVariable("month") Integer month,
+        @RequestParam(value = "user", required = false, defaultValue = "") List<Long> userIdsParam,
+        @CurrentUser CurrentOidcUser currentUser,
+        Locale locale,
+        HttpServletResponse response
+    ) {
+
+        final YearMonth yearMonth = yearMonth(year, month)
+            .orElseThrow(() -> new ResponseStatusException(BAD_REQUEST, "Invalid month."));
+
+        final UserId userId = currentUser.getUserIdComposite().id();
+        final List<UserLocalId> userIds = userIdsParam.stream().map(UserLocalId::new).toList();
+        final String fileName = messageSource.getMessage("report.monthly.csv.filename.aggregated", new Object[]{year, month}, locale);
+
+        final Consumer<PrintWriter> csvWriteConsumer = userIds.isEmpty()
+            ? writer -> reportCsvService.writeMonthReportCsvAggregated(yearMonth, locale, userId, writer)
+            : writer -> reportCsvService.writeMonthReportCsvAggregatedForUserLocalIds(yearMonth, locale, userIds, writer);
 
         writeCsv(fileName, response, csvWriteConsumer);
     }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportCsvService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportCsvService.java
@@ -1,8 +1,13 @@
 package de.focusshift.zeiterfassung.report;
 
+import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
 import de.focusshift.zeiterfassung.user.DateFormatter;
 import de.focusshift.zeiterfassung.user.UserId;
+import de.focusshift.zeiterfassung.user.UserIdComposite;
+import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
+import de.focusshift.zeiterfassung.workduration.WorkDuration;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Service;
 
@@ -12,8 +17,12 @@ import java.time.LocalTime;
 import java.time.Month;
 import java.time.Year;
 import java.time.YearMonth;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 class ReportCsvService {
@@ -22,12 +31,18 @@ class ReportCsvService {
     private final ReportService reportService;
     private final DateFormatter dateFormatter;
     private final MessageSource messageSource;
+    private final UserManagementService userManagementService;
 
-    ReportCsvService(ReportService reportService, DateFormatter dateFormatter, MessageSource messageSource) {
+    ReportCsvService(ReportService reportService, DateFormatter dateFormatter, MessageSource messageSource, UserManagementService userManagementService) {
         this.reportService = reportService;
         this.dateFormatter = dateFormatter;
         this.messageSource = messageSource;
+        this.userManagementService = userManagementService;
     }
+
+    // ------------------------------------------------------------
+    // detailed CSV (one row per time entry)
+    // ------------------------------------------------------------
 
     void writeWeekReportCsv(Year year, int week, Locale locale, UserLocalId userLocalId, PrintWriter writer) {
         writeWeekReportCsvForUserLocalIds(year, week, locale, List.of(userLocalId), writer);
@@ -49,12 +64,12 @@ class ReportCsvService {
     }
 
     private void writeWeekCsv(ReportWeek reportWeek, Locale locale, PrintWriter writer) {
-        writeHeader(locale, writer);
+        writeDetailHeader(locale, writer);
         writeWeek(reportWeek, locale, writer);
     }
 
     private void writeMonthCsv(ReportMonth reportMonth, YearMonth yearMonth, Locale locale, PrintWriter writer) {
-        writeHeader(locale, writer);
+        writeDetailHeader(locale, writer);
         reportMonth.weeks()
             .stream()
             .map(reportWeek -> reportWeekForMonthOnly(reportWeek, yearMonth.getMonth()))
@@ -70,43 +85,167 @@ class ReportCsvService {
         return new ReportWeek(reportWeek.firstDateOfWeek(), reportDays);
     }
 
-    private void writeHeader(Locale locale, PrintWriter writer) {
-        final String date = messageSource.getMessage("report.csv.header.date", new Object[]{}, locale);
-        final String givenName = messageSource.getMessage("report.csv.header.person.givenName", new Object[]{}, locale);
-        final String familyName = messageSource.getMessage("report.csv.header.person.familyName", new Object[]{}, locale);
-        final String start = messageSource.getMessage("report.csv.header.start", new Object[]{}, locale);
-        final String end = messageSource.getMessage("report.csv.header.end", new Object[]{}, locale);
-        final String workedHours = messageSource.getMessage("report.csv.header.workedHours", new Object[]{}, locale);
-        final String comment = messageSource.getMessage("report.csv.header.comment", new Object[]{}, locale);
-        final String isBreak = messageSource.getMessage("report.csv.header.break", new Object[]{}, locale);
-
-        writer.println(String.format("%s;%s;%s;%s;%s;%s;%s;%s", date, givenName, familyName, start, end, workedHours, comment, isBreak));
+    private void writeDetailHeader(Locale locale, PrintWriter writer) {
+        writer.println(csvLine(
+            message("report.csv.header.date", locale),
+            message("report.csv.header.person.givenName", locale),
+            message("report.csv.header.person.familyName", locale),
+            message("report.csv.header.start", locale),
+            message("report.csv.header.end", locale),
+            message("report.csv.header.workedHours", locale),
+            message("report.csv.header.shouldWorkingHours", locale),
+            message("report.csv.header.comment", locale),
+            message("report.csv.header.break", locale)
+        ));
     }
 
     private void writeWeek(ReportWeek reportWeek, Locale locale, PrintWriter writer) {
 
-        final NumberFormat numberFormat = NumberFormat.getInstance(locale);
-        numberFormat.setMaximumFractionDigits(FRACTION_DIGITS);
-        numberFormat.setMinimumFractionDigits(FRACTION_DIGITS);
+        final NumberFormat numberFormat = numberFormat(locale);
 
-        reportWeek.reportDays()
-            .stream()
-            .map(ReportDay::reportDayEntries)
-            .flatMap(List::stream)
-            .map(reportDayEntry -> reportDayEntryToCsvLine(reportDayEntry, numberFormat))
-            .forEach(writer::println);
+        reportWeek.reportDays().forEach(reportDay ->
+            reportDay.reportDayEntries().stream()
+                .map(reportDayEntry -> reportDayEntryToCsvLine(reportDay, reportDayEntry, numberFormat))
+                .forEach(writer::println)
+        );
     }
 
-    private String reportDayEntryToCsvLine(ReportDayEntry reportDayEntry, NumberFormat numberFormat) {
+    private String reportDayEntryToCsvLine(ReportDay reportDay, ReportDayEntry reportDayEntry, NumberFormat numberFormat) {
         final String date = dateFormatter.formatDate(reportDayEntry.start().toLocalDate());
         final String givenName = reportDayEntry.user().givenName();
         final String familyName = reportDayEntry.user().familyName();
         final LocalTime start = reportDayEntry.start().toLocalTime();
         final LocalTime end = reportDayEntry.end().toLocalTime();
         final String hoursWorked = numberFormat.format(reportDayEntry.workDuration().hoursDoubleValue());
+        final String shouldWorkingHours = shouldWorkingHoursForUserOnDay(reportDay, reportDayEntry.user().userIdComposite())
+            .map(hours -> numberFormat.format(hours.hoursDoubleValue()))
+            .orElse("");
         final String comment = reportDayEntry.comment();
         final boolean isBreak = reportDayEntry.isBreak();
 
-        return String.format("%s;%s;%s;%s;%s;%s;%s;%s", date, givenName, familyName, start, end, hoursWorked, comment, isBreak);
+        return csvLine(date, givenName, familyName, start, end, hoursWorked, shouldWorkingHours, comment, isBreak);
+    }
+
+    private Optional<ShouldWorkingHours> shouldWorkingHoursForUserOnDay(ReportDay reportDay, UserIdComposite userIdComposite) {
+        return Optional.ofNullable(reportDay.workingTimeCalendarByUser().get(userIdComposite))
+            .flatMap(calendar -> calendar.shouldWorkingHours(reportDay.date()));
+    }
+
+    // ------------------------------------------------------------
+    // aggregated CSV (one row per person and period)
+    // ------------------------------------------------------------
+
+    void writeWeekReportCsvAggregated(Year year, int week, Locale locale, UserLocalId userLocalId, PrintWriter writer) {
+        writeWeekReportCsvAggregatedForUserLocalIds(year, week, locale, List.of(userLocalId), writer);
+    }
+
+    void writeWeekReportCsvAggregatedForUserLocalIds(Year year, int week, Locale locale, List<UserLocalId> userLocalIds, PrintWriter writer) {
+        final ReportWeek reportWeek = reportService.getReportWeek(year, week, userLocalIds);
+        writeWeekCsvAggregated(reportWeek, locale, writer);
+    }
+
+    void writeMonthReportCsvAggregated(YearMonth yearMonth, Locale locale, UserId userId, PrintWriter writer) {
+        final ReportMonth reportMonth = reportService.getReportMonth(yearMonth, userId);
+        writeMonthCsvAggregated(reportMonth, locale, writer);
+    }
+
+    void writeMonthReportCsvAggregatedForUserLocalIds(YearMonth yearMonth, Locale locale, List<UserLocalId> userLocalIds, PrintWriter writer) {
+        final ReportMonth reportMonth = reportService.getReportMonth(yearMonth, userLocalIds);
+        writeMonthCsvAggregated(reportMonth, locale, writer);
+    }
+
+    private void writeWeekCsvAggregated(ReportWeek reportWeek, Locale locale, PrintWriter writer) {
+
+        writer.println(csvLine(
+            message("report.csv.header.calendarWeek", locale),
+            message("report.csv.header.start", locale),
+            message("report.csv.header.end", locale),
+            message("report.csv.header.person.givenName", locale),
+            message("report.csv.header.person.familyName", locale),
+            message("report.csv.header.workedHours", locale),
+            message("report.csv.header.shouldWorkingHours", locale)
+        ));
+
+        final NumberFormat numberFormat = numberFormat(locale);
+        final String dateFrom = dateFormatter.formatDate(reportWeek.firstDateOfWeek());
+        final String dateTo = dateFormatter.formatDate(reportWeek.lastDateOfWeek());
+        final int calendarWeek = reportWeek.calenderWeek();
+
+        for (User user : usersOrderedByName(reportWeek)) {
+            final UserIdComposite userIdComposite = user.userIdComposite();
+            final WorkDuration workDuration = reportWeek.workDurationByUser().getOrDefault(userIdComposite, WorkDuration.ZERO);
+            final ShouldWorkingHours shouldWorkingHours = reportWeek.shouldWorkingHoursByUser().getOrDefault(userIdComposite, ShouldWorkingHours.ZERO);
+
+            writer.println(csvLine(
+                calendarWeek,
+                dateFrom,
+                dateTo,
+                user.givenName(),
+                user.familyName(),
+                numberFormat.format(workDuration.hoursDoubleValue()),
+                numberFormat.format(shouldWorkingHours.hoursDoubleValue())
+            ));
+        }
+    }
+
+    private void writeMonthCsvAggregated(ReportMonth reportMonth, Locale locale, PrintWriter writer) {
+
+        writer.println(csvLine(
+            message("report.csv.header.month", locale),
+            message("report.csv.header.start", locale),
+            message("report.csv.header.end", locale),
+            message("report.csv.header.person.givenName", locale),
+            message("report.csv.header.person.familyName", locale),
+            message("report.csv.header.workedHours", locale),
+            message("report.csv.header.shouldWorkingHours", locale)
+        ));
+
+        final NumberFormat numberFormat = numberFormat(locale);
+        final YearMonth yearMonth = reportMonth.yearMonth();
+        final String monthLabel = dateFormatter.formatYearMonth(yearMonth);
+        final String dateFrom = dateFormatter.formatDate(yearMonth.atDay(1));
+        final String dateTo = dateFormatter.formatDate(yearMonth.atEndOfMonth());
+
+        for (User user : usersOrderedByName(reportMonth)) {
+            final UserIdComposite userIdComposite = user.userIdComposite();
+            final WorkDuration workDuration = reportMonth.workDurationByUser().getOrDefault(userIdComposite, WorkDuration.ZERO);
+            final ShouldWorkingHours shouldWorkingHours = reportMonth.shouldWorkingHoursByUser().getOrDefault(userIdComposite, ShouldWorkingHours.ZERO);
+
+            writer.println(csvLine(
+                monthLabel,
+                dateFrom,
+                dateTo,
+                user.givenName(),
+                user.familyName(),
+                numberFormat.format(workDuration.hoursDoubleValue()),
+                numberFormat.format(shouldWorkingHours.hoursDoubleValue())
+            ));
+        }
+    }
+
+    private List<User> usersOrderedByName(HasWorkDurationByUser report) {
+
+        final List<UserLocalId> userLocalIds = report.workDurationByUser().keySet().stream()
+            .map(UserIdComposite::localId)
+            .toList();
+
+        return userManagementService.findAllUsersByLocalIds(userLocalIds).stream()
+            .sorted(Comparator.comparing(User::familyName).thenComparing(User::givenName))
+            .toList();
+    }
+
+    private String message(String key, Locale locale) {
+        return messageSource.getMessage(key, new Object[]{}, locale);
+    }
+
+    private static NumberFormat numberFormat(Locale locale) {
+        final NumberFormat numberFormat = NumberFormat.getInstance(locale);
+        numberFormat.setMaximumFractionDigits(FRACTION_DIGITS);
+        numberFormat.setMinimumFractionDigits(FRACTION_DIGITS);
+        return numberFormat;
+    }
+
+    private static String csvLine(Object... values) {
+        return Arrays.stream(values).map(String::valueOf).collect(Collectors.joining(";"));
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
@@ -138,12 +138,14 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad, HasUserSearch
         final int selectedYear = year;
         final int selectedMonth = month;
         final String selectedYearMonthUrl = viewHelper.createUrl(String.format("/report/year/%d/month/%d", selectedYear, selectedMonth), allUsersSelected, userLocalIds);
-        final String csvDownloadUrl = selectedYearMonthUrl.contains("?") ? selectedYearMonthUrl + "&csv" : selectedYearMonthUrl + "?csv";
+        final String csvDownloadUrlDetailed = appendCsvParam(selectedYearMonthUrl, "detailed");
+        final String csvDownloadUrlAggregated = appendCsvParam(selectedYearMonthUrl, "aggregated");
 
         model.addAttribute("userReportPreviousSectionUrl", previousSectionUrl);
         model.addAttribute("userReportTodaySectionUrl", todaySectionUrl);
         model.addAttribute("userReportNextSectionUrl", nextSectionUrl);
-        model.addAttribute("userReportCsvDownloadUrl", csvDownloadUrl);
+        model.addAttribute("userReportCsvDownloadUrlDetailed", csvDownloadUrlDetailed);
+        model.addAttribute("userReportCsvDownloadUrlAggregated", csvDownloadUrlAggregated);
 
         final List<User> users = reportPermissionService.findAllPermittedUsersForCurrentUser();
 
@@ -294,6 +296,10 @@ class ReportMonthController implements HasTimeClock, HasLaunchpad, HasUserSearch
         return fromMethodCall(on(ReportMonthController.class)
             .monthlyUserReport(year, month, everyoneParam, userParam, timeEntryId, null,null,null))
             .build().toUriString();
+    }
+
+    private static String appendCsvParam(String url, String csvType) {
+        return (url.contains("?") ? url + "&csv=" : url + "?csv=") + csvType;
     }
 
     private static Optional<YearMonth> yearMonth(int year, int month) {

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportWeekController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportWeekController.java
@@ -133,12 +133,14 @@ class ReportWeekController implements HasTimeClock, HasLaunchpad, HasUserSearch 
         final int selectedYear = reportYearWeek.getYear();
         final int selectedWeek = reportYearWeek.getWeek();
         final String selectedYearWeekUrl = reportViewHelper.createUrl(format(REPORT_YEAR_WEEK_URL_TEMPLATE, selectedYear, selectedWeek), allUsersSelected, selectedUserLocalIds);
-        final String csvDownloadUrl = selectedYearWeekUrl.contains("?") ? selectedYearWeekUrl + "&csv" : selectedYearWeekUrl + "?csv";
+        final String csvDownloadUrlDetailed = appendCsvParam(selectedYearWeekUrl, "detailed");
+        final String csvDownloadUrlAggregated = appendCsvParam(selectedYearWeekUrl, "aggregated");
 
         model.addAttribute("userReportPreviousSectionUrl", previousSectionUrl);
         model.addAttribute("userReportTodaySectionUrl", todaySectionUrl);
         model.addAttribute("userReportNextSectionUrl", nextSectionUrl);
-        model.addAttribute("userReportCsvDownloadUrl", csvDownloadUrl);
+        model.addAttribute("userReportCsvDownloadUrlDetailed", csvDownloadUrlDetailed);
+        model.addAttribute("userReportCsvDownloadUrlAggregated", csvDownloadUrlAggregated);
 
         final List<User> users = reportPermissionService.findAllPermittedUsersForCurrentUser();
 
@@ -248,6 +250,10 @@ class ReportWeekController implements HasTimeClock, HasLaunchpad, HasUserSearch 
         }
 
         return reportWeek;
+    }
+
+    private static String appendCsvParam(String url, String csvType) {
+        return (url.contains("?") ? url + "&csv=" : url + "?csv=") + csvType;
     }
 
     private static Optional<YearWeek> yearWeek(int year, int week) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -354,7 +354,6 @@ report.filter.users.submit=Übernehmen
 report.week.navigation.button.today=Heute
 report.week.navigation.button.previous=Vorige Woche
 report.week.navigation.button.next=Nächste Woche
-report.week.button.csv-download=CSV Download
 report.week.current-week=Diese Woche
 report.week.group.hours-bar.worked-hours=Geleistet:
 report.week.group.hours-bar.should=Geplant:
@@ -362,21 +361,29 @@ report.week.group.hours-bar.should=Geplant:
 report.month.navigation.button.today=Heute
 report.month.navigation.button.previous=Voriger Monat
 report.month.navigation.button.next=Nächster Monat
-report.month.button.csv-download=CSV Download
 report.month.current-month=Dieser Monat
 report.month.group.hours-bar.worked-hours=Geleistet:
 report.month.group.hours-bar.should=Geplant:
 
+report.button.csv-export=Export
+report.csv.export.detailed=CSV (Detailliert)
+report.csv.export.aggregated=CSV (Aggregiert)
+
 report.monthly.csv.filename=zeiterfassung-bericht-{0,number,#}-{1}.csv
+report.monthly.csv.filename.aggregated=zeiterfassung-bericht-{0,number,#}-{1}-aggregiert.csv
 report.weekly.csv.filename=zeiterfassung-bericht-{0,number,#}-kw{1}.csv
+report.weekly.csv.filename.aggregated=zeiterfassung-bericht-{0,number,#}-kw{1}-aggregiert.csv
 report.csv.header.date=Datum
 report.csv.header.person.givenName=Vorname
 report.csv.header.person.familyName=Nachname
 report.csv.header.start=Von
 report.csv.header.end=Bis
-report.csv.header.workedHours=erfasste Stunden
+report.csv.header.workedHours=Erfasste Stunden
+report.csv.header.shouldWorkingHours=Sollarbeitszeit
 report.csv.header.comment=Kommentar
 report.csv.header.break=Pause
+report.csv.header.calendarWeek=KW
+report.csv.header.month=Monat
 
 report.time.pagination.navigation.aria-label=Bericht Seiten-Nummerierung
 

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -352,7 +352,6 @@ report.filter.users.submit=Submit
 report.week.navigation.button.today=Today
 report.week.navigation.button.previous=Previous week
 report.week.navigation.button.next=Next week
-report.week.button.csv-download=CSV Download
 report.week.current-week=Current week
 report.week.group.hours-bar.worked-hours=Worked:
 report.week.group.hours-bar.should=Planned:
@@ -360,21 +359,29 @@ report.week.group.hours-bar.should=Planned:
 report.month.navigation.button.today=Today
 report.month.navigation.button.previous=Previous month
 report.month.navigation.button.next=Next month
-report.month.button.csv-download=CSV Download
 report.month.current-month=Current month
 report.month.group.hours-bar.worked-hours=Worked:
 report.month.group.hours-bar.should=Planned:
 
+report.button.csv-export=Export
+report.csv.export.detailed=CSV (Detailed)
+report.csv.export.aggregated=CSV (Aggregated)
+
 report.monthly.csv.filename=zeiterfassung-report-{0,number,#}-{1}.csv
+report.monthly.csv.filename.aggregated=zeiterfassung-report-{0,number,#}-{1}-aggregated.csv
 report.weekly.csv.filename=zeiterfassung-report-{0,number,#}-kw{1}.csv
+report.weekly.csv.filename.aggregated=zeiterfassung-report-{0,number,#}-kw{1}-aggregated.csv
 report.csv.header.date=Date
 report.csv.header.person.givenName=Given name
 report.csv.header.person.familyName=Family name
 report.csv.header.start=From
 report.csv.header.end=To
 report.csv.header.workedHours=Worked hours
+report.csv.header.shouldWorkingHours=Should working hours
 report.csv.header.comment=Comment
 report.csv.header.break=Break
+report.csv.header.calendarWeek=CW
+report.csv.header.month=Month
 
 report.time.pagination.navigation.aria-label=Bericht Seiten-Nummerierung
 

--- a/src/main/resources/templates/reports/user-report-month.html
+++ b/src/main/resources/templates/reports/user-report-month.html
@@ -49,15 +49,47 @@
         </a>
       </nav>
       <form th:replace="~{reports/_user-select::form}" />
-      <a
-        href="#"
-        th:href="${userReportCsvDownloadUrl}"
-        download
-        class="report-actions__csv button-secondary"
-        th:text="#{report.month.button.csv-download}"
-      >
-        CSV Download
-      </a>
+      <div class="report-actions__csv">
+        <button
+          type="button"
+          popovertarget="csv-export-menu-month"
+          class="button-secondary flex items-center gap-1"
+          data-testid="csv-export-button"
+        >
+          <span th:text="#{report.button.csv-export}">Export</span>
+          <svg th:replace="~{icons/chevron-down::svg(className='w-4 h-4')}"></svg>
+        </button>
+        <div
+          popover
+          id="csv-export-menu-month"
+          class="nav-popover-menu-container popover popover--slide-to-bottom"
+        >
+          <div class="navigation-popover-menu-content">
+            <ul class="navigation-popover-menu">
+              <li>
+                <a
+                  href="#"
+                  th:href="${userReportCsvDownloadUrlDetailed}"
+                  download
+                  class="navigation-popover-menu__link"
+                  th:text="#{report.csv.export.detailed}"
+                  >CSV (Detailliert)</a
+                >
+              </li>
+              <li>
+                <a
+                  href="#"
+                  th:href="${userReportCsvDownloadUrlAggregated}"
+                  download
+                  class="navigation-popover-menu__link"
+                  th:text="#{report.csv.export.aggregated}"
+                  >CSV (Aggregiert)</a
+                >
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
     </div>
 
     <th:block th:fragment="chart">

--- a/src/main/resources/templates/reports/user-report-week.html
+++ b/src/main/resources/templates/reports/user-report-week.html
@@ -51,15 +51,47 @@
         </a>
       </nav>
       <form th:replace="~{reports/_user-select::form}" />
-      <a
-        href="#"
-        th:href="${userReportCsvDownloadUrl}"
-        download
-        class="report-actions__csv button-secondary"
-        th:text="#{report.week.button.csv-download}"
-      >
-        CSV Download
-      </a>
+      <div class="report-actions__csv">
+        <button
+          type="button"
+          popovertarget="csv-export-menu-week"
+          class="button-secondary flex items-center gap-1"
+          data-testid="csv-export-button"
+        >
+          <span th:text="#{report.button.csv-export}">Export</span>
+          <svg th:replace="~{icons/chevron-down::svg(className='w-4 h-4')}"></svg>
+        </button>
+        <div
+          popover
+          id="csv-export-menu-week"
+          class="nav-popover-menu-container popover popover--slide-to-bottom"
+        >
+          <div class="navigation-popover-menu-content">
+            <ul class="navigation-popover-menu">
+              <li>
+                <a
+                  href="#"
+                  th:href="${userReportCsvDownloadUrlDetailed}"
+                  download
+                  class="navigation-popover-menu__link"
+                  th:text="#{report.csv.export.detailed}"
+                  >CSV (Detailliert)</a
+                >
+              </li>
+              <li>
+                <a
+                  href="#"
+                  th:href="${userReportCsvDownloadUrlAggregated}"
+                  download
+                  class="navigation-popover-menu__link"
+                  th:text="#{report.csv.export.aggregated}"
+                  >CSV (Aggregiert)</a
+                >
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
     </div>
 
     <th:block th:fragment="chart">

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceIT.java
@@ -1,20 +1,30 @@
 package de.focusshift.zeiterfassung.report;
 
 import de.focusshift.zeiterfassung.SingleTenantTestContainersBase;
+import de.focusshift.zeiterfassung.security.oidc.CurrentOidcUser;
 import de.focusshift.zeiterfassung.tenancy.user.EMailAddress;
 import de.focusshift.zeiterfassung.user.UserId;
 import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
 import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.PrintWriter;
+import java.time.Year;
 import java.time.YearMonth;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
@@ -31,6 +41,11 @@ class ReportCsvServiceIT extends SingleTenantTestContainersBase {
 
     @MockitoBean
     private UserManagementService userManagementService;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
 
     @ParameterizedTest
     @CsvSource({"de,Datum;Vorname;Nachname;Von;Bis;Erfasste Stunden;Sollarbeitszeit;Kommentar;Pause", "en,Date;Given name;Family name;From;To;Worked hours;Should working hours;Comment;Break"})
@@ -50,7 +65,7 @@ class ReportCsvServiceIT extends SingleTenantTestContainersBase {
     }
 
     @ParameterizedTest
-    @CsvSource({"de,KW;Von;Bis;Vorname;Nachname;Erfasste Stunden;Sollarbeitszeit", "en,CW;From;To;Given name;Family name;Worked hours;Should working hours"})
+    @CsvSource({"de,Monat;Von;Bis;Vorname;Nachname;Erfasste Stunden;Sollarbeitszeit", "en,Month;From;To;Given name;Family name;Worked hours;Should working hours"})
     void ensureI18nHeaderAggregated(String languageTag, String expectedHeader) {
         final PrintWriter printWriter = mock(PrintWriter.class);
 
@@ -62,6 +77,31 @@ class ReportCsvServiceIT extends SingleTenantTestContainersBase {
         when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
 
         sut.writeMonthReportCsvAggregated(YearMonth.of(2022, 9), Locale.forLanguageTag(languageTag), userId, printWriter);
+
+        verify(printWriter).println(expectedHeader);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"de,KW;Von;Bis;Vorname;Nachname;Erfasste Stunden;Sollarbeitszeit", "en,CW;From;To;Given name;Family name;Worked hours;Should working hours"})
+    void ensureI18nHeaderWeekAggregated(String languageTag, String expectedHeader) {
+        final PrintWriter printWriter = mock(PrintWriter.class);
+
+        final UserId userId = new UserId("user");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        when(userManagementService.findUserByLocalId(userLocalId)).thenReturn(Optional.of(user));
+        when(userManagementService.findAllUsersByLocalIds(List.of(userLocalId))).thenReturn(List.of(user));
+
+        // permission check for the week report requires an authenticated current user
+        final OidcIdToken idToken = OidcIdToken.withTokenValue("token-value").claim("sub", userId.value()).build();
+        final OidcUserInfo userInfo = OidcUserInfo.builder().subject(userId.value()).name("Bruce Wayne").build();
+        final CurrentOidcUser currentOidcUser = new CurrentOidcUser(new DefaultOidcUser(List.of(), idToken, userInfo), List.of(), List.of(), userLocalId);
+        final Authentication authentication = new OAuth2AuthenticationToken(currentOidcUser, List.of(), "registrationId");
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        sut.writeWeekReportCsvAggregated(Year.of(2022), 36, Locale.forLanguageTag(languageTag), userLocalId, printWriter);
 
         verify(printWriter).println(expectedHeader);
     }

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceIT.java
@@ -33,7 +33,7 @@ class ReportCsvServiceIT extends SingleTenantTestContainersBase {
     private UserManagementService userManagementService;
 
     @ParameterizedTest
-    @CsvSource({"de,Datum;Vorname;Nachname;Von;Bis;erfasste Stunden;Kommentar;Pause", "en,Date;Given name;Family name;From;To;Worked hours;Comment;Break"})
+    @CsvSource({"de,Datum;Vorname;Nachname;Von;Bis;Erfasste Stunden;Sollarbeitszeit;Kommentar;Pause", "en,Date;Given name;Family name;From;To;Worked hours;Should working hours;Comment;Break"})
     void ensureI18nHeader(String languageTag, String expectedHeader) {
         final PrintWriter printWriter = mock(PrintWriter.class);
 
@@ -45,6 +45,23 @@ class ReportCsvServiceIT extends SingleTenantTestContainersBase {
         when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
 
         sut.writeMonthReportCsv(YearMonth.of(2022, 9), Locale.forLanguageTag(languageTag), userId, printWriter);
+
+        verify(printWriter).println(expectedHeader);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"de,KW;Von;Bis;Vorname;Nachname;Erfasste Stunden;Sollarbeitszeit", "en,CW;From;To;Given name;Family name;Worked hours;Should working hours"})
+    void ensureI18nHeaderAggregated(String languageTag, String expectedHeader) {
+        final PrintWriter printWriter = mock(PrintWriter.class);
+
+        final UserId userId = new UserId("user");
+        final UserLocalId userLocalId = new UserLocalId(1L);
+        final UserIdComposite userIdComposite = new UserIdComposite(userId, userLocalId);
+        final User user = new User(userIdComposite, "Bruce", "Wayne", new EMailAddress(""), Set.of());
+
+        when(userManagementService.findUserById(userId)).thenReturn(Optional.of(user));
+
+        sut.writeMonthReportCsvAggregated(YearMonth.of(2022, 9), Locale.forLanguageTag(languageTag), userId, printWriter);
 
         verify(printWriter).println(expectedHeader);
     }

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportCsvServiceTest.java
@@ -6,6 +6,7 @@ import de.focusshift.zeiterfassung.user.UserId;
 import de.focusshift.zeiterfassung.user.UserIdComposite;
 import de.focusshift.zeiterfassung.usermanagement.User;
 import de.focusshift.zeiterfassung.usermanagement.UserLocalId;
+import de.focusshift.zeiterfassung.usermanagement.UserManagementService;
 import de.focusshift.zeiterfassung.workduration.WorkDuration;
 import de.focusshift.zeiterfassung.workingtime.PlannedWorkingHours;
 import de.focusshift.zeiterfassung.workingtime.WorkingTimeCalendar;
@@ -34,6 +35,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +54,9 @@ class ReportCsvServiceTest {
     @Mock
     private MessageSource messageSource;
 
+    @Mock
+    private UserManagementService userManagementService;
+
     @BeforeEach
     void setUp() {
 
@@ -59,11 +64,14 @@ class ReportCsvServiceTest {
         when(messageSource.getMessage(any(), any(), any()))
             .thenAnswer((Answer<String>) invocationOnMock -> invocationOnMock.getArgument(0));
 
-        sut = new ReportCsvService(reportService, dateFormatter, messageSource);
+        lenient().when(dateFormatter.formatYearMonth(any()))
+            .thenAnswer(invocation -> invocation.<YearMonth>getArgument(0).toString());
+
+        sut = new ReportCsvService(reportService, dateFormatter, messageSource, userManagementService);
     }
 
     // ------------------------------------------------------------
-    // WEEK report csv
+    // WEEK report csv - detailed
     // ------------------------------------------------------------
 
     @Test
@@ -80,7 +88,7 @@ class ReportCsvServiceTest {
         sut.writeWeekReportCsv(Year.of(2021), 1, Locale.GERMAN, userLocalId, printWriter);
 
         assertThat(stringWriter).hasToString("""
-            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.comment;report.csv.header.break
+            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.shouldWorkingHours;report.csv.header.comment;report.csv.header.break
             """);
     }
 
@@ -116,8 +124,43 @@ class ReportCsvServiceTest {
         sut.writeWeekReportCsv(Year.of(2021), 1, Locale.GERMAN, batmanLocalId, printWriter);
 
         assertThat(stringWriter).hasToString("""
-            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.comment;report.csv.header.break
-            04.01.2021;Bruce;Wayne;10:00;10:30;0,500;hard work;false
+            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.shouldWorkingHours;report.csv.header.comment;report.csv.header.break
+            04.01.2021;Bruce;Wayne;10:00;10:30;0,500;8,000;hard work;false
+            """);
+    }
+
+    @Test
+    void ensureWeekReportCsvWithoutShouldWorkingHoursConfiguredLeavesColumnEmpty() {
+
+        mockDateFormatter("dd.MM.yyyy");
+
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+
+        // no working time calendar entry for the given date -> shouldWorkingHours unknown
+        final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser = Map.of(
+            batmanIdComposite, new WorkingTimeCalendar(Map.of(), Map.of())
+        );
+
+        final ZonedDateTime from = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 0), ZONE_ID_BERLIN);
+        final ZonedDateTime to = ZonedDateTime.of(LocalDateTime.of(2021, 1, 4, 10, 30), ZONE_ID_BERLIN);
+        final WorkDuration workDuration = new WorkDuration(Duration.ofMinutes(30));
+        final ReportDayEntry reportDayEntry = new ReportDayEntry(null, batman, "hard work", from, to, workDuration, false);
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), false, workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of(reportDayEntry)), Map.of(), Map.of());
+
+        when(reportService.getReportWeek(Year.of(2021), 1, List.of(batmanLocalId)))
+            .thenReturn(new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDay)));
+
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stringWriter);
+
+        sut.writeWeekReportCsv(Year.of(2021), 1, Locale.GERMAN, batmanLocalId, printWriter);
+
+        assertThat(stringWriter).hasToString("""
+            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.shouldWorkingHours;report.csv.header.comment;report.csv.header.break
+            04.01.2021;Bruce;Wayne;10:00;10:30;0,500;;hard work;false
             """);
     }
 
@@ -165,15 +208,15 @@ class ReportCsvServiceTest {
         sut.writeWeekReportCsv(Year.of(2021), 1, Locale.GERMAN, batmanLocalId, printWriter);
 
         assertThat(stringWriter).hasToString("""
-            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.comment;report.csv.header.break
-            04.01.2021;Bruce;Wayne;10:00;11:00;1,000;hard work;false
-            04.01.2021;Bruce;Wayne;14:00;15:00;1,000;hard work;false
-            05.01.2021;Bruce;Wayne;09:00;17:00;8,000;hard work;false
+            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.shouldWorkingHours;report.csv.header.comment;report.csv.header.break
+            04.01.2021;Bruce;Wayne;10:00;11:00;1,000;8,000;hard work;false
+            04.01.2021;Bruce;Wayne;14:00;15:00;1,000;8,000;hard work;false
+            05.01.2021;Bruce;Wayne;09:00;17:00;8,000;8,000;hard work;false
             """);
     }
 
     // ------------------------------------------------------------
-    // MONTH report csv
+    // MONTH report csv - detailed
     // ------------------------------------------------------------
 
     @Test
@@ -188,7 +231,7 @@ class ReportCsvServiceTest {
         sut.writeMonthReportCsv(YearMonth.of(2021, 1), Locale.GERMAN, new UserId("batman"), printWriter);
 
         assertThat(stringWriter).hasToString("""
-            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.comment;report.csv.header.break
+            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.shouldWorkingHours;report.csv.header.comment;report.csv.header.break
             """);
     }
 
@@ -229,8 +272,8 @@ class ReportCsvServiceTest {
         sut.writeMonthReportCsv(YearMonth.of(2021, 1), Locale.GERMAN, batmanId, printWriter);
 
         assertThat(stringWriter).hasToString("""
-            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.comment;report.csv.header.break
-            04.01.2021;Bruce;Wayne;10:00;10:30;0,500;hard work;false
+            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.shouldWorkingHours;report.csv.header.comment;report.csv.header.break
+            04.01.2021;Bruce;Wayne;10:00;10:30;0,500;8,000;hard work;false
             """);
     }
 
@@ -284,10 +327,122 @@ class ReportCsvServiceTest {
         sut.writeMonthReportCsv(YearMonth.of(2021, 1), Locale.GERMAN, batmanId, printWriter);
 
         assertThat(stringWriter).hasToString("""
-            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.comment;report.csv.header.break
-            04.01.2021;Bruce;Wayne;10:00;11:00;1,000;hard work;false
-            04.01.2021;Bruce;Wayne;14:00;15:00;1,000;hard work;false
-            05.01.2021;Bruce;Wayne;09:00;17:00;8,000;hard work;false
+            report.csv.header.date;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.start;report.csv.header.end;report.csv.header.workedHours;report.csv.header.shouldWorkingHours;report.csv.header.comment;report.csv.header.break
+            04.01.2021;Bruce;Wayne;10:00;11:00;1,000;8,000;hard work;false
+            04.01.2021;Bruce;Wayne;14:00;15:00;1,000;8,000;hard work;false
+            05.01.2021;Bruce;Wayne;09:00;17:00;8,000;8,000;hard work;false
+            """);
+    }
+
+    // ------------------------------------------------------------
+    // WEEK report csv - aggregated
+    // ------------------------------------------------------------
+
+    @Test
+    void ensureWeekReportCsvAggregatedWithEmptyReport() {
+
+        final UserLocalId userLocalId = new UserLocalId(1L);
+
+        when(reportService.getReportWeek(Year.of(2021), 1, List.of(userLocalId)))
+            .thenReturn(new ReportWeek(LocalDate.of(2020, 12, 28), List.of()));
+
+        when(userManagementService.findAllUsersByLocalIds(List.of()))
+            .thenReturn(List.of());
+
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stringWriter);
+
+        sut.writeWeekReportCsvAggregated(Year.of(2021), 1, Locale.GERMAN, userLocalId, printWriter);
+
+        assertThat(stringWriter).hasToString("""
+            report.csv.header.calendarWeek;report.csv.header.start;report.csv.header.end;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.workedHours;report.csv.header.shouldWorkingHours
+            """);
+    }
+
+    @Test
+    void ensureWeekReportCsvAggregatedSumsWorkedHoursOfWeek() {
+
+        mockDateFormatter("dd.MM.yyyy");
+
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+
+        final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser = Map.of(
+            batmanIdComposite, new WorkingTimeCalendar(
+                Map.of(
+                    LocalDate.of(2021, 1, 4), PlannedWorkingHours.EIGHT,
+                    LocalDate.of(2021, 1, 5), PlannedWorkingHours.EIGHT
+                ),
+                Map.of()
+            )
+        );
+
+        final ReportDay reportDayOne = new ReportDay(LocalDate.of(2021, 1, 4), false, workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, new WorkDuration(Duration.ofHours(4))), Map.of());
+        final ReportDay reportDayTwo = new ReportDay(LocalDate.of(2021, 1, 5), false, workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, new WorkDuration(Duration.ofHours(8))), Map.of());
+
+        final ReportWeek reportWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of(reportDayOne, reportDayTwo));
+
+        when(reportService.getReportWeek(Year.of(2021), 1, List.of(batmanLocalId)))
+            .thenReturn(reportWeek);
+
+        when(userManagementService.findAllUsersByLocalIds(List.of(batmanLocalId)))
+            .thenReturn(List.of(batman));
+
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stringWriter);
+
+        sut.writeWeekReportCsvAggregated(Year.of(2021), 1, Locale.GERMAN, batmanLocalId, printWriter);
+
+        assertThat(stringWriter).hasToString("""
+            report.csv.header.calendarWeek;report.csv.header.start;report.csv.header.end;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.workedHours;report.csv.header.shouldWorkingHours
+            1;04.01.2021;05.01.2021;Bruce;Wayne;12,000;16,000
+            """);
+    }
+
+    // ------------------------------------------------------------
+    // MONTH report csv - aggregated
+    // ------------------------------------------------------------
+
+    @Test
+    void ensureMonthReportCsvAggregatedSumsWorkedHoursOfMonth() {
+
+        mockDateFormatter("dd.MM.yyyy");
+
+        final UserId batmanId = new UserId("batman");
+        final UserLocalId batmanLocalId = new UserLocalId(1L);
+        final UserIdComposite batmanIdComposite = new UserIdComposite(batmanId, batmanLocalId);
+        final User batman = new User(batmanIdComposite, "Bruce", "Wayne", new EMailAddress("batman@example.org"), Set.of());
+
+        final Map<UserIdComposite, WorkingTimeCalendar> workingTimeCalendarByUser = Map.of(
+            batmanIdComposite, new WorkingTimeCalendar(
+                Map.of(LocalDate.of(2021, 1, 4), PlannedWorkingHours.EIGHT),
+                Map.of()
+            )
+        );
+
+        final ReportDay reportDay = new ReportDay(LocalDate.of(2021, 1, 4), false, workingTimeCalendarByUser, Map.of(batmanIdComposite, List.of()), Map.of(batmanIdComposite, new WorkDuration(Duration.ofHours(4))), Map.of());
+
+        final ReportWeek firstWeek = new ReportWeek(LocalDate.of(2020, 12, 28), List.of(reportDay));
+        final ReportWeek secondWeek = new ReportWeek(LocalDate.of(2021, 1, 4), List.of());
+
+        final ReportMonth reportMonth = new ReportMonth(YearMonth.of(2021, 1), List.of(firstWeek, secondWeek));
+
+        when(reportService.getReportMonth(YearMonth.of(2021, 1), batmanId))
+            .thenReturn(reportMonth);
+
+        when(userManagementService.findAllUsersByLocalIds(List.of(batmanLocalId)))
+            .thenReturn(List.of(batman));
+
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stringWriter);
+
+        sut.writeMonthReportCsvAggregated(YearMonth.of(2021, 1), Locale.GERMAN, batmanId, printWriter);
+
+        assertThat(stringWriter).hasToString("""
+            report.csv.header.month;report.csv.header.start;report.csv.header.end;report.csv.header.person.givenName;report.csv.header.person.familyName;report.csv.header.workedHours;report.csv.header.shouldWorkingHours
+            2021-01;01.01.2021;31.01.2021;Bruce;Wayne;4,000;8,000
             """);
     }
 

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportMonthControllerTest.java
@@ -365,7 +365,8 @@ class ReportMonthControllerTest implements ControllerTest {
             get("/report/year/2022/month/1")
                 .with(oidcSubject("batman"))
         )
-            .andExpect(model().attribute("userReportCsvDownloadUrl", "/report/year/2022/month/1?csv"));
+            .andExpect(model().attribute("userReportCsvDownloadUrlDetailed", "/report/year/2022/month/1?csv=detailed"))
+            .andExpect(model().attribute("userReportCsvDownloadUrlAggregated", "/report/year/2022/month/1?csv=aggregated"));
     }
 
     @Test
@@ -379,7 +380,8 @@ class ReportMonthControllerTest implements ControllerTest {
                 .with(oidcSubject("batman"))
                 .param("everyone", "")
         )
-            .andExpect(model().attribute("userReportCsvDownloadUrl", "/report/year/2022/month/1?everyone=&csv"));
+            .andExpect(model().attribute("userReportCsvDownloadUrlDetailed", "/report/year/2022/month/1?everyone=&csv=detailed"))
+            .andExpect(model().attribute("userReportCsvDownloadUrlAggregated", "/report/year/2022/month/1?everyone=&csv=aggregated"));
     }
 
     @Test
@@ -393,7 +395,8 @@ class ReportMonthControllerTest implements ControllerTest {
                 .with(oidcSubject("batman"))
                 .param("user", "1", "2", "42")
         )
-            .andExpect(model().attribute("userReportCsvDownloadUrl", "/report/year/2022/month/1?user=1&user=2&user=42&csv"));
+            .andExpect(model().attribute("userReportCsvDownloadUrlDetailed", "/report/year/2022/month/1?user=1&user=2&user=42&csv=detailed"))
+            .andExpect(model().attribute("userReportCsvDownloadUrlAggregated", "/report/year/2022/month/1?user=1&user=2&user=42&csv=aggregated"));
     }
 
     @Test

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportWeekControllerTest.java
@@ -348,7 +348,8 @@ class ReportWeekControllerTest implements ControllerTest {
             get("/report/year/2022/week/1")
                 .with(oidcSubject(userIdComposite))
         )
-            .andExpect(model().attribute("userReportCsvDownloadUrl", "/report/year/2022/week/1?csv"));
+            .andExpect(model().attribute("userReportCsvDownloadUrlDetailed", "/report/year/2022/week/1?csv=detailed"))
+            .andExpect(model().attribute("userReportCsvDownloadUrlAggregated", "/report/year/2022/week/1?csv=aggregated"));
     }
 
     @Test
@@ -362,7 +363,8 @@ class ReportWeekControllerTest implements ControllerTest {
                 .with(oidcSubject("batman"))
                 .param("everyone", "")
         )
-            .andExpect(model().attribute("userReportCsvDownloadUrl", "/report/year/2022/week/1?everyone=&csv"));
+            .andExpect(model().attribute("userReportCsvDownloadUrlDetailed", "/report/year/2022/week/1?everyone=&csv=detailed"))
+            .andExpect(model().attribute("userReportCsvDownloadUrlAggregated", "/report/year/2022/week/1?everyone=&csv=aggregated"));
     }
 
     @Test
@@ -376,7 +378,8 @@ class ReportWeekControllerTest implements ControllerTest {
                 .with(oidcSubject("batman"))
                 .param("user", "1", "2", "42")
         )
-            .andExpect(model().attribute("userReportCsvDownloadUrl", "/report/year/2022/week/1?user=1&user=2&user=42&csv"));
+            .andExpect(model().attribute("userReportCsvDownloadUrlDetailed", "/report/year/2022/week/1?user=1&user=2&user=42&csv=detailed"))
+            .andExpect(model().attribute("userReportCsvDownloadUrlAggregated", "/report/year/2022/week/1?user=1&user=2&user=42&csv=aggregated"));
     }
 
     @Test


### PR DESCRIPTION
# Add CSV export dropdown with aggregated export option to Berichte page

## Description

Replaces the single "CSV Download" button on the Berichte (reports) page with an "Export" dropdown offering two CSV variants, and improves the existing CSV export along the way:

- `CSV (Detailliert)` - the existing per-time-entry CSV export, unchanged in structure.
- `CSV (Aggregiert)` - a new export that summarizes hours per period: one row per calendar week (KW) when the current view is "Woche", or one row per month when the current view is "Monat".
- Fixed a capitalization bug in the existing CSV header: `erfasste Stunden` -> `Erfasste Stunden`.
- Added a new `Sollarbeitszeit` (should-working-hours) column to both CSV variants, sourced from the employee's working-time settings; left empty when not configured for that day.

## Use case

The detailed, one-row-per-time-entry CSV is useful for auditing individual entries but tedious to reconcile against payroll/contract hours, which are usually tracked per week or per month. Adding an aggregated export lets admins get period totals (worked vs. should-work hours) directly, without post-processing the detailed export in a spreadsheet. The Sollarbeitszeit column was missing entirely, so any planned-vs-actual comparison had to be done by cross-referencing the settings module by hand.

## Changes

### CSV export (`report` package):

- `ReportCsvService`: existing per-entry CSV writer gained a `Sollarbeitszeit` column, resolved per user/day via `ReportDay.workingTimeCalendarByUser()` -> `WorkingTimeCalendar.shouldWorkingHours(date)`, left blank via `Optional` when not configured. Added new `writeWeekReportCsvAggregated(...)` / `writeMonthReportCsvAggregated(...)` (and their `ForUserLocalIds` overloads) producing one row per selected person per KW/month, using the already-existing `ReportWeek`/`ReportMonth` aggregation (`workDurationByUser()`, `shouldWorkingHoursByUser()`) - no new aggregation logic was needed, just new CSV formatting on top of it. Rows include the period's date range (first/last date of the week, or first/last day of the month) alongside the KW number / month label.
- `ReportCsvController`: split the single `?csv` query param into `?csv=detailed` / `?csv=aggregated`, each mapped to its own `@GetMapping`. Added two new endpoints (`weeklyUserReportCsvAggregated`, `monthlyUserReportCsvAggregated`) mirroring the existing detailed ones, with their own filename message keys.
- `ReportWeekController` / `ReportMonthController`: now expose `userReportCsvDownloadUrlDetailed` and `userReportCsvDownloadUrlAggregated` model attributes (previously a single `userReportCsvDownloadUrl`), built via a small `appendCsvParam(url, csvType)` helper.

### View wiring:

- `user-report-week.html` / `user-report-month.html`: the CSV download `<a>` is replaced with a `popovertarget`/`popover` dropdown (same native-HTML popover pattern already used for the avatar menu and feedback form - no new JS, no Bootstrap-style component introduced), containing the two export links. Existing `.report-actions__csv` responsive display rules (hidden below the `xs` breakpoint) now apply to the wrapping `<div>` instead of the `<a>`, so the responsive layout is unchanged.

### i18n: new keys added to both `messages.properties` (DE, default locale) and `messages_en.properties` - confirmed these are the only two message bundles in the project (no other locale files to update):

- `report.button.csv-export`, `report.csv.export.detailed`, `report.csv.export.aggregated`
- `report.csv.header.shouldWorkingHours`, `report.csv.header.calendarWeek`, `report.csv.header.month`
- `report.weekly.csv.filename.aggregated`, `report.monthly.csv.filename.aggregated`
- `report.csv.header.workedHours` corrected from `erfasste Stunden` to `Erfasste Stunden`

### Backward compatibility

- The detailed CSV keeps its existing row shape (one row per time entry); only a new trailing-before-comment `Sollarbeitszeit` column was inserted, so downstream consumers parsing by header name are unaffected, though anyone parsing by fixed column index will see a shift.
- The old `?csv` query param is replaced by `?csv=detailed` / `?csv=aggregated` rather than kept alongside the new ones, since the CSV download link is always generated server-side from the model attribute - no bookmarked/hardcoded external links are expected to depend on the bare `?csv` param.
- No changes to `ReportWeek`, `ReportMonth`, `ReportDay`, or any aggregation logic - the aggregated CSV reuses their existing `workDurationByUser()`/`shouldWorkingHoursByUser()` accessors as-is.

## Testing

- New/updated unit tests: `ReportCsvServiceTest` (detailed CSV with the new Sollarbeitszeit column, incl. the "not configured -> empty cell" case; new aggregated-CSV tests for week and month summing hours correctly), `ReportCsvServiceIT` (i18n header assertions updated for both DE/EN, incl. new aggregated-header test), `ReportWeekControllerTest` / `ReportMonthControllerTest` (updated to assert the new `userReportCsvDownloadUrlDetailed`/`userReportCsvDownloadUrlAggregated` model attributes and `csv=detailed`/`csv=aggregated` URLs).
- Full report-package test run: `./mvnw test -Dtest=ReportCsvServiceTest,ReportWeekControllerTest,ReportMonthControllerTest` - 47 tests, 0 failures, 0 errors.