### PR TITLE
fix mobile navigation drawer on Samsung Internet

### DIFF
--- a/src/main/css/components/navigation.css
+++ b/src/main/css/components/navigation.css
@@ -7,11 +7,19 @@
 
   .navigation {
     background-color: var(--color-white);
+
+    /* anchor-size(height)/position-area (inherited from .popover) resolve unreliably
+     * for this element on some Chromium builds (observed on Samsung Internet), collapsing
+     * the drawer to a small anchor-sized box instead of a full-viewport drawer.
+     * position the drawer statically below the topbar instead of relying on anchor positioning. */
+    position-area: none;
+    inset-inline-start: 0;
+    top: calc(var(--topbar-height) + var(--info-banner-height));
     width: 100dvw;
 
     /* prevent body scrolling with overscroll behaviour and full height */
     overscroll-behavior: none;
-    height: calc(100dvh - anchor-size(height) - var(--info-banner-height));
+    height: calc(100dvh - var(--topbar-height) - var(--info-banner-height));
 
     @variant dark {
       background-color: var(--color-zinc-950);

--- a/src/test/java/de/focusshift/zeiterfassung/ui/NavigationUIIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/ui/NavigationUIIT.java
@@ -1,0 +1,70 @@
+package de.focusshift.zeiterfassung.ui;
+
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.BoundingBox;
+import de.focusshift.zeiterfassung.SingleTenantPostgreSQLContainer;
+import de.focusshift.zeiterfassung.TestKeycloakContainer;
+import de.focusshift.zeiterfassung.ui.extension.UiIntegrationTest;
+import de.focusshift.zeiterfassung.ui.extension.UiTest;
+import de.focusshift.zeiterfassung.ui.pages.LoginPage;
+import de.focusshift.zeiterfassung.ui.pages.NavigationPage;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static de.focusshift.zeiterfassung.ui.pages.LoginPage.Credentials.USER;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@Testcontainers(parallel = true)
+@UiIntegrationTest
+@UiTest
+class NavigationUIIT {
+
+    // narrower than the `desktop` breakpoint (1280px) so the mobile hamburger menu / drawer is used
+    private static final int MOBILE_VIEWPORT_WIDTH = 390;
+    private static final int MOBILE_VIEWPORT_HEIGHT = 844;
+
+    @LocalServerPort
+    private int port;
+
+    @Container
+    private static final SingleTenantPostgreSQLContainer postgre = new SingleTenantPostgreSQLContainer();
+    @Container
+    private static final TestKeycloakContainer keycloak = new TestKeycloakContainer();
+
+    @DynamicPropertySource
+    static void containerProperties(DynamicPropertyRegistry registry) {
+        postgre.configureSpringDataSource(registry);
+        keycloak.configureSpringDataSource(registry);
+    }
+
+    @Test
+    void ensureMobileNavigationDrawerOpensFullyAndShowsLinks(Page page) {
+
+        page.setViewportSize(MOBILE_VIEWPORT_WIDTH, MOBILE_VIEWPORT_HEIGHT);
+
+        final LoginPage loginPage = new LoginPage(page, port);
+        final NavigationPage navigationPage = new NavigationPage(page);
+
+        loginPage.login(USER);
+
+        navigationPage.openMobileMenu();
+
+        assertThat(navigationPage.mobileMenu()).isVisible();
+        assertThat(navigationPage.timeEntryLink()).isVisible();
+
+        // regression guard: the drawer previously collapsed to a small anchor-sized box (a few dozen px)
+        // instead of covering the viewport, on browsers where the anchor-positioning-based sizing broke.
+        final BoundingBox box = navigationPage.mobileMenu().boundingBox();
+        Assertions.assertThat(box).isNotNull();
+        Assertions.assertThat(box.width).isGreaterThan(MOBILE_VIEWPORT_WIDTH * 0.9);
+        Assertions.assertThat(box.height).isGreaterThan(MOBILE_VIEWPORT_HEIGHT * 0.5);
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/ui/pages/NavigationPage.java
+++ b/src/test/java/de/focusshift/zeiterfassung/ui/pages/NavigationPage.java
@@ -12,6 +12,9 @@ import static com.microsoft.playwright.options.WaitForSelectorState.VISIBLE;
  */
 public class NavigationPage {
 
+    private static final String MOBILE_MENU_TOGGLE_SELECTOR = "button[popovertarget=navigation]";
+    private static final String MOBILE_MENU_SELECTOR = "#navigation";
+
     private final Page page;
     private final AvatarMenu avatarMenu;
 
@@ -38,6 +41,21 @@ public class NavigationPage {
 
     public void goToReportsPage() {
         goTo(reportsLink());
+    }
+
+    /**
+     * Opens the mobile navigation drawer by clicking the hamburger menu button, which is only visible below the
+     * desktop breakpoint.
+     */
+    public void openMobileMenu() {
+        page.locator(MOBILE_MENU_TOGGLE_SELECTOR).click();
+    }
+
+    /**
+     * @return the mobile navigation drawer element itself
+     */
+    public Locator mobileMenu() {
+        return page.locator(MOBILE_MENU_SELECTOR);
     }
 
     public Locator timeEntryLink() {


### PR DESCRIPTION
Fixes the mobile navigation drawer on Samsung Internet, where it opens as a small box near the menu button with no visible navigation links instead of the full-viewport drawer.

Same bug and same fix as urlaubsverwaltung/urlaubsverwaltung#6434 / urlaubsverwaltung/urlaubsverwaltung#6435 — the navigation CSS here was identical.

## Root cause

The drawer (`<nav id="navigation" popover>`) got its geometry entirely from CSS Anchor Positioning: `position-area`/`top: calc(anchor(bottom) + …)` inherited from the shared `.popover` class, plus `height: calc(100dvh - anchor-size(height) - var(--info-banner-height))`. Those resolve unreliably for this element on Samsung Internet — the `height` declaration is dropped and the popover falls back to the browser's default `[popover]` box (small, centered, content-sized).

Not a stuck transition: same result with animations/reduce-motion disabled. Note upstream first tried adding an explicit `anchor-name`/`position-anchor` pair, which did **not** fix it on a real device — so this isn't about the implicit-vs-explicit anchor distinction.

## Change

The drawer is positioned statically below the topbar using the existing `--topbar-height`/`--info-banner-height` variables instead of relying on anchor positioning. The other anchored popovers (avatar menu, launchpad, nav tooltip, user search) are untouched since those are confirmed working. Desktop is unaffected — `@variant desktop` already sets `position: static` and `width: 100%` on `.navigation`, so the new inset/top declarations are inert there.

## Verification

- [x] New Playwright regression test `NavigationUIIT` opens the app at a 390×844 viewport, opens the drawer, and asserts the drawer plus a navigation link are visible and that the drawer's bounding box covers >90% of the viewport width and >50% of its height — green
- [x] Confirmed the test bites: temporarily shrinking the drawer to `width: 120px` turns it red (`Expecting actual: 120.0 to be greater than: 351.0`), restoring the fix turns it green
- [ ] Visual confirmation on a real Samsung Internet device

The Samsung-Internet-specific quirk cannot be reproduced in CI's Chromium, so the test guards the resulting drawer geometry rather than the browser bug itself.

Closes #2199
