### PR TITLE
build(deps): bump rabbitmq amqp-client from 5.30.0 to 5.33.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <excluded.groups>a11y</excluded.groups>
     <java.version>25</java.version>
     <tomcat.version>11.0.25</tomcat.version>
+    <rabbit-amqp-client.version>5.33.1</rabbit-amqp-client.version>
 
     <node.env>production</node.env>
     <docker-publish-registry>registry.example.com</docker-publish-registry>


### PR DESCRIPTION
Hebt den RabbitMQ Java Client von 5.30.0 auf 5.33.1.

Spring Boot 4.1.1 verwaltet noch 5.30.0, deshalb wird die Version übergangsweise per `rabbit-amqp-client.version`-Property in der `pom.xml` gesetzt. Sobald Spring Boot selbst auf ≥ 5.33.1 zeigt, kann das Property wieder raus.

Für 5.30.0 sind sechs Advisories offen, zwei davon als *High* eingestuft und erst in 5.33.1 behoben (`CVE-2026-69219`, `CVE-2026-69220` – beide im `ValueReader`). Mit 5.33.1 sind alle sechs abgedeckt. Die vollständige Liste inklusive Einschätzung, warum die Zeiterfassung nach aktuellem Stand von keinem der Punkte akut betroffen ist, steht in #2256.

Analog zum Vorgehen beim embedded Tomcat in #2255.

Verifikation:
* `./mvnw dependency:list` löst `com.rabbitmq:amqp-client` auf `5.33.1` auf (und `tomcat-embed-core` weiterhin auf `11.0.25`)
* `./mvnw verify` (nach Rebase auf `main`): BUILD SUCCESS – komplette Unit-Test-Suite plus 20 RabbitMQ-Integrationstests (8 IT-Klassen, testcontainers), 0 Failures, 0 Errors

**Multi-Tenancy**

Keine Entitäten oder Datenbankänderungen, daher nicht relevant.

closes #2256
