### PR TITLE
Push release notes and release version in one commit

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -129,28 +129,20 @@ jobs:
           changelog-file: ${{format('{0}{1}{2}', '.chglog/', github.event.inputs.releaseVersion, '.md')}}
           config-file: '.github/release-notes.yml'
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit Release Notes
-        run: |
-          git add .chglog/*.md
-          git commit -m "[skip ci] Add release notes for version ${{ github.event.inputs.releaseVersion }}"
-      - name: Push Release Notes
-        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c
-        with:
-          github_token: ${{ secrets.AM_PAT }}
-          branch: ${{ github.ref }}
-
       - name: Set release version
         run: ./mvnw versions:set -DnewVersion=${{ github.event.inputs.releaseVersion }}
-      - name: Commit release version
-        run: git add pom.xml && git commit -m "New Release Version zeiterfassung-${{ github.event.inputs.releaseVersion }}"
+      - name: Commit release notes and release version
+        run: |
+          git add .chglog/*.md pom.xml
+          git commit -m "New Release Version zeiterfassung-${{ github.event.inputs.releaseVersion }}"
       - name: Add release tag
         run: git tag -a -m "zeiterfassung-${{ github.event.inputs.releaseVersion }}" zeiterfassung-${{ github.event.inputs.releaseVersion }}
-      - name: Push release version
+      - name: Push release notes and release version
         uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c
         with:
           github_token: ${{ secrets.AM_PAT }}
           branch: ${{ github.ref }}
+          pull: true
 
       - name: Set new snapshot version
         run: ./mvnw versions:set -DnewVersion=${{ github.event.inputs.nextVersion }}
@@ -161,3 +153,4 @@ jobs:
         with:
           github_token: ${{ secrets.AM_PAT }}
           branch: ${{ github.ref }}
+          pull: true


### PR DESCRIPTION
The release notes and the release version were committed and pushed separately, which meant two pushes and a window in which the branch carried the release notes but not yet the new version.

Both changes are now a single commit, pushed atomically together with the release tag. All pushes pull (rebase) beforehand so a moved remote branch does not fail the release.


Here are some things you should have thought about:

**Multi-Tenancy**
- [ ] Extended new entities with `AbstractTenantAwareEntity`?
- [ ] New entity added to `TenantAwareDatabaseConfiguration`?
- [ ] Tested with `dev-multitenant` profile?

<!--

Thanks for contributing to the zeiterfassung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@focus-shift.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
