### PR TITLE
Feature: Make time-entry form fields configurable

### DIFF
--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportMonthController.java
@@ -6,6 +6,7 @@ import de.focusshift.zeiterfassung.search.UserSearchViewHelper;
 import de.focusshift.zeiterfassung.security.CurrentUser;
 import de.focusshift.zeiterfassung.security.oidc.CurrentOidcUser;
 import de.focusshift.zeiterfassung.timeclock.HasTimeClock;
+import de.focusshift.zeiterfassung.timeentry.HasTimeEntryForm;
 import de.focusshift.zeiterfassung.timeentry.ShouldWorkingHours;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryDTO;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryDialogHelper;
@@ -52,7 +53,7 @@ import static org.springframework.web.servlet.mvc.method.annotation.MvcUriCompon
 import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.on;
 
 @Controller
-class ReportMonthController implements HasTimeClock, HasLaunchpad, HasUserSearch {
+class ReportMonthController implements HasTimeClock, HasLaunchpad, HasUserSearch, HasTimeEntryForm {
 
     private static final Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());
 

--- a/src/main/java/de/focusshift/zeiterfassung/report/ReportWeekController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/report/ReportWeekController.java
@@ -6,6 +6,7 @@ import de.focusshift.zeiterfassung.search.UserSearchViewHelper;
 import de.focusshift.zeiterfassung.security.CurrentUser;
 import de.focusshift.zeiterfassung.security.oidc.CurrentOidcUser;
 import de.focusshift.zeiterfassung.timeclock.HasTimeClock;
+import de.focusshift.zeiterfassung.timeentry.HasTimeEntryForm;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryDTO;
 import de.focusshift.zeiterfassung.timeentry.TimeEntryDialogHelper;
 import de.focusshift.zeiterfassung.usermanagement.User;
@@ -48,7 +49,7 @@ import static org.springframework.web.servlet.mvc.method.annotation.MvcUriCompon
 import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.on;
 
 @Controller
-class ReportWeekController implements HasTimeClock, HasLaunchpad, HasUserSearch {
+class ReportWeekController implements HasTimeClock, HasLaunchpad, HasUserSearch, HasTimeEntryForm {
 
     private static final Logger LOG = LoggerFactory.getLogger(lookup().lookupClass());
 

--- a/src/main/java/de/focusshift/zeiterfassung/settings/SettingsController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/SettingsController.java
@@ -67,7 +67,8 @@ class SettingsController implements HasLaunchpad, HasTimeClock, HasUserSearch {
         final FederalStateSettings federalStateSettings = settingsService.getFederalStateSettings();
         final LockTimeEntriesSettings lockTimeEntriesSettings = settingsService.getLockTimeEntriesSettings();
         final Optional<SubtractBreakFromTimeEntrySettings> subtractBreakFromTimeEntrySettings = settingsService.getSubtractBreakFromTimeEntrySettings();
-        final SettingsDto settingsDto = toSettingsDto(federalStateSettings, lockTimeEntriesSettings, subtractBreakFromTimeEntrySettings.orElse(null));
+        final TimeEntrySettings timeEntrySettings = settingsService.getTimeEntrySettings();
+        final SettingsDto settingsDto = toSettingsDto(federalStateSettings, lockTimeEntriesSettings, subtractBreakFromTimeEntrySettings.orElse(null), timeEntrySettings);
 
         prepareModel(model, locale, settingsDto);
 
@@ -116,6 +117,8 @@ class SettingsController implements HasLaunchpad, HasTimeClock, HasUserSearch {
             settingsService.updateSubtractBreakFromTimeEntrySettings(subtractBreakFromTimeEntryIsActive, timestamp);
         }
 
+        settingsService.updateTimeEntrySettings(settingsDto.commentEnabled(), settingsDto.durationEnabled(), settingsDto.breakEnabled());
+
         return new ModelAndView("redirect:/settings");
     }
 
@@ -141,7 +144,8 @@ class SettingsController implements HasLaunchpad, HasTimeClock, HasUserSearch {
     private SettingsDto toSettingsDto(
         FederalStateSettings federalStateSettings,
         LockTimeEntriesSettings lockTimeEntriesSettings,
-        @Nullable SubtractBreakFromTimeEntrySettings subtractBreakFromTimeEntrySettings
+        @Nullable SubtractBreakFromTimeEntrySettings subtractBreakFromTimeEntrySettings,
+        TimeEntrySettings timeEntrySettings
     ) {
 
         final ZoneId userZoneId = userSettingsProvider.zoneId();
@@ -162,7 +166,10 @@ class SettingsController implements HasLaunchpad, HasTimeClock, HasUserSearch {
             lockTimeEntriesSettings.lockingIsActive(),
             lockTimeEntriesDaysInPast > -1 ? String.valueOf(lockTimeEntriesDaysInPast) : null,
             subtractBreakFromTimeEntryIsActive,
-            subtractBreakFromTimeEntryIsActiveDate
+            subtractBreakFromTimeEntryIsActiveDate,
+            timeEntrySettings.commentEnabled(),
+            timeEntrySettings.durationEnabled(),
+            timeEntrySettings.breakEnabled()
         );
     }
 

--- a/src/main/java/de/focusshift/zeiterfassung/settings/SettingsDto.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/SettingsDto.java
@@ -19,8 +19,24 @@ record SettingsDto(
     Boolean subtractBreakFromTimeEntryIsActive,
     @Nullable
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    LocalDate subtractBreakFromTimeEntryActiveDate
+    LocalDate subtractBreakFromTimeEntryActiveDate,
+
+    boolean commentEnabled,
+    boolean durationEnabled,
+    boolean breakEnabled
 ) {
+
+    SettingsDto(
+        FederalState federalState,
+        boolean worksOnPublicHoliday,
+        boolean lockingIsActive,
+        @Nullable String lockTimeEntriesDaysInPast,
+        @Nullable Boolean subtractBreakFromTimeEntryIsActive,
+        @Nullable LocalDate subtractBreakFromTimeEntryActiveDate
+    ) {
+        this(federalState, worksOnPublicHoliday, lockingIsActive, lockTimeEntriesDaysInPast,
+            subtractBreakFromTimeEntryIsActive, subtractBreakFromTimeEntryActiveDate, true, true, true);
+    }
 
     /**
      * Returns the user input string as number, or {@code null} when there is no value, or it is not a number.

--- a/src/main/java/de/focusshift/zeiterfassung/settings/SettingsService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/SettingsService.java
@@ -18,13 +18,14 @@ import static java.util.stream.StreamSupport.stream;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Service
-class SettingsService implements FederalStateSettingsService, LockTimeEntriesSettingsService, SubtractBreakFromTimeEntrySettingsService {
+class SettingsService implements FederalStateSettingsService, LockTimeEntriesSettingsService, SubtractBreakFromTimeEntrySettingsService, TimeEntrySettingsService {
 
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
     private final FederalStateSettingsRepository federalStateSettingsRepository;
     private final LockTimeEntriesSettingsRepository lockTimeEntriesSettingsRepository;
     private final SubtractBreakFromTimeEntrySettingsRepository subtractBreakFromTimeEntrySettingsRepository;
+    private final TimeEntrySettingsRepository timeEntrySettingsRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final Clock clock;
 
@@ -32,12 +33,14 @@ class SettingsService implements FederalStateSettingsService, LockTimeEntriesSet
         FederalStateSettingsRepository federalStateSettingsRepository,
         LockTimeEntriesSettingsRepository lockTimeEntriesSettingsRepository,
         SubtractBreakFromTimeEntrySettingsRepository subtractBreakFromTimeEntrySettingsRepository,
+        TimeEntrySettingsRepository timeEntrySettingsRepository,
         ApplicationEventPublisher applicationEventPublisher,
         Clock clock
     ) {
         this.federalStateSettingsRepository = federalStateSettingsRepository;
         this.lockTimeEntriesSettingsRepository = lockTimeEntriesSettingsRepository;
         this.subtractBreakFromTimeEntrySettingsRepository = subtractBreakFromTimeEntrySettingsRepository;
+        this.timeEntrySettingsRepository = timeEntrySettingsRepository;
         this.applicationEventPublisher = applicationEventPublisher;
         this.clock = clock;
     }
@@ -60,6 +63,13 @@ class SettingsService implements FederalStateSettingsService, LockTimeEntriesSet
     public Optional<SubtractBreakFromTimeEntrySettings> getSubtractBreakFromTimeEntrySettings() {
         return getSubtractBreakFromTimeEntrySettingsEntity()
             .map(SettingsService::toSubtractBreakFromTimeEntrySettings);
+    }
+
+    @Override
+    public TimeEntrySettings getTimeEntrySettings() {
+        return getTimeEntrySettingsEntity()
+            .map(SettingsService::toTimeEntrySettings)
+            .orElse(TimeEntrySettings.DEFAULT);
     }
 
     /**
@@ -129,6 +139,16 @@ class SettingsService implements FederalStateSettingsService, LockTimeEntriesSet
         return toSubtractBreakFromTimeEntrySettings(saved);
     }
 
+    TimeEntrySettings updateTimeEntrySettings(boolean commentEnabled, boolean durationEnabled, boolean breakEnabled) {
+
+        final TimeEntrySettingsEntity entity = getTimeEntrySettingsEntity().orElseGet(TimeEntrySettingsEntity::new);
+        entity.setCommentEnabled(commentEnabled);
+        entity.setDurationEnabled(durationEnabled);
+        entity.setBreakEnabled(breakEnabled);
+
+        return toTimeEntrySettings(timeEntrySettingsRepository.save(entity));
+    }
+
     private Optional<FederalStateSettingsEntity> getFederalStateEntity() {
         // `findFirst` is sufficient as there exists only one FederalStateSettingsEntity per tenant.
         // however, the tenantId is handled transparently in the background. and we only have the public API of `findAll`.
@@ -166,6 +186,11 @@ class SettingsService implements FederalStateSettingsService, LockTimeEntriesSet
         return stream(settings.spliterator(), false).findFirst();
     }
 
+    private Optional<TimeEntrySettingsEntity> getTimeEntrySettingsEntity() {
+        final Iterable<TimeEntrySettingsEntity> settings = timeEntrySettingsRepository.findAll();
+        return stream(settings.spliterator(), false).findFirst();
+    }
+
     private static FederalStateSettings toFederalStateSettings(FederalStateSettingsEntity federalStateSettingsEntity) {
         return new FederalStateSettings(
             federalStateSettingsEntity.getFederalState(),
@@ -185,5 +210,9 @@ class SettingsService implements FederalStateSettingsService, LockTimeEntriesSet
             entity.isSubtractBreakFromTimeEntryIsActive(),
             Optional.ofNullable(entity.getSubtractBreakFromTimeEntryEnabledTimestamp())
         );
+    }
+
+    private static TimeEntrySettings toTimeEntrySettings(TimeEntrySettingsEntity entity) {
+        return new TimeEntrySettings(entity.isCommentEnabled(), entity.isDurationEnabled(), entity.isBreakEnabled());
     }
 }

--- a/src/main/java/de/focusshift/zeiterfassung/settings/TimeEntrySettings.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/TimeEntrySettings.java
@@ -1,0 +1,6 @@
+package de.focusshift.zeiterfassung.settings;
+
+public record TimeEntrySettings(boolean commentEnabled, boolean durationEnabled, boolean breakEnabled) {
+
+    public static final TimeEntrySettings DEFAULT = new TimeEntrySettings(true, true, true);
+}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/TimeEntrySettingsEntity.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/TimeEntrySettingsEntity.java
@@ -1,0 +1,93 @@
+package de.focusshift.zeiterfassung.settings;
+
+import de.focusshift.zeiterfassung.tenancy.tenant.AbstractTenantAwareEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+@Entity(name = "settings_time_entry")
+public class TimeEntrySettingsEntity extends AbstractTenantAwareEntity {
+
+    @Id
+    @Column(name = "id", unique = true, nullable = false, updatable = false)
+    @SequenceGenerator(name = "settings_time_entry_seq", sequenceName = "settings_time_entry_seq", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "settings_time_entry_seq")
+    protected Long id;
+
+    @NotNull
+    @Column(name = "comment_enabled", nullable = false)
+    private boolean commentEnabled;
+
+    @NotNull
+    @Column(name = "duration_enabled", nullable = false)
+    private boolean durationEnabled;
+
+    @NotNull
+    @Column(name = "break_enabled", nullable = false)
+    private boolean breakEnabled;
+
+    protected TimeEntrySettingsEntity() {
+        super(null);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public boolean isCommentEnabled() {
+        return commentEnabled;
+    }
+
+    public void setCommentEnabled(boolean commentEnabled) {
+        this.commentEnabled = commentEnabled;
+    }
+
+    public boolean isDurationEnabled() {
+        return durationEnabled;
+    }
+
+    public void setDurationEnabled(boolean durationEnabled) {
+        this.durationEnabled = durationEnabled;
+    }
+
+    public boolean isBreakEnabled() {
+        return breakEnabled;
+    }
+
+    public void setBreakEnabled(boolean breakEnabled) {
+        this.breakEnabled = breakEnabled;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TimeEntrySettingsEntity that = (TimeEntrySettingsEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "TimeEntrySettingsEntity{" +
+            "id=" + id +
+            ", commentEnabled=" + commentEnabled +
+            ", durationEnabled=" + durationEnabled +
+            ", breakEnabled=" + breakEnabled +
+            '}';
+    }
+}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/TimeEntrySettingsRepository.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/TimeEntrySettingsRepository.java
@@ -1,0 +1,6 @@
+package de.focusshift.zeiterfassung.settings;
+
+import org.springframework.data.repository.CrudRepository;
+
+interface TimeEntrySettingsRepository extends CrudRepository<TimeEntrySettingsEntity, Long> {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/settings/TimeEntrySettingsService.java
+++ b/src/main/java/de/focusshift/zeiterfassung/settings/TimeEntrySettingsService.java
@@ -1,0 +1,6 @@
+package de.focusshift.zeiterfassung.settings;
+
+public interface TimeEntrySettingsService {
+
+    TimeEntrySettings getTimeEntrySettings();
+}

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/HasTimeEntryForm.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/HasTimeEntryForm.java
@@ -1,0 +1,4 @@
+package de.focusshift.zeiterfassung.timeentry;
+
+public interface HasTimeEntryForm {
+}

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryController.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryController.java
@@ -61,7 +61,7 @@ import static org.springframework.web.servlet.mvc.method.annotation.MvcUriCompon
 import static org.springframework.web.servlet.mvc.method.annotation.MvcUriComponentsBuilder.on;
 
 @Controller
-class TimeEntryController implements HasTimeClock, HasLaunchpad, HasUserSearch {
+class TimeEntryController implements HasTimeClock, HasLaunchpad, HasUserSearch, HasTimeEntryForm {
 
     private static final String IS_REDIRECTED = "isRedirected";
 

--- a/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryFormControllerAdvice.java
+++ b/src/main/java/de/focusshift/zeiterfassung/timeentry/TimeEntryFormControllerAdvice.java
@@ -1,0 +1,21 @@
+package de.focusshift.zeiterfassung.timeentry;
+
+import de.focusshift.zeiterfassung.settings.TimeEntrySettingsService;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice(assignableTypes = HasTimeEntryForm.class)
+class TimeEntryFormControllerAdvice {
+
+    private final TimeEntrySettingsService timeEntrySettingsService;
+
+    TimeEntryFormControllerAdvice(TimeEntrySettingsService timeEntrySettingsService) {
+        this.timeEntrySettingsService = timeEntrySettingsService;
+    }
+
+    @ModelAttribute
+    public void addAttributes(Model model) {
+        model.addAttribute("timeEntrySettings", timeEntrySettingsService.getTimeEntrySettings());
+    }
+}

--- a/src/main/resources/db/changelog/changelog-3.2.2-add-time-entry-settings.xml
+++ b/src/main/resources/db/changelog/changelog-3.2.2-add-time-entry-settings.xml
@@ -1,0 +1,60 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd">
+
+  <changeSet author="roboes" id="add-time-entry-settings">
+    <preConditions>
+      <not>
+        <tableExists tableName="settings_time_entry"/>
+      </not>
+    </preConditions>
+
+    <createSequence sequenceName="settings_time_entry_seq" incrementBy="1"/>
+
+    <createTable tableName="settings_time_entry">
+      <column name="id" type="BIGINT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="PK_SETTINGS_TIME_ENTRY"/>
+      </column>
+      <column name="tenant_id" type="VARCHAR(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="comment_enabled" type="BOOLEAN" defaultValue="true">
+        <constraints nullable="false"/>
+      </column>
+      <column name="duration_enabled" type="BOOLEAN" defaultValue="true">
+        <constraints nullable="false"/>
+      </column>
+      <column name="break_enabled" type="BOOLEAN" defaultValue="true">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <addForeignKeyConstraint
+      constraintName="FK_SETTINGS_TIME_ENTRY_TENANT_ID__TENANT_ID"
+      baseColumnNames="tenant_id"
+      baseTableName="settings_time_entry"
+      referencedColumnNames="tenant_id"
+      referencedTableName="tenant"
+      deferrable="false"
+      initiallyDeferred="false"
+      onDelete="CASCADE"
+      onUpdate="NO ACTION"
+    />
+
+    <createIndex tableName="settings_time_entry" indexName="IDX_SETTINGS_TIME_ENTRY_TENANT_ID">
+      <column name="tenant_id"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet author="roboes" id="enable-row-level-security-on-settings_time_entry">
+    <sql dbms="postgresql">
+      ALTER TABLE settings_time_entry ENABLE ROW LEVEL SECURITY;
+      DROP
+      POLICY IF EXISTS settings_time_entry_tenant_isolation_policy ON settings_time_entry;
+            CREATE
+      POLICY settings_time_entry_tenant_isolation_policy ON settings_time_entry
+                USING (tenant_id = current_setting('app.tenant_id')::VARCHAR);
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-main.xml
+++ b/src/main/resources/db/changelog/db.changelog-main.xml
@@ -44,4 +44,5 @@
   <include relativeToChangelogFile="true" file="changelog-3.1.0-add-navigation-collapsed-to-user-settings.xml"/>
   <include relativeToChangelogFile="true" file="changelog-3.2.0-add-time-clock-running-unique-index.xml"/>
   <include relativeToChangelogFile="true" file="changelog-3.2.0-relax-oidc-client-tenant-fk.xml"/>
+  <include relativeToChangelogFile="true" file="changelog-3.2.2-add-time-entry-settings.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -498,6 +498,11 @@ settings.work-duration.calculation.subtract-breaks.teaser-text-2=Beispiel: Ein Z
 settings.work-duration.calculation.subtract-breaks.is-active.label=Abzug aktivieren
 settings.work-duration.calculation.subtract-breaks.date.label=ab dem
 settings.work-duration.calculation.subtract-breaks.date.validation.NotNull=Das Datum muss angegeben werden.
+settings.time-entry.heading=Zeiteintrag Einstellungen
+settings.time-entry.teaser-text=Lege fest, welche optionalen Felder bei der Zeiterfassung angezeigt werden.
+settings.time-entry.comment-enabled.label=Kommentarfeld anzeigen
+settings.time-entry.duration-enabled.label=Dauerfeld anzeigen
+settings.time-entry.break-enabled.label=Pause-Schalter anzeigen
 settings.save=Speichern
 settings.reset=Zurücksetzen
 

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -494,6 +494,11 @@ settings.work-duration.calculation.subtract-breaks.teaser-text-2=Example: A time
 settings.work-duration.calculation.subtract-breaks.is-active.label=Activate deduction
 settings.work-duration.calculation.subtract-breaks.date.label=starting from
 settings.work-duration.calculation.subtract-breaks.date.validation.NotNull=The date must be provided.
+settings.time-entry.heading=Time Entry Settings
+settings.time-entry.teaser-text=Define which optional fields are shown when recording time entries.
+settings.time-entry.comment-enabled.label=Show comment field
+settings.time-entry.duration-enabled.label=Show duration field
+settings.time-entry.break-enabled.label=Show break toggle
 settings.save=Save
 settings.reset=Reset
 

--- a/src/main/resources/templates/settings/settings.html
+++ b/src/main/resources/templates/settings/settings.html
@@ -266,6 +266,61 @@
                   </div>
                 </div>
               </div>
+              <div class="mt-8 lg:mt-12">
+                <h2 class="font-bold" th:text="#{settings.time-entry.heading}">
+                  Zeiteintrag Einstellungen
+                </h2>
+                <p
+                  class="mt-2 text-dimmed"
+                  th:text="#{settings.time-entry.teaser-text}"
+                >
+                  Lege fest, welche optionalen Felder bei der Zeiterfassung angezeigt werden.
+                </p>
+                <div class="mt-4 flex flex-col gap-3">
+                  <div class="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id="comment-enabled-checkbox"
+                      data-testid="comment-enabled-checkbox"
+                      th:field="*{commentEnabled}"
+                    />
+                    <label
+                      for="comment-enabled-checkbox"
+                      th:text="#{settings.time-entry.comment-enabled.label}"
+                    >
+                      Kommentarfeld anzeigen
+                    </label>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id="duration-enabled-checkbox"
+                      data-testid="duration-enabled-checkbox"
+                      th:field="*{durationEnabled}"
+                    />
+                    <label
+                      for="duration-enabled-checkbox"
+                      th:text="#{settings.time-entry.duration-enabled.label}"
+                    >
+                      Dauerfeld anzeigen
+                    </label>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id="break-enabled-checkbox"
+                      data-testid="break-enabled-checkbox"
+                      th:field="*{breakEnabled}"
+                    />
+                    <label
+                      for="break-enabled-checkbox"
+                      th:text="#{settings.time-entry.break-enabled.label}"
+                    >
+                      Pause-Schalter anzeigen
+                    </label>
+                  </div>
+                </div>
+              </div>
               <div class="mt-8 flex flex-col gap-2 sm:flex-row sm:items-center">
                 <button
                   type="submit"

--- a/src/main/resources/templates/timeentries/fragments/time-entry-form.html
+++ b/src/main/resources/templates/timeentries/fragments/time-entry-form.html
@@ -96,7 +96,10 @@
                 />
               </svg>
               <div class="ajax-loader time-entry-cell-container">
-                <div class="time-entry-cell time-entry-cell__comment">
+                <div
+                  th:if="${timeEntrySettings == null or timeEntrySettings.commentEnabled()}"
+                  class="time-entry-cell time-entry-cell__comment"
+                >
                   <input
                     type="text"
                     id="input-entry-comment"
@@ -115,6 +118,12 @@
                     Kommentar
                   </label>
                 </div>
+                <input
+                  th:if="${timeEntrySettings != null and !timeEntrySettings.commentEnabled()}"
+                  type="hidden"
+                  name="comment"
+                  th:value="${timeEntry.comment}"
+                />
                 <div class="time-entry-cell time-entry-cell__from">
                   <input
                     type="time"
@@ -163,7 +172,10 @@
                     Bis
                   </label>
                 </div>
-                <div class="time-entry-cell time-entry-cell__duration">
+                <div
+                  th:if="${timeEntrySettings == null or timeEntrySettings.durationEnabled()}"
+                  class="time-entry-cell time-entry-cell__duration"
+                >
                   <input
                     is="z-time-entry-duration-input"
                     type="text"
@@ -188,7 +200,16 @@
                     Dauer
                   </label>
                 </div>
-                <div class="time-entry-cell time-entry-cell__break">
+                <input
+                  th:if="${timeEntrySettings != null and !timeEntrySettings.durationEnabled()}"
+                  type="hidden"
+                  name="duration"
+                  th:value="${timeEntry.duration}"
+                />
+                <div
+                  th:if="${timeEntrySettings == null or timeEntrySettings.breakEnabled()}"
+                  class="time-entry-cell time-entry-cell__break"
+                >
                   <span class="checkbox-switch">
                     <input
                       type="checkbox"
@@ -209,6 +230,12 @@
                     Pause
                   </label>
                 </div>
+                <input
+                  th:if="${timeEntrySettings != null and !timeEntrySettings.breakEnabled()}"
+                  type="hidden"
+                  name="break"
+                  th:value="${timeEntry.isBreak}"
+                />
               </div>
             </div>
           </div>

--- a/src/test/java/de/focusshift/zeiterfassung/settings/SettingsControllerSecurityIT.java
+++ b/src/test/java/de/focusshift/zeiterfassung/settings/SettingsControllerSecurityIT.java
@@ -79,6 +79,9 @@ class SettingsControllerSecurityIT extends SingleTenantTestContainersBase implem
                 .param("worksOnPublicHoliday", "false")
                 .param("lockingIsActive", "false")
                 .param("lockTimeEntriesDaysInPast", "1")
+                .param("commentEnabled", "true")
+                .param("durationEnabled", "true")
+                .param("breakEnabled", "true")
             )
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/settings"));

--- a/src/test/java/de/focusshift/zeiterfassung/settings/SettingsControllerTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/settings/SettingsControllerTest.java
@@ -77,6 +77,7 @@ class SettingsControllerTest implements ControllerTest {
         when(settingsService.getFederalStateSettings()).thenReturn(federalStateSettings);
         when(settingsService.getLockTimeEntriesSettings()).thenReturn(lockTimeEntriesSettings);
         when(settingsService.getSubtractBreakFromTimeEntrySettings()).thenReturn(Optional.of(subtractBreakFromTimeEntrySettings));
+        when(settingsService.getTimeEntrySettings()).thenReturn(new TimeEntrySettings(false, true, false));
 
         when(userSettingsProvider.zoneId()).thenReturn(ZoneId.of("Europe/Berlin"));
 
@@ -86,7 +87,10 @@ class SettingsControllerTest implements ControllerTest {
             true,
             "42",
             true,
-            subtractBreakFeatureDate
+            subtractBreakFeatureDate,
+            false,
+            true,
+            false
         );
 
         perform(get("/settings"))
@@ -105,6 +109,7 @@ class SettingsControllerTest implements ControllerTest {
         when(settingsService.getFederalStateSettings()).thenReturn(federalStateSettings);
         when(settingsService.getLockTimeEntriesSettings()).thenReturn(lockTimeEntriesSettings);
         when(settingsService.getSubtractBreakFromTimeEntrySettings()).thenReturn(Optional.empty());
+        when(settingsService.getTimeEntrySettings()).thenReturn(TimeEntrySettings.DEFAULT);
 
         when(userSettingsProvider.zoneId()).thenReturn(ZoneId.of("Europe/Berlin"));
 
@@ -121,6 +126,7 @@ class SettingsControllerTest implements ControllerTest {
         when(settingsService.getFederalStateSettings()).thenReturn(federalStateSettings);
         when(settingsService.getLockTimeEntriesSettings()).thenReturn(lockTimeEntriesSettings);
         when(settingsService.getSubtractBreakFromTimeEntrySettings()).thenReturn(Optional.empty());
+        when(settingsService.getTimeEntrySettings()).thenReturn(TimeEntrySettings.DEFAULT);
         when(userSettingsProvider.zoneId()).thenReturn(ZoneId.of("Europe/Berlin"));
 
         final SettingsDto expectedSettingsDto = new SettingsDto(
@@ -163,6 +169,9 @@ class SettingsControllerTest implements ControllerTest {
             .param("lockingIsActive", "true")
             .param("lockTimeEntriesDaysInPast", "-1")
             .param("subtractBreakFromTimeEntryIsActive", "false")
+            .param("commentEnabled", "true")
+            .param("durationEnabled", "true")
+            .param("breakEnabled", "true")
         )
             .andExpect(status().isUnprocessableContent())
             .andExpect(view().name("settings/settings"));
@@ -181,7 +190,10 @@ class SettingsControllerTest implements ControllerTest {
             true,
             "42",
             true,
-            LocalDate.parse("2025-05-30")
+            LocalDate.parse("2025-05-30"),
+            false,
+            true,
+            false
         );
 
         perform(post("/settings")
@@ -192,6 +204,9 @@ class SettingsControllerTest implements ControllerTest {
             .param("lockTimeEntriesDaysInPast", "42")
             .param("subtractBreakFromTimeEntryIsActive", "true")
             .param("subtractBreakFromTimeEntryActiveDate", "2025-05-30")
+            .param("commentEnabled", "false")
+            .param("durationEnabled", "true")
+            .param("breakEnabled", "false")
         )
             .andExpect(status().isOk())
             .andExpect(model().attribute("settings", expectedSettingsDto))
@@ -212,6 +227,9 @@ class SettingsControllerTest implements ControllerTest {
             .param("lockTimeEntriesDaysInPast", "42")
             .param("subtractBreakFromTimeEntryIsActive", "true")
             .param("subtractBreakFromTimeEntryActiveDate", "2025-05-30")
+            .param("commentEnabled", "false")
+            .param("durationEnabled", "true")
+            .param("breakEnabled", "false")
         )
             .andExpect(flash().attributeCount(0))
             .andExpect(status().is3xxRedirection())
@@ -220,6 +238,7 @@ class SettingsControllerTest implements ControllerTest {
         verify(settingsService).updateFederalStateSettings(FederalState.NONE, false);
         verify(settingsService).updateLockTimeEntriesSettings(true, 42);
         verify(settingsService).updateSubtractBreakFromTimeEntrySettings(true, LocalDate.parse("2025-05-30").atStartOfDay().toInstant(UTC));
+        verify(settingsService).updateTimeEntrySettings(false, true, false);
     }
 
     @ParameterizedTest
@@ -232,6 +251,9 @@ class SettingsControllerTest implements ControllerTest {
             .param("lockingIsActive", "false")
             .param("lockTimeEntriesDaysInPast", daysInPast)
             .param("subtractBreakFromTimeEntryIsActive", "false")
+            .param("commentEnabled", "true")
+            .param("durationEnabled", "true")
+            .param("breakEnabled", "true")
         )
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/settings"));

--- a/src/test/java/de/focusshift/zeiterfassung/settings/SettingsServiceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/settings/SettingsServiceTest.java
@@ -40,6 +40,8 @@ class SettingsServiceTest {
     @Mock
     private SubtractBreakFromTimeEntrySettingsRepository subtractBreakFromTimeEntrySettingsRepository;
     @Mock
+    private TimeEntrySettingsRepository timeEntrySettingsRepository;
+    @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
 
@@ -49,6 +51,7 @@ class SettingsServiceTest {
             federalStateSettingsRepository,
             lockTimeEntriesSettingsRepository,
             subtractBreakFromTimeEntrySettingsRepository,
+            timeEntrySettingsRepository,
             applicationEventPublisher,
             clock
         );
@@ -311,6 +314,32 @@ class SettingsServiceTest {
 
             assertThat(result.subtractBreakFromTimeEntryIsActive()).isTrue();
             assertThat(result.subtractBreakFromTimeEntryEnabledTimestamp()).hasValue(timestamp);
+        }
+    }
+
+    @Nested
+    class TimeEntrySettingsTest {
+
+        @Test
+        void ensureGetReturnsDefaultsWhenNothingIsConfigured() {
+            when(timeEntrySettingsRepository.findAll()).thenReturn(List.of());
+
+            assertThat(sut.getTimeEntrySettings()).isEqualTo(TimeEntrySettings.DEFAULT);
+        }
+
+        @Test
+        void ensureUpdateCreatesSettings() {
+            when(timeEntrySettingsRepository.findAll()).thenReturn(List.of());
+            when(timeEntrySettingsRepository.save(any(TimeEntrySettingsEntity.class))).thenAnswer(returnsFirstArg());
+
+            final TimeEntrySettings result = sut.updateTimeEntrySettings(false, true, false);
+
+            assertThat(result).isEqualTo(new TimeEntrySettings(false, true, false));
+            verify(timeEntrySettingsRepository).save(assertArg(entity -> {
+                assertThat(entity.isCommentEnabled()).isFalse();
+                assertThat(entity.isDurationEnabled()).isTrue();
+                assertThat(entity.isBreakEnabled()).isFalse();
+            }));
         }
     }
 }

--- a/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryFormControllerAdviceTest.java
+++ b/src/test/java/de/focusshift/zeiterfassung/timeentry/TimeEntryFormControllerAdviceTest.java
@@ -1,0 +1,26 @@
+package de.focusshift.zeiterfassung.timeentry;
+
+import de.focusshift.zeiterfassung.settings.TimeEntrySettings;
+import de.focusshift.zeiterfassung.settings.TimeEntrySettingsService;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ConcurrentModel;
+import org.springframework.ui.Model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TimeEntryFormControllerAdviceTest {
+
+    @Test
+    void ensureTimeEntrySettingsAreAddedToModel() {
+        final TimeEntrySettingsService service = mock(TimeEntrySettingsService.class);
+        final TimeEntrySettings settings = new TimeEntrySettings(false, true, false);
+        when(service.getTimeEntrySettings()).thenReturn(settings);
+
+        final Model model = new ConcurrentModel();
+        new TimeEntryFormControllerAdvice(service).addAttributes(model);
+
+        assertThat(model.getAttribute("timeEntrySettings")).isEqualTo(settings);
+    }
+}


### PR DESCRIPTION
# Make time-entry form fields configurable

## Description

Adds three global admin settings that control which optional controls are shown in the time-entry form:

- `Comment` field.
- `Duration` field.
- `Break` toggle.

All three settings default to enabled, preserving the current behavior for existing installations.

## Use case

Organizations use different time-entry workflows. Some do not collect comments, some require start and end times instead of a duration, and some do not create dedicated break entries. Hiding unused controls keeps the form focused without changing how time entries are stored or calculated.

## Changes

**Settings:**

- Added `TimeEntrySettings`, its tenant-aware entity/repository, and `TimeEntrySettingsService`.
- Extended `SettingsService`, `SettingsController`, and `SettingsDto` with `commentEnabled`, `durationEnabled`, and `breakEnabled`.
- Added a Liquibase changeset for the RLS-enabled `settings_time_entry` table.

**View wiring:**

- Added `HasTimeEntryForm` and `TimeEntryFormControllerAdvice` to expose the settings wherever the shared time-entry form is rendered.
- Added three checkboxes to the global settings page.
- Conditionally renders the comment field, duration field, and break toggle in the shared form.
- Keeps hidden values for disabled controls so existing client-side validation continues to work and editing another field does not erase an existing comment or change an existing break entry.

**i18n:**

- Added German and English labels and explanatory text.

## Backward compatibility

- All settings default to `true`, so existing installations retain the current form unchanged.
- No time-entry persistence, duration calculation, break calculation, or service API is changed.
- Disabling a control only changes its visibility in the form.

## Testing

- Added tests for default settings, persistence updates, controller binding, and the shared form model attribute.