### PR TITLE
Fix `report/month` and `report/week` navigation links losing the servlet context path behind a reverse proxy

### DIFF
--- a/src/main/resources/templates/reports/_user-select.html
+++ b/src/main/resources/templates/reports/_user-select.html
@@ -14,7 +14,7 @@
       th:if="${userReportFilterUrl != null}"
       th:with="personsSelected=${allUsersSelected or !#lists.isEmpty(selectedUserIds)}"
       action="#"
-      th:action="${userReportFilterUrl}"
+      th:action="@{__${userReportFilterUrl}__}"
       method="get"
       class="report-actions__persons"
       th:classappend="${personsSelected ? 'report-actions__persons--persons-selected' : ''}"

--- a/src/main/resources/templates/reports/user-report-month.html
+++ b/src/main/resources/templates/reports/user-report-month.html
@@ -17,7 +17,7 @@
       >
         <a
           href="#"
-          th:href="${userReportPreviousSectionUrl}"
+          th:href="@{__${userReportPreviousSectionUrl}__}"
           class="button-primary button-primary-icon"
         >
           <svg
@@ -29,7 +29,7 @@
         </a>
         <a
           href="#"
-          th:href="${userReportTodaySectionUrl}"
+          th:href="@{__${userReportTodaySectionUrl}__}"
           class="button-primary button-primary-icon flex-1 justify-center xs:flex-none xs:justify-normal"
           th:text="#{report.month.navigation.button.today}"
         >
@@ -37,7 +37,7 @@
         </a>
         <a
           href="#"
-          th:href="${userReportNextSectionUrl}"
+          th:href="@{__${userReportNextSectionUrl}__}"
           class="button-primary button-primary-icon"
         >
           <svg
@@ -51,7 +51,7 @@
       <form th:replace="~{reports/_user-select::form}" />
       <a
         href="#"
-        th:href="${userReportCsvDownloadUrl}"
+        th:href="@{__${userReportCsvDownloadUrl}__}"
         download
         class="report-actions__csv button-secondary"
         th:text="#{report.month.button.csv-download}"

--- a/src/main/resources/templates/reports/user-report-week.html
+++ b/src/main/resources/templates/reports/user-report-week.html
@@ -17,7 +17,7 @@
       >
         <a
           href="#"
-          th:href="${userReportPreviousSectionUrl}"
+          th:href="@{__${userReportPreviousSectionUrl}__}"
           class="button-primary button-primary-icon"
         >
           <svg
@@ -31,7 +31,7 @@
         </a>
         <a
           href="#"
-          th:href="${userReportTodaySectionUrl}"
+          th:href="@{__${userReportTodaySectionUrl}__}"
           class="button-primary flex-1 justify-center xs:flex-none xs:justify-normal"
           th:text="#{report.month.navigation.button.today}"
         >
@@ -39,7 +39,7 @@
         </a>
         <a
           href="#"
-          th:href="${userReportNextSectionUrl}"
+          th:href="@{__${userReportNextSectionUrl}__}"
           class="button-primary button-primary-icon"
         >
           <svg
@@ -53,7 +53,7 @@
       <form th:replace="~{reports/_user-select::form}" />
       <a
         href="#"
-        th:href="${userReportCsvDownloadUrl}"
+        th:href="@{__${userReportCsvDownloadUrl}__}"
         download
         class="report-actions__csv button-secondary"
         th:text="#{report.week.button.csv-download}"


### PR DESCRIPTION
# Fix `report/month` and `report/week` navigation links losing the servlet context path behind a reverse proxy

## Problem

When Zeiterfassung is deployed behind a reverse proxy with a non-root context path, e.g.:

```.properties
SERVER_SERVLET_CONTEXT_PATH=/zeiterfassung
SERVER_FORWARD_HEADERS_STRATEGY=native
```

almost every generated link correctly includes the `/zeiterfassung/` prefix - except the pagination links ("previous", "today", "next") and the CSV download link on the `report/month` and `report/week` views, plus the person-filter form on both. Clicking "next month", for example, takes the browser from

```
https://.../zeiterfassung/report/month
```

to

```
https://.../report/year/2026/month/9
```

i.e. the context path is silently dropped, and the request 404s at the reverse proxy / servlet container.

The cause is in the Thymeleaf fragments `user-report-month.html`, `user-report-week.html` and `_user-select.html`. The controllers (ReportMonthController, ReportWeekController) build these URLs as plain root-relative strings via `ReportViewHelper.createUrl(...)` (e.g. `"/report/year/2026/month/9"`) and pass them into the model. The templates then rendered them with a **plain Thymeleaf variable expression**:

```.html
th:href="${userReportNextSectionUrl}"
```

A plain `${...}` expression is emitted verbatim by Thymeleaf. Context-path rewriting (and forwarded-prefix awareness via `ServletUriComponentsBuilder`/`RequestContext`) only happens for Thymeleaf's **link-expression syntax `@{...}`**. Since these attributes never used `@{...}`, the context path was never prepended - regardless of forward-headers configuration. The rest of the app (`_navigation.html`, `_report-time-entries.html`, `timeentries/index.html`, etc.) consistently uses `@{__${...}__}` for exactly this reason, which is why other links worked correctly and only these stood out.

## Solution

Wrap the affected `th:href` / `th:action` attributes in the `@{__${...}__}` link-expression idiom already used elsewhere in the codebase, so Thymeleaf applies the servlet context path / forwarded prefix the same way it does for every other internal link.

No controller or model changes were necessary - the underlying URLs were always correct, only the rendering syntax was wrong.

## Changes

- **`user-report-month.html`** - `previous`/`today`/`next` pagination links and the CSV download link now use `@{__${...}__}` instead of `${...}`.
- **`user-report-week.html`** - same fix for its `previous`/`today`/`next` pagination links and CSV download link.
- **`_user-select.html`** - the person-filter `<form>`'s `th:action` now uses `@{__${userReportFilterUrl}__}` instead of `${userReportFilterUrl}`.

No Java changes were required; `ReportViewHelper.createUrl(...)` already returns correct context-relative paths (optionally with query parameters), they just weren't being routed through Thymeleaf's URL-rewriting mechanism.

## Testing

Verified manually by setting `server.servlet.context-path=/zeiterfassung` locally and confirming that:

- The "previous", "today", "next", and CSV download links on `/zeiterfassung/report/month` and `/zeiterfassung/report/year/{year}/month/{month}` all render with the `/zeiterfassung/` prefix.
- Same for `/zeiterfassung/report/week` and `/zeiterfassung/report/year/{year}/week/{week}`.
- The person-filter form on both views posts to a URL containing the `/zeiterfassung/` prefix.
- Existing controller/model attribute tests (`ReportMonthControllerTest`, `ReportWeekControllerTest`) still pass unchanged, since they assert on the raw model attribute values, not the rendered HTML.