### PR TITLE
build(deps): bump tomcat from 11.0.24 to 11.0.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     <excluded.groups>a11y</excluded.groups>
     <java.version>25</java.version>
+    <tomcat.version>11.0.25</tomcat.version>
 
     <node.env>production</node.env>
     <docker-publish-registry>registry.example.com</docker-publish-registry>


### PR DESCRIPTION
Hebt den embedded Tomcat von 11.0.24 auf 11.0.25.

Spring Boot 4.1.1 verwaltet noch 11.0.24, deshalb wird die Version übergangsweise per `tomcat.version`-Property in der `pom.xml` gesetzt. Sobald Spring Boot selbst auf 11.0.25 oder höher zeigt, kann das Property wieder raus.

Mit 11.0.25 sind elf Sicherheitslücken geschlossen worden, vier davon als *Important* eingestuft (`CVE-2026-65182`, `CVE-2026-65927`, `CVE-2026-68569`, `CVE-2026-68763`). Die vollständige Liste inklusive Einschätzung, warum die Zeiterfassung nach aktuellem Stand von keinem der Punkte akut betroffen ist, steht in #2254.

Analog zur Urlaubsverwaltung, siehe urlaubsverwaltung/urlaubsverwaltung#6606.

Verifikation:
* `./mvnw dependency:list` löst `tomcat-embed-core`, `tomcat-embed-websocket` und `tomcat-embed-el` auf `11.0.25` auf
* `./mvnw test -DskipITs`: BUILD SUCCESS – 1273 Java-Tests (142 Testklassen), 0 Failures, 0 Errors, plus 76 Frontend-Tests (vitest)

**Multi-Tenancy**

Keine Entitäten oder Datenbankänderungen, daher nicht relevant.

closes #2254
