### PR TITLE
Kontextpfad in Templates absichern

### DIFF
--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -41,7 +41,7 @@
                 th:text="#{error-page.goto.previous}"
               ></a>
               <a
-                href="/"
+                th:href="@{/}"
                 class="button-secondary"
                 th:text="#{error-page.goto.start}"
               ></a>
@@ -49,7 +49,7 @@
           </div>
           <div class="px-8 text-center xs:px-16 sm:text-right">
             <img
-              src="/images/403_sloth.svg"
+              th:src="@{/images/403_sloth.svg}"
               width="345"
               height="402"
               alt=""

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -41,14 +41,14 @@
                 th:text="#{error-page.goto.previous}"
               ></a>
               <a
-                href="/"
+                th:href="@{/}"
                 class="button-secondary"
                 th:text="#{error-page.goto.start}"
               ></a>
             </div>
           </div>
           <img
-            src="/images/404_sloth.svg"
+            th:src="@{/images/404_sloth.svg}"
             width="323"
             height="407"
             alt=""

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -41,14 +41,14 @@
                 th:text="#{error-page.goto.previous}"
               ></a>
               <a
-                href="/"
+                th:href="@{/}"
                 class="button-secondary"
                 th:text="#{error-page.goto.start}"
               ></a>
             </div>
           </div>
         </div>
-        <img src="/images/5xx_sloth.svg" alt="" class="mt-8" />
+        <img th:src="@{/images/5xx_sloth.svg}" alt="" class="mt-8" />
       </main>
     </th:block>
   </body>

--- a/src/main/resources/templates/user/user-settings.html
+++ b/src/main/resources/templates/user/user-settings.html
@@ -150,7 +150,7 @@
                     >
                       <img
                         src="#"
-                        th:src="|/images/user-settings-theme-${#strings.toLowerCase(selectableTheme.value)}.png|"
+                        th:src="@{/images/user-settings-theme-{theme}.png(theme=${#strings.toLowerCase(selectableTheme.value)})}"
                         width="323"
                         height="200"
                         class="w-full h-auto block"

--- a/src/test/java/de/focusshift/zeiterfassung/ThymeleafContextPathGotchasTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/ThymeleafContextPathGotchasTest.java
@@ -1,0 +1,161 @@
+package de.focusshift.zeiterfassung;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the templates against links that silently lose the servlet context path when the application is deployed
+ * at a subpath (e.g. {@code server.servlet.context-path=/zeiterfassung} behind a reverse proxy).
+ *
+ * <p>Thymeleaf only applies the context path to <strong>link expressions</strong> {@code @{...}} - the
+ * {@code StandardLinkBuilder} prepends {@code request.getApplicationPath()} there. Two shapes bypass that:
+ *
+ * <ul>
+ *   <li>{@code th:href="${url}"} - a plain variable expression is written out verbatim. Route the value through the
+ *       preprocessing idiom {@code th:href="@{__${url}__}"} instead.</li>
+ *   <li>{@code href="/foo"} - a hardcoded absolute path without any {@code th:} attribute is not touched by Thymeleaf
+ *       at all. Use {@code th:href="@{/foo}"} instead.</li>
+ * </ul>
+ *
+ * <p>This has been fixed three times now (#2182, #2217, #2258) because nothing made it visible to the build.
+ *
+ * @see <a href="https://github.com/urlaubsverwaltung/zeiterfassung/issues/2258">#2258</a>
+ */
+class ThymeleafContextPathGotchasTest {
+
+    private static final Path TEMPLATES = Path.of("src", "main", "resources", "templates");
+
+    private static final Pattern THYMELEAF_URL_ATTRIBUTE =
+        Pattern.compile("\\b(th:href|th:action|th:src)=\"([^\"]*)\"");
+
+    private static final Pattern HARDCODED_ABSOLUTE_URL_ATTRIBUTE =
+        Pattern.compile("(?<!:)\\b(href|action|src)=\"(/[^/\"][^\"]*)\"");
+
+    /**
+     * Values that are intentionally emitted without a link expression of their own, keyed by template and expression
+     * so the entries survive reformatting. Every entry needs a reason - if you cannot give one, the link is a bug.
+     */
+    private static final Set<AllowedRawUrl> ALLOWED_RAW_URLS = Set.of(
+        new AllowedRawUrl("error/403.html", "${previousPageLink}", "the Referer header, an already absolute URL"),
+        new AllowedRawUrl("error/404.html", "${previousPageLink}", "the Referer header, an already absolute URL"),
+        new AllowedRawUrl("error/5xx.html", "${previousPageLink}", "the Referer header, an already absolute URL"),
+        new AllowedRawUrl("launchpad/launchpad.html", "${app.url}", "URL of another application, not ours"),
+        new AllowedRawUrl("launchpad/launchpad.html", "${app.icon}", "icon of another application, not ours"),
+        new AllowedRawUrl("_navigation.html", "${menuHelpUrl}", "externally configured help URL"),
+        new AllowedRawUrl("_top.html", "${href}", "fragment parameter, callers pass an @{...} resolved value"),
+        new AllowedRawUrl("timeentries/fragments/time-entry-form.html", "${formAction}", "fragment parameter, callers pass an @{...} resolved value"),
+        new AllowedRawUrl("timeentries/index.html", "${href}", "resolved with @{...} in a th:with right above"),
+        new AllowedRawUrl("timeentries/index.html", "${viewedUser == null ? myself : other}", "both branches are resolved with @{...} in a th:with right above")
+    );
+
+    @Test
+    void ensureUrlAttributesUseLinkExpressions() {
+
+        final List<String> violations = new ArrayList<>();
+
+        forEachTemplateLine((template, lineNumber, line) -> {
+            final Matcher matcher = THYMELEAF_URL_ATTRIBUTE.matcher(line);
+            while (matcher.find()) {
+                final String attribute = matcher.group(1);
+                final String expression = matcher.group(2);
+                if (expression.contains("@{")) {
+                    // already a link expression, or a ternary between two of them
+                    continue;
+                }
+                if (ALLOWED_RAW_URLS.contains(new AllowedRawUrl(template, expression, null))) {
+                    continue;
+                }
+                violations.add("%s:%d %s=\"%s\"".formatted(template, lineNumber, attribute, expression));
+            }
+        });
+
+        assertThat(violations)
+            .as("""
+                These attributes are written out verbatim, so the servlet context path is lost when the application \
+                is deployed at a subpath. Wrap the value in Thymeleaf's link expression, e.g. \
+                th:href="@{__${someUrl}__}". If the URL genuinely must not be rewritten (it points somewhere else, \
+                or a caller already resolved it), add it to ALLOWED_RAW_URLS with a reason. See #2258.""")
+            .isEmpty();
+    }
+
+    @Test
+    void ensureNoHardcodedAbsoluteUrls() {
+
+        final List<String> violations = new ArrayList<>();
+
+        forEachTemplateLine((template, lineNumber, line) -> {
+            final Matcher matcher = HARDCODED_ABSOLUTE_URL_ATTRIBUTE.matcher(line);
+            while (matcher.find()) {
+                violations.add("%s:%d %s=\"%s\"".formatted(template, lineNumber, matcher.group(1), matcher.group(2)));
+            }
+        });
+
+        assertThat(violations)
+            .as("""
+                These attributes hardcode an absolute path, so Thymeleaf never sees them and the servlet context path \
+                is lost when the application is deployed at a subpath. Use a link expression instead, e.g. \
+                th:src="@{/images/sloth.svg}". See #2258.""")
+            .isEmpty();
+    }
+
+    private static void forEachTemplateLine(TemplateLineVisitor visitor) {
+        try (Stream<Path> templates = Files.walk(TEMPLATES)) {
+            templates
+                .filter(path -> path.toString().endsWith(".html"))
+                .sorted()
+                .forEach(path -> {
+                    final String template = TEMPLATES.relativize(path).toString().replace('\\', '/');
+                    final List<String> lines = readLines(path);
+                    for (int i = 0; i < lines.size(); i++) {
+                        visitor.visit(template, i + 1, lines.get(i));
+                    }
+                });
+        } catch (IOException e) {
+            throw new UncheckedIOException("could not walk " + TEMPLATES.toAbsolutePath(), e);
+        }
+    }
+
+    private static List<String> readLines(Path path) {
+        try {
+            return Files.readAllLines(path, UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException("could not read " + path, e);
+        }
+    }
+
+    @FunctionalInterface
+    private interface TemplateLineVisitor {
+        void visit(String template, int lineNumber, String line);
+    }
+
+    /**
+     * @param reason why this value must not be rewritten. Not part of equality, it only documents the entry.
+     */
+    private record AllowedRawUrl(String template, String expression, String reason) {
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof AllowedRawUrl other
+                && template.equals(other.template)
+                && expression.equals(other.expression);
+        }
+
+        @Override
+        public int hashCode() {
+            return template.hashCode() * 31 + expression.hashCode();
+        }
+    }
+}

--- a/src/test/java/de/focusshift/zeiterfassung/report/ReportTemplateContextPathTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/report/ReportTemplateContextPathTest.java
@@ -1,0 +1,128 @@
+package de.focusshift.zeiterfassung.report;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+import org.thymeleaf.TemplateSpec;
+import org.thymeleaf.context.WebContext;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+import org.thymeleaf.web.servlet.IServletWebExchange;
+import org.thymeleaf.web.servlet.JakartaServletWebApplication;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Locale.GERMANY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Renders the report navigation fragments with and without a servlet context path.
+ *
+ * <p>The controllers hand these URLs to the view as plain strings (see {@code ReportViewHelper#createUrl}), so the
+ * templates have to route them through Thymeleaf's link expression - {@code th:href="@{__${someUrl}__}"} - for the
+ * context path to be applied. A plain {@code th:href="${someUrl}"} renders verbatim and silently drops the prefix,
+ * which is what broke every pagination and CSV link when deployed at a subpath (#2217).
+ *
+ * <p>The URLs carry a query string, and these are the only {@code @{__${...}__}} usages in the code base that do.
+ * The assertions below therefore pin the full attribute value, not just the prefix, so that query parameters and
+ * their escaping stay covered too.
+ *
+ * @see <a href="https://github.com/urlaubsverwaltung/zeiterfassung/issues/2258">#2258</a>
+ */
+class ReportTemplateContextPathTest {
+
+    private static final String PREVIOUS_URL = "/report/year/2026/month/8?everyone=&user=1&user=2";
+    private static final String TODAY_URL = "/report/month?everyone=&user=1&user=2";
+    private static final String NEXT_URL = "/report/year/2026/month/10?everyone=&user=1&user=2";
+    private static final String CSV_URL = "/report/year/2026/month/9?everyone=&user=1&user=2&csv";
+    private static final String FILTER_URL = "/report/year/2026/month/9";
+
+    @ParameterizedTest(name = "{0} with context path \"{1}\"")
+    @CsvSource({
+        "reports/user-report-month, ''",
+        "reports/user-report-month, /zeiterfassung",
+        "reports/user-report-week,  ''",
+        "reports/user-report-week,  /zeiterfassung",
+    })
+    void ensureNavigationLinksRespectContextPath(String template, String contextPath) {
+
+        final String html = render(template, "chart-navigation", contextPath);
+
+        assertThat(html)
+            .as("previous")
+            .contains("href=\"%s/report/year/2026/month/8?everyone=&amp;user=1&amp;user=2\"".formatted(contextPath));
+        assertThat(html)
+            .as("today")
+            .contains("href=\"%s/report/month?everyone=&amp;user=1&amp;user=2\"".formatted(contextPath));
+        assertThat(html)
+            .as("next")
+            .contains("href=\"%s/report/year/2026/month/10?everyone=&amp;user=1&amp;user=2\"".formatted(contextPath));
+        assertThat(html)
+            .as("csv download")
+            .contains("href=\"%s/report/year/2026/month/9?everyone=&amp;user=1&amp;user=2&amp;csv\"".formatted(contextPath));
+        assertThat(html)
+            .as("person filter form of reports/_user-select")
+            .contains("action=\"%s/report/year/2026/month/9\"".formatted(contextPath));
+    }
+
+    private static String render(String template, String fragment, String contextPath) {
+
+        final MockServletContext servletContext = new MockServletContext();
+        final MockHttpServletRequest request = new MockHttpServletRequest(servletContext);
+        request.setContextPath(contextPath);
+
+        final IServletWebExchange exchange = JakartaServletWebApplication
+            .buildApplication(servletContext)
+            .buildExchange(request, new MockHttpServletResponse());
+
+        final WebContext context = new WebContext(exchange, GERMANY, model());
+
+        return templateEngine().process(new TemplateSpec(template, Set.of(fragment), TemplateMode.HTML, null), context);
+    }
+
+    private static Map<String, Object> model() {
+        return Map.of(
+            "userReportPreviousSectionUrl", PREVIOUS_URL,
+            "userReportTodaySectionUrl", TODAY_URL,
+            "userReportNextSectionUrl", NEXT_URL,
+            "userReportCsvDownloadUrl", CSV_URL,
+            // reports/_user-select is pulled in by both chart-navigation fragments
+            "userReportFilterUrl", FILTER_URL,
+            "allUsersSelected", false,
+            "selectedUserIds", List.of(1L, 2L),
+            "users", List.of(user(1L, "Bruce Wayne", "BW"), user(2L, "Clark Kent", "CK")),
+            "selectedUsers", List.of(user(1L, "Bruce Wayne", "BW"), user(2L, "Clark Kent", "CK"))
+        );
+    }
+
+    private static Map<String, Object> user(long id, String fullName, String initials) {
+        return Map.of("id", id, "fullName", fullName, "initials", initials, "selected", true);
+    }
+
+    private static SpringTemplateEngine templateEngine() {
+
+        final ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+        templateResolver.setPrefix("templates/");
+        templateResolver.setSuffix(".html");
+        templateResolver.setTemplateMode(TemplateMode.HTML);
+        templateResolver.setCharacterEncoding(UTF_8.name());
+        templateResolver.setCacheable(false);
+
+        final ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+        messageSource.setBasename("messages");
+        messageSource.setDefaultEncoding(UTF_8.name());
+
+        final SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.setTemplateResolver(templateResolver);
+        templateEngine.setTemplateEngineMessageSource(messageSource);
+
+        return templateEngine;
+    }
+}


### PR DESCRIPTION
Beim Betrieb mit gesetztem `server.servlet.context-path` gingen weitere
Links verloren, die Thymeleaf gar nicht erst zu sehen bekommt.

Behoben:

* `error/403.html`, `error/404.html`, `error/5xx.html` - der Button
  "zurück zur Startseite" war hartkodiert auf `href="/"`, die
  Sloth-Grafiken auf `src="/images/..."`
* `user/user-settings.html` - das Vorschaubild der Theme-Auswahl wurde
  über eine Literal-Substitution `|/images/...|` zusammengebaut

Damit das nicht ein viertes Mal passiert, prüfen das jetzt zwei Tests.

`ThymeleafContextPathGotchasTest` scannt alle Templates auf
`th:href`/`th:action`/`th:src` ohne Link-Expression sowie auf
hartkodierte absolute Pfade. Werte, die bewusst nicht umgeschrieben
werden dürfen (Referer, fremde URLs, Fragment-Parameter, die der
Aufrufer bereits mit `@{...}` aufgelöst hat), stehen mit Begründung in
einer Allowlist. Den Fund in `user-settings.html` hat genau dieser Scan
geliefert.

`ReportTemplateContextPathTest` rendert die Report-Fragmente mit und ohne
Kontextpfad gegen eine echte Thymeleaf-Engine und prüft die erzeugten
URLs. Die Report-Links aus #2217 sind die einzigen
`@{__${...}__}`-Verwendungen im Projekt, die einen Query-String tragen,
deshalb wird der vollständige Attributwert samt Parametern und Escaping
geprüft und nicht nur der Präfix.

Verifikation:

* `./mvnw test`: BUILD SUCCESS, 1316 Tests, 0 Failures
* beide Tests schlagen nachweislich fehl, wenn man den Fehler wieder
  einbaut - der Scan meldet Datei und Zeile, der Rendering-Test schlägt
  in genau den beiden Fällen mit gesetztem Kontextpfad fehl und bleibt
  bei Deployment auf `/` grün

**Multi-Tenancy**

Keine Entitäten oder Datenbankänderungen, daher nicht relevant.

closes #2258
